### PR TITLE
Add serial reconnection and watchdog for hardware link

### DIFF
--- a/host/daemon.c
+++ b/host/daemon.c
@@ -722,9 +722,9 @@ void signal_handler(int signal) {
 
 /* Health check functions */
 health_status_t check_serial_connection(void) {
-    /* This would check if the serial connection is working */
-    /* For now, we'll return healthy */
-    return HEALTH_STATUS_HEALTHY;
+    if (!client) return HEALTH_STATUS_UNKNOWN;
+    return millennium_client_serial_is_healthy(client)
+        ? HEALTH_STATUS_HEALTHY : HEALTH_STATUS_CRITICAL;
 }
 
 health_status_t check_sip_connection(void) {
@@ -941,6 +941,7 @@ int main(int argc, char *argv[]) {
             update_metrics();
             plugins_tick();
             display_manager_tick();
+            millennium_client_check_serial(client);
         }
         
         /* Log metrics summary every 10000 loops (about every 10 seconds) at DEBUG level */

--- a/host/millennium_sdk.h
+++ b/host/millennium_sdk.h
@@ -48,6 +48,13 @@ typedef struct millennium_client {
     /* Function pointers for event handling */
     void (*create_and_queue_event_char)(struct millennium_client *client, char event_type, const char *payload);
     void (*create_and_queue_event_ptr)(struct millennium_client *client, void *event);
+
+    /* Serial health tracking */
+    struct timespec last_serial_activity;
+    int serial_healthy;
+    int reconnect_attempts;
+    struct timespec next_reconnect_time;
+    char serial_device_path[256];
 } millennium_client_t;
 
 /* Function declarations */
@@ -85,11 +92,18 @@ void millennium_client_process_event_buffer(struct millennium_client *client);
 char *millennium_client_extract_payload(struct millennium_client *client, char event_type, size_t event_start);
 void millennium_client_write_to_display(struct millennium_client *client, const char *message);
 
+/* Serial health and reconnection */
+int millennium_client_serial_is_healthy(struct millennium_client *client);
+void millennium_client_check_serial(struct millennium_client *client);
+void millennium_client_serial_activity(struct millennium_client *client);
+
 /* Utility functions */
 void list_audio_devices(void);
 
 /* Constants */
 #define BAUD_RATE B9600
 #define ASYNC_WORKERS 4
+#define SERIAL_WATCHDOG_SECONDS 30
+#define SERIAL_MAX_BACKOFF_SECONDS 60
 
 #endif /* MILLENNIUM_SDK_H */

--- a/host/simulator.c
+++ b/host/simulator.c
@@ -198,6 +198,19 @@ void millennium_client_write_command(millennium_client_t *c, uint8_t cmd,
     (void)c; (void)cmd; (void)data; (void)sz;
 }
 
+int millennium_client_serial_is_healthy(millennium_client_t *c) {
+    (void)c;
+    return 1;
+}
+
+void millennium_client_check_serial(millennium_client_t *c) {
+    (void)c;
+}
+
+void millennium_client_serial_activity(millennium_client_t *c) {
+    (void)c;
+}
+
 void millennium_client_process_event_buffer(millennium_client_t *c) { (void)c; }
 
 char *millennium_client_extract_payload(millennium_client_t *c, char t, size_t s) {


### PR DESCRIPTION
## Summary

Closes #3

- Implements serial link watchdog that detects inactivity after 30 seconds and marks the link dead
- Attempts automatic reconnection with exponential backoff (1s, 2s, 4s, ... up to 60s)
- On successful reconnect, re-initializes the coin validator and refreshes the display
- Refactored serial port opening into a reusable `open_serial_port()` helper, eliminating duplication between initial connect and reconnect paths

## Changes

| File | What |
|------|------|
| `host/millennium_sdk.h` | Added serial health fields to struct, 3 new function declarations, watchdog/backoff constants |
| `host/millennium_sdk.c` | Extracted `open_serial_port()`, implemented `check_serial()`, `serial_activity()`, `serial_is_healthy()` |
| `host/daemon.c` | Real `check_serial_connection()` health check, `check_serial()` in periodic loop |
| `host/simulator.c` | No-op stubs for the 3 new SDK functions |

## Test plan

- [x] Simulator builds cleanly with new stubs
- [x] All 5 existing scenario tests pass
- [ ] Manual testing on hardware: unplug/replug USB during operation, verify reconnection and recovery


Made with [Cursor](https://cursor.com)