### PR TITLE
Harden buffer handling and add bounds checking

### DIFF
--- a/host/config.c
+++ b/host/config.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200112L
 #include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -252,7 +253,8 @@ int config_set_value(config_data_t* config, const char* key, const char* value) 
                 strncpy(config->values[i], value, sizeof(config->values[i]) - 1);
                 config->values[i][sizeof(config->values[i]) - 1] = '\0';
             } else {
-                strcpy(config->values[i], value);
+                strncpy(config->values[i], value, sizeof(config->values[i]) - 1);
+                config->values[i][sizeof(config->values[i]) - 1] = '\0';
             }
             return 1;
         }
@@ -265,7 +267,8 @@ int config_set_value(config_data_t* config, const char* key, const char* value) 
         strncpy(config->keys[config->count], key, sizeof(config->keys[config->count]) - 1);
         config->keys[config->count][sizeof(config->keys[config->count]) - 1] = '\0';
     } else {
-        strcpy(config->keys[config->count], key);
+        strncpy(config->keys[config->count], key, sizeof(config->keys[config->count]) - 1);
+        config->keys[config->count][sizeof(config->keys[config->count]) - 1] = '\0';
     }
     
     if (strlen(value) >= sizeof(config->values[config->count])) {
@@ -273,7 +276,8 @@ int config_set_value(config_data_t* config, const char* key, const char* value) 
         strncpy(config->values[config->count], value, sizeof(config->values[config->count]) - 1);
         config->values[config->count][sizeof(config->values[config->count]) - 1] = '\0';
     } else {
-        strcpy(config->values[config->count], value);
+        strncpy(config->values[config->count], value, sizeof(config->values[config->count]) - 1);
+        config->values[config->count][sizeof(config->values[config->count]) - 1] = '\0';
     }
     config->count++;
     

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200112L
 #include "config.h"
 #include "daemon_state.h"
 #include "logger.h"
@@ -155,10 +156,10 @@ void format_number(const char* buffer, char *output) {
         filled[i] = buffer[i];
     }
     
-    sprintf(output, "(%c%c%c) %c%c%c-%c%c%c%c",
-            filled[0], filled[1], filled[2],
-            filled[3], filled[4], filled[5],
-            filled[6], filled[7], filled[8], filled[9]);
+    snprintf(output, 21, "(%c%c%c) %c%c%c-%c%c%c%c",
+             filled[0], filled[1], filled[2],
+             filled[3], filled[4], filled[5],
+             filled[6], filled[7], filled[8], filled[9]);
 }
 
 void generate_message(int inserted, char *output) {
@@ -174,7 +175,7 @@ void generate_message(int inserted, char *output) {
         remaining = 0;
     }
     
-    sprintf(output, "Insert %02d cents", remaining);
+    snprintf(output, 32, "Insert %02d cents", remaining);
     
     logger_debugf_with_category("Display", "Generated message: %s", output);
 }
@@ -736,7 +737,8 @@ int main(int argc, char *argv[]) {
     /* Load configuration */
     strcpy(config_file, "/etc/millennium/daemon.conf");
     if (argc > 2 && strcmp(argv[1], "--config") == 0) {
-        strcpy(config_file, argv[2]);
+        strncpy(config_file, argv[2], MAX_STRING_LEN - 1);
+        config_file[MAX_STRING_LEN - 1] = '\0';
     }
     
     if (!config_load_from_file(config, config_file)) {

--- a/host/events.c
+++ b/host/events.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200112L
 #include "events.h"
 #include "logger.h"
 #include <stdlib.h>
@@ -295,7 +296,7 @@ static char *coin_eeprom_validation_error_get_repr(void *event) {
     coin_eeprom_validation_error_t *ee = (coin_eeprom_validation_error_t *)event;
     char *repr = malloc(64);
     if (repr) {
-        sprintf(repr, "Addr: %d, Expected: %d, Actual: %d", 
+        snprintf(repr, 64, "Addr: %d, Expected: %d, Actual: %d", 
                 ee->addr, ee->expected, ee->actual);
     }
     return repr;

--- a/host/logger.c
+++ b/host/logger.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200112L
 #include "logger.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -147,9 +148,9 @@ void logger_write_log(log_level_t level, const char* category, const char* messa
     
     /* Format the log message */
     if (category != NULL && strlen(category) > 0) {
-        sprintf(formatted_message, "[%s] [%s] [%s] %s", timestamp, level_str, category, message);
+        snprintf(formatted_message, sizeof(formatted_message), "[%s] [%s] [%s] %s", timestamp, level_str, category, message);
     } else {
-        sprintf(formatted_message, "[%s] [%s] %s", timestamp, level_str, message);
+        snprintf(formatted_message, sizeof(formatted_message), "[%s] [%s] %s", timestamp, level_str, message);
     }
     
     /* Store in memory */
@@ -187,7 +188,7 @@ void logger_format_timestamp(char* buffer, size_t buffer_size) {
     milliseconds = now % 1000;
     
     /* Format timestamp: YYYY-MM-DD HH:MM:SS.mmm */
-    sprintf(buffer, "%04d-%02d-%02d %02d:%02d:%02d.%03ld",
+    snprintf(buffer, 64, "%04d-%02d-%02d %02d:%02d:%02d.%03ld",
             tm_info->tm_year + 1900,
             tm_info->tm_mon + 1,
             tm_info->tm_mday,
@@ -295,9 +296,7 @@ static void logger_vlogf(log_level_t level, const char* category, const char* fo
         return;
     }
     
-    /* C89 compatible: use vsprintf with size check for safety */
-    vsprintf(buffer, format, args);
-    buffer[sizeof(buffer) - 1] = '\0'; /* Ensure null termination */
+    vsnprintf(buffer, sizeof(buffer), format, args);
     
     if (category && strlen(category) > 0) {
         logger_log_with_category(level, category, buffer);

--- a/host/metrics.c
+++ b/host/metrics.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200112L
 #include "metrics.h"
 #include <stdlib.h>
 #include <string.h>
@@ -468,11 +469,11 @@ char *metrics_export_prometheus(void) {
     if (!result) return NULL;
     
     /* Add timestamp */
-    pos += sprintf(result + pos,
+    pos += snprintf(result + pos, len - pos,
         "# HELP millennium_metrics_start_time Start time of the metrics collection\n");
-    pos += sprintf(result + pos,
+    pos += snprintf(result + pos, len - pos,
         "# TYPE millennium_metrics_start_time counter\n");
-    pos += sprintf(result + pos,
+    pos += snprintf(result + pos, len - pos,
         "millennium_metrics_start_time %ld\n\n", (long)g_metrics->start_time);
     
     /* Export counters */
@@ -481,18 +482,18 @@ char *metrics_export_prometheus(void) {
         
         sanitized_name = metrics_sanitize_name(g_metrics->counter_names[i]);
         if (sanitized_name) {
-            pos += sprintf(result + pos,
+            pos += snprintf(result + pos, len - pos,
                 "# HELP %s Counter metric\n", sanitized_name);
-            pos += sprintf(result + pos,
+            pos += snprintf(result + pos, len - pos,
                 "# TYPE %s counter\n", sanitized_name);
-            pos += sprintf(result + pos,
+            pos += snprintf(result + pos, len - pos,
                 "%s %llu\n", sanitized_name, (unsigned long long)g_metrics->counters[i].value);
             free(sanitized_name);
         }
     }
     
     if (g_metrics->counter_count > 0) {
-        pos += sprintf(result + pos, "\n");
+        pos += snprintf(result + pos, len - pos, "\n");
     }
     
     /* Export gauges */
@@ -501,18 +502,18 @@ char *metrics_export_prometheus(void) {
         
         sanitized_name = metrics_sanitize_name(g_metrics->gauge_names[i]);
         if (sanitized_name) {
-            pos += sprintf(result + pos,
+            pos += snprintf(result + pos, len - pos,
                 "# HELP %s Gauge metric\n", sanitized_name);
-            pos += sprintf(result + pos,
+            pos += snprintf(result + pos, len - pos,
                 "# TYPE %s gauge\n", sanitized_name);
-            pos += sprintf(result + pos,
+            pos += snprintf(result + pos, len - pos,
                 "%s %.2f\n", sanitized_name, g_metrics->gauges[i].value);
             free(sanitized_name);
         }
     }
     
     if (g_metrics->gauge_count > 0) {
-        pos += sprintf(result + pos, "\n");
+        pos += snprintf(result + pos, len - pos, "\n");
     }
     
     /* Export histograms */
@@ -523,60 +524,60 @@ char *metrics_export_prometheus(void) {
         if (metrics_get_histogram_stats(g_metrics->histogram_names[i], &stats) == 0) {
             sanitized_name = metrics_sanitize_name(g_metrics->histogram_names[i]);
             if (sanitized_name) {
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# HELP %s_count Histogram count\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# TYPE %s_count counter\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "%s_count %llu\n", sanitized_name, (unsigned long long)stats.count);
                 
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# HELP %s_sum Histogram sum\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# TYPE %s_sum counter\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "%s_sum %.2f\n", sanitized_name, stats.sum);
                 
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# HELP %s_min Histogram minimum\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# TYPE %s_min gauge\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "%s_min %.2f\n", sanitized_name, stats.min);
                 
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# HELP %s_max Histogram maximum\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# TYPE %s_max gauge\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "%s_max %.2f\n", sanitized_name, stats.max);
                 
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# HELP %s_mean Histogram mean\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# TYPE %s_mean gauge\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "%s_mean %.2f\n", sanitized_name, stats.mean);
                 
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# HELP %s_median Histogram median\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# TYPE %s_median gauge\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "%s_median %.2f\n", sanitized_name, stats.median);
                 
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# HELP %s_p95 Histogram 95th percentile\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# TYPE %s_p95 gauge\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "%s_p95 %.2f\n", sanitized_name, stats.p95);
                 
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# HELP %s_p99 Histogram 99th percentile\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "# TYPE %s_p99 gauge\n", sanitized_name);
-                pos += sprintf(result + pos,
+                pos += snprintf(result + pos, len - pos,
                     "%s_p99 %.2f\n\n", sanitized_name, stats.p99);
                 
                 free(sanitized_name);
@@ -612,60 +613,60 @@ char *metrics_export_json(void) {
         return NULL;
     }
     
-                pos += sprintf(result + pos, "{\n");
-                pos += sprintf(result + pos, "  \"timestamp\": \"%s\",\n", timestamp);
-                pos += sprintf(result + pos, "  \"counters\": {\n");
+                pos += snprintf(result + pos, len - pos, "{\n");
+                pos += snprintf(result + pos, len - pos, "  \"timestamp\": \"%s\",\n", timestamp);
+                pos += snprintf(result + pos, len - pos, "  \"counters\": {\n");
     
     /* Export counters */
     for (i = 0; i < (int)g_metrics->counter_count; i++) {
-        if (i > 0) pos += sprintf(result + pos, ",\n");
-                pos += sprintf(result + pos, "    \"%s\": %llu",
+        if (i > 0) pos += snprintf(result + pos, len - pos, ",\n");
+                pos += snprintf(result + pos, len - pos, "    \"%s\": %llu",
             g_metrics->counter_names[i], (unsigned long long)g_metrics->counters[i].value);
     }
     
-                pos += sprintf(result + pos, "\n  },\n");
-                pos += sprintf(result + pos, "  \"gauges\": {\n");
+                pos += snprintf(result + pos, len - pos, "\n  },\n");
+                pos += snprintf(result + pos, len - pos, "  \"gauges\": {\n");
     
     /* Export gauges */
     for (i = 0; i < (int)g_metrics->gauge_count; i++) {
-        if (i > 0) pos += sprintf(result + pos, ",\n");
-                pos += sprintf(result + pos, "    \"%s\": %.2f",
+        if (i > 0) pos += snprintf(result + pos, len - pos, ",\n");
+                pos += snprintf(result + pos, len - pos, "    \"%s\": %.2f",
             g_metrics->gauge_names[i], g_metrics->gauges[i].value);
     }
     
-                pos += sprintf(result + pos, "\n  },\n");
-                pos += sprintf(result + pos, "  \"histograms\": {\n");
+                pos += snprintf(result + pos, len - pos, "\n  },\n");
+                pos += snprintf(result + pos, len - pos, "  \"histograms\": {\n");
     
     /* Export histograms */
     for (i = 0; i < (int)g_metrics->histogram_count; i++) {
         metrics_histogram_stats_t stats;
         
         if (metrics_get_histogram_stats(g_metrics->histogram_names[i], &stats) == 0) {
-            if (i > 0) pos += sprintf(result + pos, ",\n");
-            pos += sprintf(result + pos, "    \"%s\": {\n",
+            if (i > 0) pos += snprintf(result + pos, len - pos, ",\n");
+            pos += snprintf(result + pos, len - pos, "    \"%s\": {\n",
                 g_metrics->histogram_names[i]);
-            pos += sprintf(result + pos,
+            pos += snprintf(result + pos, len - pos,
                 "      \"count\": %llu,\n", (unsigned long long)stats.count);
-            pos += sprintf(result + pos,
+            pos += snprintf(result + pos, len - pos,
                 "      \"sum\": %.2f,\n", stats.sum);
-            pos += sprintf(result + pos,
+            pos += snprintf(result + pos, len - pos,
                 "      \"min\": %.2f,\n", stats.min);
-            pos += sprintf(result + pos,
+            pos += snprintf(result + pos, len - pos,
                 "      \"max\": %.2f,\n", stats.max);
-            pos += sprintf(result + pos,
+            pos += snprintf(result + pos, len - pos,
                 "      \"mean\": %.2f,\n", stats.mean);
-            pos += sprintf(result + pos,
+            pos += snprintf(result + pos, len - pos,
                 "      \"median\": %.2f,\n", stats.median);
-            pos += sprintf(result + pos,
+            pos += snprintf(result + pos, len - pos,
                 "      \"p95\": %.2f,\n", stats.p95);
-            pos += sprintf(result + pos,
+            pos += snprintf(result + pos, len - pos,
                 "      \"p99\": %.2f\n", stats.p99);
-            pos += sprintf(result + pos, "    }");
+            pos += snprintf(result + pos, len - pos, "    }");
         }
     }
     
-                pos += sprintf(result + pos, "\n  }\n");
-                pos += sprintf(result + pos, "}\n");
+                pos += snprintf(result + pos, len - pos, "\n  }\n");
+                pos += snprintf(result + pos, len - pos, "}\n");
     
     free(timestamp);
     return result;

--- a/host/metrics_server.c
+++ b/host/metrics_server.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200112L
 #include "metrics_server.h"
 #include "metrics.h"
 #include "logger.h"
@@ -278,7 +279,7 @@ char *metrics_server_generate_metrics_response(metrics_server_t *server) {
         return NULL;
     }
     
-    sprintf(response,
+    snprintf(response, response_len,
         "HTTP/1.1 200 OK\r\n"
         "Content-Type: text/plain; version=0.0.4; charset=utf-8\r\n"
         "Content-Length: %zu\r\n"
@@ -299,7 +300,7 @@ char *metrics_server_generate_health_response(metrics_server_t *server) {
     response = malloc(200);
     if (!response) return NULL;
     
-    sprintf(response,
+    snprintf(response, 200,
         "HTTP/1.1 200 OK\r\n"
         "Content-Type: application/json\r\n"
         "Content-Length: 15\r\n"

--- a/host/plugins.c
+++ b/host/plugins.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200112L
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -127,13 +127,14 @@ int plugins_list(char *buffer, size_t buffer_size) {
     int i;
     for (i = 0; i < plugin_count && pos < (int)buffer_size - 1; i++) {
         char temp[256];
-        sprintf(temp, "%s: %s%s\n",
+        snprintf(temp, sizeof(temp), "%s: %s%s\n",
                 plugins[i].name, plugins[i].description,
                 (i == active_plugin_index) ? " (ACTIVE)" : "");
         
         int len = strlen(temp);
         if (pos + len < (int)buffer_size - 1) {
-            strcpy(buffer + pos, temp);
+            strncpy(buffer + pos, temp, buffer_size - pos - 1);
+            buffer[buffer_size - 1] = '\0';
             pos += len;
         }
     }

--- a/host/plugins/classic_phone.c
+++ b/host/plugins/classic_phone.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200112L
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -110,7 +110,7 @@ static int classic_phone_handle_hook(int hook_up, int hook_down) {
 
 static int classic_phone_handle_call_state(int call_state) {
     char log_msg[128];
-    sprintf(log_msg, "Call state changed to: %d (dialing=%d, in_call=%d)", 
+    snprintf(log_msg, sizeof(log_msg), "Call state changed to: %d (dialing=%d, in_call=%d)", 
             call_state, classic_phone_data.is_dialing, classic_phone_data.is_in_call);
     logger_info_with_category("ClassicPhone", log_msg);
     
@@ -178,9 +178,9 @@ static void classic_phone_update_display(void) {
         }
         
         if (classic_phone_data.inserted_cents > 0) {
-            sprintf(line2, "Have: %dc", classic_phone_data.inserted_cents);
+            snprintf(line2, sizeof(line2), "Have: %dc", classic_phone_data.inserted_cents);
         } else {
-            sprintf(line2, "Insert %dc", classic_phone_data.call_cost_cents);
+            snprintf(line2, sizeof(line2), "Insert %dc", classic_phone_data.call_cost_cents);
         }
     }
     
@@ -255,7 +255,8 @@ static void classic_phone_check_and_call(void) {
 
 static void classic_phone_start_call(void) {
     classic_phone_data.is_dialing = 1;
-    strcpy(classic_phone_data.current_number, classic_phone_data.keypad_buffer);
+    strncpy(classic_phone_data.current_number, classic_phone_data.keypad_buffer, sizeof(classic_phone_data.current_number) - 1);
+    classic_phone_data.current_number[sizeof(classic_phone_data.current_number) - 1] = '\0';
     
     classic_phone_update_display();
     
@@ -266,7 +267,7 @@ static void classic_phone_start_call(void) {
     millennium_client_call(client, classic_phone_data.current_number);
     
     char log_msg[256];
-    sprintf(log_msg, "Starting call to %s", classic_phone_data.current_number);
+    snprintf(log_msg, sizeof(log_msg), "Starting call to %s", classic_phone_data.current_number);
     logger_info_with_category("ClassicPhone", log_msg);
 }
 
@@ -297,7 +298,7 @@ static void classic_phone_format_number(const char* buffer, char *output) {
         filled[i] = buffer[i];
     }
     
-    sprintf(output, "(%c%c%c) %c%c%c-%c%c%c%c",
+    snprintf(output, 21, "(%c%c%c) %c%c%c-%c%c%c%c",
             filled[0], filled[1], filled[2],
             filled[3], filled[4], filled[5],
             filled[6], filled[7], filled[8], filled[9]);
@@ -343,7 +344,7 @@ static void classic_phone_tick(void) {
     seconds = remaining % 60;
 
     strcpy(line1, "Call active");
-    sprintf(line2, "%d:%02d remaining", minutes, seconds);
+    snprintf(line2, sizeof(line2), "%d:%02d remaining", minutes, seconds);
 
     pos = 0;
     for (i = 0; i < 20 && pos < sizeof(display_bytes) - 2; i++) {

--- a/host/plugins/fortune_teller.c
+++ b/host/plugins/fortune_teller.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200112L
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -155,10 +155,10 @@ static void fortune_teller_show_welcome(void) {
         strcpy(line1, "Lift receiver");
         strcpy(line2, "for fortune");
     } else if (fortune_teller_data.inserted_cents > 0) {
-        sprintf(line1, "Have: %dc", fortune_teller_data.inserted_cents);
-        sprintf(line2, "Need: %dc", fortune_teller_data.fortune_cost_cents - fortune_teller_data.inserted_cents);
+        snprintf(line1, sizeof(line1), "Have: %dc", fortune_teller_data.inserted_cents);
+        snprintf(line2, sizeof(line2), "Need: %dc", fortune_teller_data.fortune_cost_cents - fortune_teller_data.inserted_cents);
     } else {
-        sprintf(line1, "Insert %dc", fortune_teller_data.fortune_cost_cents);
+        snprintf(line1, sizeof(line1), "Insert %dc", fortune_teller_data.fortune_cost_cents);
         strcpy(line2, "for your fortune");
     }
     
@@ -267,7 +267,7 @@ static void fortune_teller_give_fortune(void) {
     
     /* Log the fortune */
     char log_msg[256];
-    sprintf(log_msg, "Fortune given: %s - %s", category, fortune);
+    snprintf(log_msg, sizeof(log_msg), "Fortune given: %s - %s", category, fortune);
     logger_info_with_category("FortuneTeller", log_msg);
     
     /* Reset for next fortune */

--- a/host/plugins/jukebox.c
+++ b/host/plugins/jukebox.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200112L
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -174,10 +174,10 @@ static void jukebox_show_welcome(void) {
         strcpy(line1, "Lift receiver");
         strcpy(line2, "to play music");
     } else if (jukebox_data.inserted_cents > 0) {
-        sprintf(line1, "Have: %dc", jukebox_data.inserted_cents);
-        sprintf(line2, "Need: %dc", jukebox_data.song_cost_cents - jukebox_data.inserted_cents);
+        snprintf(line1, sizeof(line1), "Have: %dc", jukebox_data.inserted_cents);
+        snprintf(line2, sizeof(line2), "Need: %dc", jukebox_data.song_cost_cents - jukebox_data.inserted_cents);
     } else {
-        sprintf(line1, "Insert %dc", jukebox_data.song_cost_cents);
+        snprintf(line1, sizeof(line1), "Insert %dc", jukebox_data.song_cost_cents);
         strcpy(line2, "to play music");
     }
     
@@ -270,20 +270,20 @@ static void jukebox_play_song(int song_number) {
     
     const song_info_t *song = &songs[song_number];
     char log_msg[256];
-    sprintf(log_msg, "Playing song: %s by %s", song->title, song->artist);
+    snprintf(log_msg, sizeof(log_msg), "Playing song: %s by %s", song->title, song->artist);
     logger_info_with_category("Jukebox", log_msg);
     
     /* Play the WAV file using ALSA */
     const char* wav_file = songs[song_number].audio_file;
     if (jukebox_play_wav_file(wav_file) == 0) {
         char log_msg[256];
-        sprintf(log_msg, "Started playing WAV file: %s", wav_file);
+        snprintf(log_msg, sizeof(log_msg), "Started playing WAV file: %s", wav_file);
         logger_info_with_category("Jukebox", log_msg);
     } else {
         logger_warn_with_category("Jukebox", "Failed to play WAV file, falling back to beep tones");
         /* Fallback to simple beep if WAV file not available */
         char command[128];
-        sprintf(command, "beep -f 800 -l 200 -n -f 1000 -l 200 -n -f 1200 -l 400 &");
+        snprintf(command, sizeof(command), "beep -f 800 -l 200 -n -f 1000 -l 200 -n -f 1200 -l 400 &");
         system(command);
     }
 }
@@ -330,7 +330,7 @@ static int jukebox_init_alsa(void) {
     err = snd_pcm_open(&jukebox_data.pcm_handle, "default", SND_PCM_STREAM_PLAYBACK, 0);
     if (err < 0) {
         char log_msg[256];
-        sprintf(log_msg, "Cannot open PCM device: %s", snd_strerror(err));
+        snprintf(log_msg, sizeof(log_msg), "Cannot open PCM device: %s", snd_strerror(err));
         logger_error_with_category("Jukebox", log_msg);
         return -1;
     }
@@ -452,7 +452,7 @@ static void* jukebox_audio_thread(void* arg) {
     file = fopen(wav_file, "rb");
     if (!file) {
         char log_msg[256];
-        sprintf(log_msg, "Cannot open WAV file: %s", wav_file);
+        snprintf(log_msg, sizeof(log_msg), "Cannot open WAV file: %s", wav_file);
         logger_error_with_category("Jukebox", log_msg);
         return NULL;
     }


### PR DESCRIPTION
## Summary
- Replaces all `sprintf`/`vsprintf` calls with bounds-checked `snprintf`/`vsnprintf` across 11 source files (70+ call sites)
- Hardens `strcpy` calls that copy non-literal sources (config values, `argv`, keypad buffer) with `strncpy` + explicit null termination
- Adds `_POSIX_C_SOURCE 200112L` to files compiled with `-std=c89` to ensure `snprintf` availability

## Test plan
- [x] `make simulator` builds cleanly with zero warnings (except the expected GCC-only `-Wstringop-truncation` pragma on Mac)
- [x] All 4 simulator scenario tests pass (`make test`)
- [x] CI should confirm Linux build + test pass

Closes #12

Made with [Cursor](https://cursor.com)