### PR TITLE
Add log rotation to prevent disk exhaustion

### DIFF
--- a/host/config.c
+++ b/host/config.c
@@ -311,6 +311,14 @@ int config_get_log_to_file(const config_data_t* config) {
     return config_get_bool(config, "logging.to_file", 0);
 }
 
+int config_get_log_max_size_bytes(const config_data_t* config) {
+    return config_get_int(config, "logging.max_size_bytes", 1048576);
+}
+
+int config_get_log_max_files(const config_data_t* config) {
+    return config_get_int(config, "logging.max_files", 5);
+}
+
 /* System Configuration */
 int config_get_update_interval_ms(const config_data_t* config) {
     return config_get_int(config, "system.update_interval_ms", 33);

--- a/host/config.h
+++ b/host/config.h
@@ -36,6 +36,8 @@ int config_get_call_timeout_seconds(const config_data_t* config);
 const char* config_get_log_level(const config_data_t* config);
 const char* config_get_log_file(const config_data_t* config);
 int config_get_log_to_file(const config_data_t* config);
+int config_get_log_max_size_bytes(const config_data_t* config);
+int config_get_log_max_files(const config_data_t* config);
 
 /* System Configuration */
 int config_get_update_interval_ms(const config_data_t* config);

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -751,6 +751,9 @@ int main(int argc, char *argv[]) {
     
     /* Setup logging */
     logger_set_level(logger_parse_level(config_get_log_level(config)));
+    logger_set_rotation(
+        (long)config_get_log_max_size_bytes(config),
+        config_get_log_max_files(config));
     if (config_get_log_to_file(config) && strlen(config_get_log_file(config)) > 0) {
         fprintf(stderr, "Logging to %s\n", config_get_log_file(config));
         logger_set_log_file(config_get_log_file(config));

--- a/host/logger.h
+++ b/host/logger.h
@@ -23,6 +23,11 @@ typedef struct {
     int log_to_file;
     FILE* file_stream;
     
+    /* Log rotation */
+    long max_file_size;     /* Max bytes before rotation (0 = disabled) */
+    int max_rotated_files;  /* Number of rotated files to keep */
+    long current_file_size; /* Approximate bytes written to current file */
+
     /* In-memory log storage */
     char memory_logs[1000][512];  /* Fixed size array for C89 */
     int memory_logs_count;
@@ -38,6 +43,7 @@ void logger_set_level(log_level_t level);
 void logger_set_log_file(const char* filename);
 void logger_set_log_to_console(int enable);
 void logger_set_log_to_file(int enable);
+void logger_set_rotation(long max_file_size, int max_rotated_files);
 
 /* Logging methods */
 void logger_log(log_level_t level, const char* message);


### PR DESCRIPTION
## Summary
- Adds automatic log file rotation when size exceeds a configurable threshold (default: 1MB)
- Rotates files as `daemon.log` -> `daemon.log.1` -> ... -> `daemon.log.N`, deleting the oldest
- Defaults to 5 rotated files (6MB total disk usage max), configurable via `logging.max_size_bytes` and `logging.max_files`
- Tracks current file size across reopens (picks up existing file size on startup)

## Config keys
| Key | Default | Description |
|---|---|---|
| `logging.max_size_bytes` | `1048576` (1MB) | Max bytes before rotation |
| `logging.max_files` | `5` | Number of rotated files to keep |

## Test plan
- [x] Simulator builds cleanly
- [x] All 4 existing scenario tests pass (no behavioral regressions)
- [x] CI should confirm Linux build + test pass

Closes #7

Made with [Cursor](https://cursor.com)