### PR TITLE
Persist coin balance and plugin state across daemon restarts

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -40,7 +40,10 @@ event_processor.o: event_processor.c event_processor.h events.h
 millennium_sdk.o: millennium_sdk.c millennium_sdk.h events.h baresip_interface.h
 	gcc millennium_sdk.c -o millennium_sdk.o -c $(CFLAGS)
 
-daemon.o: daemon.c millennium_sdk.h events.h event_processor.h config.h logger.h health_monitor.h metrics.h metrics_server.h web_server.h plugins.h
+state_persistence.o: state_persistence.c state_persistence.h daemon_state.h logger.h
+	gcc state_persistence.c -o state_persistence.o -c $(CFLAGS)
+
+daemon.o: daemon.c millennium_sdk.h events.h event_processor.h config.h logger.h health_monitor.h metrics.h metrics_server.h web_server.h plugins.h state_persistence.h
 	gcc daemon.c -o daemon.o -c $(CFLAGS)
 
 # Executables
@@ -56,15 +59,15 @@ plugins/fortune_teller.o: plugins/fortune_teller.c plugins.h
 plugins/jukebox.o: plugins/jukebox.c plugins.h
 	gcc plugins/jukebox.c -o plugins/jukebox.o -c $(C99_CFLAGS) -lpthread
 
-daemon: daemon.o daemon_state.o millennium_sdk.o baresip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o
-	gcc daemon.o daemon_state.o millennium_sdk.o baresip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o -o daemon $(LDFLAGS)
+daemon: daemon.o daemon_state.o millennium_sdk.o baresip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o state_persistence.o
+	gcc daemon.o daemon_state.o millennium_sdk.o baresip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o state_persistence.o -o daemon $(LDFLAGS)
 
 # Simulator object file (uses C99 for mixed declarations)
 simulator.o: simulator.c millennium_sdk.h events.h config.h daemon_state.h logger.h metrics.h plugins.h
 	gcc simulator.c -o simulator.o -c $(C99_CFLAGS)
 
 # Simulator objects — no baresip, no web server, no daemon.o
-SIM_OBJS = simulator.o daemon_state.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o
+SIM_OBJS = simulator.o daemon_state.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o state_persistence.o
 
 # On Linux, wrap time() for simulated time; elsewhere use real time
 SIM_LDFLAGS = -lpthread

--- a/host/config.c
+++ b/host/config.c
@@ -323,6 +323,11 @@ int config_get_log_max_files(const config_data_t* config) {
     return config_get_int(config, "logging.max_files", 5);
 }
 
+/* State Persistence Configuration */
+const char* config_get_state_file(const config_data_t* config) {
+    return config_get_string(config, "persistence.state_file", "/var/lib/millennium/state");
+}
+
 /* System Configuration */
 int config_get_update_interval_ms(const config_data_t* config) {
     return config_get_int(config, "system.update_interval_ms", 33);

--- a/host/config.h
+++ b/host/config.h
@@ -39,6 +39,9 @@ int config_get_log_to_file(const config_data_t* config);
 int config_get_log_max_size_bytes(const config_data_t* config);
 int config_get_log_max_files(const config_data_t* config);
 
+/* State Persistence Configuration */
+const char* config_get_state_file(const config_data_t* config);
+
 /* System Configuration */
 int config_get_update_interval_ms(const config_data_t* config);
 int config_get_max_retries(const config_data_t* config);

--- a/host/plugins/classic_phone.c
+++ b/host/plugins/classic_phone.c
@@ -139,8 +139,8 @@ static int classic_phone_handle_call_state(int call_state) {
 
 /* Internal function implementations */
 static void classic_phone_on_activation(void) {
-    /* Reset state and show display when plugin is activated */
-    classic_phone_data.inserted_cents = 0;
+    /* Restore coins from daemon_state (may have been loaded from persisted state) */
+    classic_phone_data.inserted_cents = daemon_state ? daemon_state->inserted_cents : 0;
     classic_phone_data.keypad_length = 0;
     classic_phone_data.is_dialing = 0;
     classic_phone_data.is_in_call = 0;

--- a/host/state_persistence.c
+++ b/host/state_persistence.c
@@ -1,0 +1,81 @@
+#define _POSIX_C_SOURCE 200112L
+#include "state_persistence.h"
+#include "logger.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int state_persistence_save(const persisted_state_t *state, const char *filepath) {
+    FILE *f;
+    char tmp_path[512];
+    int fd;
+
+    if (!state || !filepath) return -1;
+
+    /* Write to a temp file then rename for atomicity */
+    snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", filepath);
+
+    f = fopen(tmp_path, "w");
+    if (!f) {
+        logger_warn_with_category("Persistence", "Failed to open state file for writing");
+        return -1;
+    }
+
+    fprintf(f, "inserted_cents=%d\n", state->inserted_cents);
+    fprintf(f, "last_state=%d\n", state->last_state);
+    fprintf(f, "active_plugin=%s\n", state->active_plugin);
+
+    fflush(f);
+    fd = fileno(f);
+    if (fd >= 0) {
+        fsync(fd);
+    }
+    fclose(f);
+
+    if (rename(tmp_path, filepath) != 0) {
+        logger_warn_with_category("Persistence", "Failed to rename state file");
+        remove(tmp_path);
+        return -1;
+    }
+
+    return 0;
+}
+
+int state_persistence_load(persisted_state_t *state, const char *filepath) {
+    FILE *f;
+    char line[256];
+
+    if (!state || !filepath) return -1;
+
+    memset(state, 0, sizeof(persisted_state_t));
+
+    f = fopen(filepath, "r");
+    if (!f) {
+        return -1;
+    }
+
+    while (fgets(line, sizeof(line), f)) {
+        char *eq = strchr(line, '=');
+        char *newline;
+        if (!eq) continue;
+
+        *eq = '\0';
+        eq++;
+
+        newline = strchr(eq, '\n');
+        if (newline) *newline = '\0';
+
+        if (strcmp(line, "inserted_cents") == 0) {
+            state->inserted_cents = atoi(eq);
+        } else if (strcmp(line, "last_state") == 0) {
+            state->last_state = atoi(eq);
+        } else if (strcmp(line, "active_plugin") == 0) {
+            strncpy(state->active_plugin, eq, sizeof(state->active_plugin) - 1);
+            state->active_plugin[sizeof(state->active_plugin) - 1] = '\0';
+        }
+    }
+
+    fclose(f);
+    return 0;
+}

--- a/host/state_persistence.h
+++ b/host/state_persistence.h
@@ -1,0 +1,25 @@
+#ifndef STATE_PERSISTENCE_H
+#define STATE_PERSISTENCE_H
+
+#include "daemon_state.h"
+
+typedef struct {
+    int inserted_cents;
+    int last_state;         /* daemon_state_t enum value */
+    char active_plugin[64];
+} persisted_state_t;
+
+/*
+ * Save current state to disk. Uses fsync for durability.
+ * Returns 0 on success, -1 on failure.
+ */
+int state_persistence_save(const persisted_state_t *state, const char *filepath);
+
+/*
+ * Load persisted state from disk.
+ * Returns 0 on success, -1 if file doesn't exist or is corrupt.
+ * On failure, *state is zeroed out.
+ */
+int state_persistence_load(persisted_state_t *state, const char *filepath);
+
+#endif /* STATE_PERSISTENCE_H */

--- a/host/tests/test_state_persistence.scenario
+++ b/host/tests/test_state_persistence.scenario
@@ -1,0 +1,38 @@
+# Test: State persistence saves and restores coins across "restarts"
+
+# Start fresh, lift receiver
+hook_up
+assert_state IDLE_UP
+assert_display Insert 50c
+
+# Insert coins
+coin 25
+assert_display Have: 25c
+coin 25
+assert_display Have: 50c
+
+# Save state with coins inserted (state=IDLE_UP, coins=50)
+save_state /tmp/millennium_test_state
+print
+
+# Simulate "crash": go to a clean state
+hook_down
+assert_state IDLE_DOWN
+assert_display Lift receiver
+
+# Simulate daemon restart: load persisted state directly
+# This restores daemon_state (IDLE_UP, 50 cents) and re-activates the plugin
+load_state /tmp/millennium_test_state
+
+# After restore, plugin reads coins from daemon_state — display should show them
+assert_state IDLE_UP
+assert_display Have: 50c
+print
+
+# Verify we can still make a call with restored coins
+keys 5551234567
+assert_display Call active
+assert_state CALL_ACTIVE
+
+hook_down
+assert_state IDLE_DOWN


### PR DESCRIPTION
## Summary
- New `state_persistence` module that saves/loads runtime state to disk using atomic writes (write to temp file, `fsync`, `rename`)
- Persists: `inserted_cents`, `active_plugin`, and `last_state` (daemon state enum)
- On daemon startup, restores persisted state so users don't lose inserted coins after a crash or reboot
- Detects unclean shutdowns (last state was `CALL_ACTIVE`) and logs a warning + increments `unclean_shutdowns` metric
- Classic phone plugin now reads `daemon_state->inserted_cents` on activation instead of always resetting to 0
- State file path configurable via `persistence.state_file` (default: `/var/lib/millennium/state`)

## Files
- New: `state_persistence.h`, `state_persistence.c`
- Modified: `daemon.c`, `plugins/classic_phone.c`, `config.h`, `config.c`, `Makefile`, `simulator.c`
- New test: `tests/test_state_persistence.scenario`

## Test plan
- [x] New scenario test verifies save/load round-trips coins correctly — inserts 50c, saves, resets, loads, verifies coins restored and call succeeds
- [x] All 5 scenario tests pass (4 existing + 1 new)
- [x] CI should confirm Linux build + test pass

Closes #8

Made with [Cursor](https://cursor.com)