### PR TITLE
Add build version tracking and /api/version endpoint

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -5,6 +5,11 @@ LDFLAGS=-lpthread -latomic -lasound `pkg-config libre --libs` `pkg-config libbar
 CFLAGS=-g -O3 -Wall -Wextra -std=c89
 C99_CFLAGS=-g -O3 -Wall -Wextra -std=c99
 
+# Build version info
+GIT_HASH := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_TIME := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "unknown")
+VERSION_CFLAGS = -DGIT_HASH='"$(GIT_HASH)"' -DBUILD_TIME='"$(BUILD_TIME)"'
+
 # Object files
 config.o: config.c config.h
 	gcc config.c -o config.o -c $(CFLAGS)
@@ -28,7 +33,7 @@ metrics_server.o: metrics_server.c metrics_server.h metrics.h logger.h
 websocket.o: websocket.c websocket.h
 	gcc websocket.c -o websocket.o -c $(CFLAGS)
 
-web_server.o: web_server.c web_server.h websocket.h config.h logger.h metrics.h health_monitor.h
+web_server.o: web_server.c web_server.h websocket.h config.h logger.h metrics.h health_monitor.h version.h
 	gcc web_server.c -o web_server.o -c $(CFLAGS)
 
 baresip_interface.o: baresip_interface.c baresip_interface.h
@@ -49,6 +54,9 @@ state_persistence.o: state_persistence.c state_persistence.h daemon_state.h logg
 display_manager.o: display_manager.c display_manager.h millennium_sdk.h
 	gcc display_manager.c -o display_manager.o -c $(CFLAGS)
 
+version.o: version.c version.h
+	gcc version.c -o version.o -c $(CFLAGS) $(VERSION_CFLAGS)
+
 daemon.o: daemon.c millennium_sdk.h events.h event_processor.h config.h logger.h health_monitor.h metrics.h metrics_server.h web_server.h plugins.h state_persistence.h display_manager.h
 	gcc daemon.c -o daemon.o -c $(CFLAGS)
 
@@ -65,15 +73,15 @@ plugins/fortune_teller.o: plugins/fortune_teller.c plugins.h
 plugins/jukebox.o: plugins/jukebox.c plugins.h
 	gcc plugins/jukebox.c -o plugins/jukebox.o -c $(C99_CFLAGS) -lpthread
 
-daemon: daemon.o daemon_state.o millennium_sdk.o baresip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o state_persistence.o display_manager.o
-	gcc daemon.o daemon_state.o millennium_sdk.o baresip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o state_persistence.o display_manager.o -o daemon $(LDFLAGS)
+daemon: daemon.o daemon_state.o millennium_sdk.o baresip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o state_persistence.o display_manager.o version.o
+	gcc daemon.o daemon_state.o millennium_sdk.o baresip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o state_persistence.o display_manager.o version.o -o daemon $(LDFLAGS)
 
 # Simulator object file (uses C99 for mixed declarations)
 simulator.o: simulator.c millennium_sdk.h events.h config.h daemon_state.h logger.h metrics.h plugins.h
 	gcc simulator.c -o simulator.o -c $(C99_CFLAGS)
 
 # Simulator objects — no baresip, no web server, no daemon.o
-SIM_OBJS = simulator.o daemon_state.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o state_persistence.o display_manager.o
+SIM_OBJS = simulator.o daemon_state.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o state_persistence.o display_manager.o version.o
 
 # On Linux, wrap time() for simulated time; elsewhere use real time
 SIM_LDFLAGS = -lpthread
@@ -87,7 +95,7 @@ simulator: $(SIM_OBJS)
 all: daemon
 
 # Unit test binary
-UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o state_persistence.o display_manager.o
+UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o state_persistence.o display_manager.o version.o
 
 tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h millennium_sdk.h
 	gcc tests/unit_tests.c -o tests/unit_tests.o -c $(C99_CFLAGS) -I.

--- a/host/version.c
+++ b/host/version.c
@@ -1,0 +1,13 @@
+#include "version.h"
+
+const char *version_get_string(void) {
+    return VERSION_STRING;
+}
+
+const char *version_get_git_hash(void) {
+    return GIT_HASH;
+}
+
+const char *version_get_build_time(void) {
+    return BUILD_TIME;
+}

--- a/host/version.h
+++ b/host/version.h
@@ -1,0 +1,27 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+/*
+ * Build version info. GIT_HASH and BUILD_TIME are injected by the
+ * Makefile via -D flags. Provide sensible defaults for standalone
+ * compilation or the simulator.
+ */
+
+#ifndef GIT_HASH
+#define GIT_HASH "unknown"
+#endif
+
+#ifndef BUILD_TIME
+#define BUILD_TIME "unknown"
+#endif
+
+#define VERSION_MAJOR 0
+#define VERSION_MINOR 2
+#define VERSION_PATCH 0
+#define VERSION_STRING "0.2.0"
+
+const char *version_get_string(void);
+const char *version_get_git_hash(void);
+const char *version_get_build_time(void);
+
+#endif /* VERSION_H */

--- a/host/web_server.c
+++ b/host/web_server.c
@@ -6,6 +6,7 @@
 #include "health_monitor.h"
 #include "plugins.h"
 #include "websocket.h"
+#include "version.h"
 
 #include <sys/socket.h>
 #include <sys/select.h>
@@ -739,6 +740,7 @@ void web_server_setup_api_routes(struct web_server* server) {
     web_server_add_route(server, "POST", "/api/control", web_server_handle_api_control);
     web_server_add_route(server, "GET", "/api/logs", web_server_handle_api_logs);
     web_server_add_route(server, "GET", "/api/plugins", web_server_handle_api_plugins);
+    web_server_add_route(server, "GET", "/api/version", web_server_handle_api_version);
 }
 
 /* Default handlers */
@@ -1277,6 +1279,20 @@ struct http_response web_server_handle_api_plugins(const struct http_request* re
         active_plugin ? active_plugin : "Unknown"
     );
     
+    web_server_strcpy_safe(response.body, json, sizeof(response.body));
+    return response;
+}
+
+struct http_response web_server_handle_api_version(const struct http_request* request) {
+    (void)request;
+    struct http_response response;
+    char json[512];
+    memset(&response, 0, sizeof(response));
+    web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
+    response.status_code = 200;
+    snprintf(json, sizeof(json),
+        "{\"version\":\"%s\",\"git_hash\":\"%s\",\"build_time\":\"%s\"}",
+        version_get_string(), version_get_git_hash(), version_get_build_time());
     web_server_strcpy_safe(response.body, json, sizeof(response.body));
     return response;
 }


### PR DESCRIPTION
## Summary

Partial progress on #10

Lays the groundwork for OTA updates by making the daemon version-aware. Every build now embeds the git commit hash and a UTC timestamp, and the web server exposes this via a new JSON API endpoint.

## Changes

| File | What |
|------|------|
| `host/version.h` | New: version constants (0.2.0), accessor declarations |
| `host/version.c` | New: accessor implementations for version string, git hash, build time |
| `host/Makefile` | Injects `GIT_HASH` and `BUILD_TIME` via `-D` flags; adds `version.o` to all build targets |
| `host/web_server.c` | New `/api/version` route returning `{"version","git_hash","build_time"}` |

## API

```
GET /api/version
→ {"version":"0.2.0","git_hash":"7caf7e5","build_time":"2026-02-22T23:43:46Z"}
```

## Test plan

- [x] 25 unit tests pass
- [x] 6 scenario tests pass
- [x] version.o correctly receives git hash and build timestamp at compile time


Made with [Cursor](https://cursor.com)