### PR TITLE
Add OTA update checker, web dashboard, and version comparison

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -33,7 +33,7 @@ metrics_server.o: metrics_server.c metrics_server.h metrics.h logger.h
 websocket.o: websocket.c websocket.h
 	gcc websocket.c -o websocket.o -c $(CFLAGS)
 
-web_server.o: web_server.c web_server.h websocket.h config.h logger.h metrics.h health_monitor.h version.h
+web_server.o: web_server.c web_server.h websocket.h config.h logger.h metrics.h health_monitor.h version.h updater.h
 	gcc web_server.c -o web_server.o -c $(CFLAGS)
 
 baresip_interface.o: baresip_interface.c baresip_interface.h
@@ -60,6 +60,9 @@ version.o: version.c version.h
 audio_tones.o: audio_tones.c audio_tones.h logger.h
 	gcc audio_tones.c -o audio_tones.o -c $(CFLAGS) -lm
 
+updater.o: updater.c updater.h version.h logger.h
+	gcc updater.c -o updater.o -c $(CFLAGS)
+
 daemon.o: daemon.c millennium_sdk.h events.h event_processor.h config.h logger.h health_monitor.h metrics.h metrics_server.h web_server.h plugins.h state_persistence.h display_manager.h audio_tones.h
 	gcc daemon.c -o daemon.o -c $(CFLAGS)
 
@@ -76,8 +79,8 @@ plugins/fortune_teller.o: plugins/fortune_teller.c plugins.h
 plugins/jukebox.o: plugins/jukebox.c plugins.h
 	gcc plugins/jukebox.c -o plugins/jukebox.o -c $(C99_CFLAGS) -lpthread
 
-daemon: daemon.o daemon_state.o millennium_sdk.o baresip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o state_persistence.o display_manager.o version.o audio_tones.o
-	gcc daemon.o daemon_state.o millennium_sdk.o baresip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o state_persistence.o display_manager.o version.o audio_tones.o -o daemon $(LDFLAGS) -lm
+daemon: daemon.o daemon_state.o millennium_sdk.o baresip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o state_persistence.o display_manager.o version.o audio_tones.o updater.o
+	gcc daemon.o daemon_state.o millennium_sdk.o baresip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o state_persistence.o display_manager.o version.o audio_tones.o updater.o -o daemon $(LDFLAGS) -lm
 
 # Simulator object file (uses C99 for mixed declarations)
 simulator.o: simulator.c millennium_sdk.h events.h config.h daemon_state.h logger.h metrics.h plugins.h
@@ -98,9 +101,9 @@ simulator: $(SIM_OBJS)
 all: daemon
 
 # Unit test binary
-UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o state_persistence.o display_manager.o version.o
+UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o state_persistence.o display_manager.o version.o updater.o
 
-tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h millennium_sdk.h
+tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h millennium_sdk.h updater.h
 	gcc tests/unit_tests.c -o tests/unit_tests.o -c $(C99_CFLAGS) -I.
 
 # Unit tests don't use time wrapping; link ALSA on Linux for jukebox

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -6,6 +6,7 @@
 #include "../logger.h"
 #include "../metrics.h"
 #include "../millennium_sdk.h"
+#include "../updater.h"
 #include <stdlib.h>
 
 /* ── Stubs for linker (plugins.c references these) ──────────────── */
@@ -387,6 +388,37 @@ static void test_plugins_duplicate_register(void) {
     plugins_cleanup();
 }
 
+/* ── Updater tests ─────────────────────────────────────────────── */
+
+static void test_version_compare_equal(void) {
+    TEST_ASSERT_EQ_INT(0, updater_compare_versions("1.0.0", "1.0.0"));
+}
+
+static void test_version_compare_major(void) {
+    TEST_ASSERT(updater_compare_versions("2.0.0", "1.0.0") > 0);
+    TEST_ASSERT(updater_compare_versions("1.0.0", "2.0.0") < 0);
+}
+
+static void test_version_compare_minor(void) {
+    TEST_ASSERT(updater_compare_versions("1.2.0", "1.1.0") > 0);
+    TEST_ASSERT(updater_compare_versions("1.1.0", "1.2.0") < 0);
+}
+
+static void test_version_compare_patch(void) {
+    TEST_ASSERT(updater_compare_versions("1.0.2", "1.0.1") > 0);
+    TEST_ASSERT(updater_compare_versions("1.0.1", "1.0.2") < 0);
+}
+
+static void test_version_compare_with_v_prefix(void) {
+    TEST_ASSERT_EQ_INT(0, updater_compare_versions("v1.0.0", "1.0.0"));
+    TEST_ASSERT(updater_compare_versions("v2.0.0", "v1.0.0") > 0);
+}
+
+static void test_version_no_update_initially(void) {
+    TEST_ASSERT_EQ_INT(0, updater_is_update_available());
+    TEST_ASSERT_NULL((void *)updater_get_latest_version());
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -422,6 +454,14 @@ int main(void) {
     TEST_SUITE_RUN(test_plugins_register_custom);
     TEST_SUITE_RUN(test_plugins_list);
     TEST_SUITE_RUN(test_plugins_duplicate_register);
+
+    TEST_SUITE_BEGIN("Updater");
+    TEST_SUITE_RUN(test_version_compare_equal);
+    TEST_SUITE_RUN(test_version_compare_major);
+    TEST_SUITE_RUN(test_version_compare_minor);
+    TEST_SUITE_RUN(test_version_compare_patch);
+    TEST_SUITE_RUN(test_version_compare_with_v_prefix);
+    TEST_SUITE_RUN(test_version_no_update_initially);
 
     TEST_REPORT();
 }

--- a/host/updater.c
+++ b/host/updater.c
@@ -1,0 +1,98 @@
+#define _POSIX_C_SOURCE 200112L
+#include "updater.h"
+#include "version.h"
+#include "logger.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+static char latest_version[64] = {0};
+static int  checked = 0;
+
+static int parse_version(const char *s, int *major, int *minor, int *patch) {
+    if (!s) return -1;
+    if (*s == 'v' || *s == 'V') s++;
+    if (sscanf(s, "%d.%d.%d", major, minor, patch) != 3) return -1;
+    return 0;
+}
+
+int updater_compare_versions(const char *a, const char *b) {
+    int a_maj = 0, a_min = 0, a_pat = 0;
+    int b_maj = 0, b_min = 0, b_pat = 0;
+
+    if (parse_version(a, &a_maj, &a_min, &a_pat) != 0) return -1;
+    if (parse_version(b, &b_maj, &b_min, &b_pat) != 0) return 1;
+
+    if (a_maj != b_maj) return a_maj - b_maj;
+    if (a_min != b_min) return a_min - b_min;
+    return a_pat - b_pat;
+}
+
+int updater_check(void) {
+    FILE *fp;
+    char buf[4096];
+    const char *tag;
+    size_t len;
+
+    /*
+     * Query GitHub Releases API.  curl is available on Raspberry Pi OS
+     * by default; the -s flag suppresses progress, -m limits timeout.
+     */
+    fp = popen("curl -s -m 10 "
+               "https://api.github.com/repos/kmatzen/millennium/releases/latest"
+               " 2>/dev/null", "r");
+    if (!fp) {
+        logger_warn_with_category("Updater", "Failed to run curl");
+        return -1;
+    }
+
+    len = fread(buf, 1, sizeof(buf) - 1, fp);
+    pclose(fp);
+    if (len == 0) {
+        logger_warn_with_category("Updater", "Empty response from GitHub");
+        return -1;
+    }
+    buf[len] = '\0';
+
+    /*
+     * Minimal JSON extraction: find "tag_name" : "vX.Y.Z"
+     * Full JSON parsing is overkill for a single field.
+     */
+    tag = strstr(buf, "\"tag_name\"");
+    if (!tag) {
+        logger_debug_with_category("Updater", "No tag_name in GitHub response (may have no releases)");
+        return -1;
+    }
+
+    /* Advance past the key and colon to the value */
+    tag = strchr(tag + 10, '"');
+    if (!tag) return -1;
+    tag++; /* skip opening quote */
+
+    {
+        const char *end = strchr(tag, '"');
+        if (!end || (size_t)(end - tag) >= sizeof(latest_version)) return -1;
+        memcpy(latest_version, tag, (size_t)(end - tag));
+        latest_version[end - tag] = '\0';
+    }
+
+    checked = 1;
+    {
+        char log_msg[128];
+        snprintf(log_msg, sizeof(log_msg),
+                 "Latest release: %s (running: %s)", latest_version, version_get_string());
+        logger_info_with_category("Updater", log_msg);
+    }
+
+    return 0;
+}
+
+const char *updater_get_latest_version(void) {
+    return checked ? latest_version : NULL;
+}
+
+int updater_is_update_available(void) {
+    if (!checked) return 0;
+    return updater_compare_versions(latest_version, version_get_string()) > 0;
+}

--- a/host/updater.h
+++ b/host/updater.h
@@ -1,0 +1,29 @@
+#ifndef UPDATER_H
+#define UPDATER_H
+
+/*
+ * OTA update checker.
+ * Compares the running version against the latest GitHub release tag.
+ */
+
+/* Semantic version comparison.
+ * Returns <0 if a < b, 0 if equal, >0 if a > b.
+ * Expects "X.Y.Z" format (leading 'v' is stripped). */
+int updater_compare_versions(const char *a, const char *b);
+
+/*
+ * Check GitHub for the latest release tag.
+ * Uses curl (must be installed) to query the GitHub Releases API.
+ * Stores result internally; subsequent calls return the cached value
+ * until updater_check() is called again.
+ * Returns 0 on success, -1 on failure.
+ */
+int updater_check(void);
+
+/* Returns the cached latest version string, or NULL if never checked. */
+const char *updater_get_latest_version(void);
+
+/* Returns 1 if the latest version is newer than the running version. */
+int updater_is_update_available(void);
+
+#endif /* UPDATER_H */


### PR DESCRIPTION
## Summary

Further progress on #10

Adds the core infrastructure for over-the-air update awareness: the daemon can now check GitHub for newer releases and report the result through the web API. Also adds a proper web dashboard that serves as the primary monitoring and control interface.

## New features

### Update checker (`updater.h/.c`)
- `updater_compare_versions()` — semantic version comparison supporting `vX.Y.Z` and `X.Y.Z` formats
- `updater_check()` — queries GitHub Releases API via `curl` (available by default on Raspberry Pi OS)
- `updater_is_update_available()` / `updater_get_latest_version()` — cached result accessors

### Web dashboard (`GET /`)
Dark-themed, responsive single-page dashboard:
- **Phone State**: Real-time state, VFD display mirror, coins, keypad, active plugin — all updated live via WebSocket
- **Controls**: Check for Updates button, Health/Metrics quick-view
- **Live Events**: Scrolling event log from WebSocket stream

### API endpoint (`GET /api/check-update`)
```json
{
  "current_version": "0.2.0",
  "latest_version": "v0.2.0",
  "update_available": false,
  "git_hash": "e34df94"
}
```

## Changes

| File | What |
|------|------|
| `host/updater.h` | New: update checker API |
| `host/updater.c` | New: version comparison, GitHub API check via popen/curl |
| `host/web_server.c` | New `/` dashboard handler, `/api/check-update` endpoint |
| `host/Makefile` | Added `updater.o` to daemon and unit test builds |
| `host/tests/unit_tests.c` | 6 new tests for version comparison (31 total) |

## Test plan

- [x] 31 unit tests pass (6 new for version comparison)
- [x] 6 scenario tests pass
- [ ] Manual: visit `http://<pi-ip>:8080/` to see dashboard
- [ ] Manual: click "Check Updates" to verify GitHub API call


Made with [Cursor](https://cursor.com)