### PR TITLE
Support free emergency calls without coin deposit

### DIFF
--- a/host/config.c
+++ b/host/config.c
@@ -302,6 +302,32 @@ int config_get_call_timeout_seconds(const config_data_t* config) {
     return config_get_int(config, "call.timeout_seconds", 300);
 }
 
+const char* config_get_free_numbers(const config_data_t* config) {
+    return config_get_string(config, "call.free_numbers", "911,311,0");
+}
+
+int config_is_free_number(const config_data_t* config, const char* number) {
+    const char *list, *p;
+    size_t nlen;
+    if (!number || !*number) return 0;
+    list = config_get_free_numbers(config);
+    if (!list) return 0;
+    nlen = strlen(number);
+    p = list;
+    while (*p) {
+        const char *comma = strchr(p, ',');
+        size_t entry_len = comma ? (size_t)(comma - p) : strlen(p);
+        /* Skip leading whitespace */
+        while (entry_len > 0 && (*p == ' ' || *p == '\t')) { p++; entry_len--; }
+        /* Trim trailing whitespace */
+        while (entry_len > 0 && (p[entry_len-1] == ' ' || p[entry_len-1] == '\t')) { entry_len--; }
+        if (entry_len == nlen && strncmp(p, number, nlen) == 0) return 1;
+        if (!comma) break;
+        p = comma + 1;
+    }
+    return 0;
+}
+
 /* Logging Configuration */
 const char* config_get_log_level(const config_data_t* config) {
     return config_get_string(config, "logging.level", "INFO");

--- a/host/config.h
+++ b/host/config.h
@@ -31,6 +31,8 @@ int config_get_baud_rate(const config_data_t* config);
 /* Call Configuration */
 int config_get_call_cost_cents(const config_data_t* config);
 int config_get_call_timeout_seconds(const config_data_t* config);
+const char* config_get_free_numbers(const config_data_t* config);
+int config_is_free_number(const config_data_t* config, const char* number);
 
 /* Logging Configuration */
 const char* config_get_log_level(const config_data_t* config);

--- a/host/tests/test_emergency_call.scenario
+++ b/host/tests/test_emergency_call.scenario
@@ -1,0 +1,62 @@
+# Test: Emergency calls bypass coin requirement
+# 911, 311, 0 should connect without any coins
+
+# Start with receiver down
+assert_state IDLE_DOWN
+
+# Lift receiver
+hook_up
+assert_state IDLE_UP
+assert_display Insert 50c
+
+# Dial 911 — no coins inserted, should immediately connect
+keys 911
+assert_state CALL_ACTIVE
+assert_display EMERGENCY CALL
+assert_display Hang up to end
+
+# Hang up
+hook_down
+assert_state IDLE_DOWN
+assert_display Lift receiver
+
+# Test another free number: 0 (operator)
+hook_up
+assert_state IDLE_UP
+
+keys 0
+assert_state CALL_ACTIVE
+assert_display EMERGENCY CALL
+
+hook_down
+assert_state IDLE_DOWN
+
+# Test 311
+hook_up
+assert_state IDLE_UP
+
+keys 311
+assert_state CALL_ACTIVE
+assert_display EMERGENCY CALL
+
+hook_down
+assert_state IDLE_DOWN
+
+# Test that a regular number still requires coins
+hook_up
+assert_state IDLE_UP
+
+keys 5551234567
+assert_state IDLE_UP
+assert_no_display Call active
+assert_no_display EMERGENCY
+
+# Now insert coins — call should go through normally
+coin 25
+coin 25
+assert_state CALL_ACTIVE
+assert_display Call active
+assert_no_display EMERGENCY
+
+hook_down
+assert_state IDLE_DOWN

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -388,6 +388,46 @@ static void test_plugins_duplicate_register(void) {
     plugins_cleanup();
 }
 
+/* ── Emergency number tests ────────────────────────────────────── */
+
+static void test_free_number_911(void) {
+    config_data_t cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    config_set_default_values(&cfg);
+    TEST_ASSERT_EQ_INT(1, config_is_free_number(&cfg, "911"));
+}
+
+static void test_free_number_311(void) {
+    config_data_t cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    config_set_default_values(&cfg);
+    TEST_ASSERT_EQ_INT(1, config_is_free_number(&cfg, "311"));
+}
+
+static void test_free_number_0(void) {
+    config_data_t cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    config_set_default_values(&cfg);
+    TEST_ASSERT_EQ_INT(1, config_is_free_number(&cfg, "0"));
+}
+
+static void test_not_free_number(void) {
+    config_data_t cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    config_set_default_values(&cfg);
+    TEST_ASSERT_EQ_INT(0, config_is_free_number(&cfg, "5551234567"));
+}
+
+static void test_free_number_custom(void) {
+    config_data_t cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "call.free_numbers", "211,411");
+    TEST_ASSERT_EQ_INT(1, config_is_free_number(&cfg, "211"));
+    TEST_ASSERT_EQ_INT(1, config_is_free_number(&cfg, "411"));
+    TEST_ASSERT_EQ_INT(0, config_is_free_number(&cfg, "911"));
+}
+
 /* ── Updater tests ─────────────────────────────────────────────── */
 
 static void test_version_compare_equal(void) {
@@ -454,6 +494,13 @@ int main(void) {
     TEST_SUITE_RUN(test_plugins_register_custom);
     TEST_SUITE_RUN(test_plugins_list);
     TEST_SUITE_RUN(test_plugins_duplicate_register);
+
+    TEST_SUITE_BEGIN("Emergency Numbers");
+    TEST_SUITE_RUN(test_free_number_911);
+    TEST_SUITE_RUN(test_free_number_311);
+    TEST_SUITE_RUN(test_free_number_0);
+    TEST_SUITE_RUN(test_not_free_number);
+    TEST_SUITE_RUN(test_free_number_custom);
 
     TEST_SUITE_BEGIN("Updater");
     TEST_SUITE_RUN(test_version_compare_equal);


### PR DESCRIPTION
## Summary

Closes #29

Adds FCC-compliant emergency call support: 911, 311, and operator (0) connect immediately without requiring any coins.

## How it works

1. After each keypress, `classic_phone_check_and_call()` checks if the current keypad buffer matches a configured free number
2. If it matches, the call starts immediately — no coin check, no 10-digit requirement
3. Coins are not consumed for emergency calls
4. Display shows "EMERGENCY CALL" instead of "Call active"
5. Emergency calls have no timeout (won't auto-disconnect)

## Configuration

```ini
# Default: 911,311,0
call.free_numbers=911,311,0,211
```

## Changes

| File | What |
|------|------|
| `host/config.h` | New: `config_get_free_numbers()`, `config_is_free_number()` |
| `host/config.c` | New: free number list parsing and matching with whitespace tolerance |
| `host/plugins/classic_phone.c` | Emergency number detection, free call flow, display, no timeout |
| `host/tests/test_emergency_call.scenario` | New: 7-test scenario covering 911/0/311 free calls and regular paid calls |
| `host/tests/unit_tests.c` | 5 new tests: default numbers, custom config, non-match |

## Test plan

- [x] 36 unit tests pass (5 new for emergency numbers)
- [x] 7 scenario tests pass (1 new emergency call scenario)
- [x] 911/311/0 connect without coins
- [x] Regular 10-digit numbers still require 50¢
- [x] Emergency calls show "EMERGENCY CALL" on display
- [x] Emergency calls don't timeout


Made with [Cursor](https://cursor.com)