### PR TITLE
Integrate magstripe reader for card-based free calling

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -70,7 +70,7 @@ daemon.o: daemon.c millennium_sdk.h events.h event_processor.h config.h logger.h
 plugins.o: plugins.c plugins.h
 	gcc plugins.c -o plugins.o -c $(CFLAGS)
 
-plugins/classic_phone.o: plugins/classic_phone.c plugins.h audio_tones.h
+plugins/classic_phone.o: plugins/classic_phone.c plugins.h audio_tones.h config.h
 	gcc plugins/classic_phone.c -o plugins/classic_phone.o -c $(CFLAGS)
 
 plugins/fortune_teller.o: plugins/fortune_teller.c plugins.h

--- a/host/config.c
+++ b/host/config.c
@@ -332,6 +332,45 @@ int config_get_idle_timeout_seconds(const config_data_t* config) {
     return config_get_int(config, "call.idle_timeout_seconds", 60);
 }
 
+/* Card Configuration */
+int config_get_card_enabled(const config_data_t* config) {
+    return config_get_bool(config, "card.enabled", 1);
+}
+
+const char* config_get_card_free_cards(const config_data_t* config) {
+    return config_get_string(config, "card.free_cards", "");
+}
+
+const char* config_get_card_admin_cards(const config_data_t* config) {
+    return config_get_string(config, "card.admin_cards", "");
+}
+
+static int config_card_in_list(const char *list, const char *card_number) {
+    const char *p;
+    size_t clen;
+    if (!card_number || !*card_number || !list) return 0;
+    clen = strlen(card_number);
+    p = list;
+    while (*p) {
+        const char *comma = strchr(p, ',');
+        size_t entry_len = comma ? (size_t)(comma - p) : strlen(p);
+        while (entry_len > 0 && (*p == ' ' || *p == '\t')) { p++; entry_len--; }
+        while (entry_len > 0 && (p[entry_len-1] == ' ' || p[entry_len-1] == '\t')) { entry_len--; }
+        if (entry_len == clen && strncmp(p, card_number, clen) == 0) return 1;
+        if (!comma) break;
+        p = comma + 1;
+    }
+    return 0;
+}
+
+int config_is_free_card(const config_data_t* config, const char* card_number) {
+    return config_card_in_list(config_get_card_free_cards(config), card_number);
+}
+
+int config_is_admin_card(const config_data_t* config, const char* card_number) {
+    return config_card_in_list(config_get_card_admin_cards(config), card_number);
+}
+
 /* Logging Configuration */
 const char* config_get_log_level(const config_data_t* config) {
     return config_get_string(config, "logging.level", "INFO");

--- a/host/config.h
+++ b/host/config.h
@@ -35,6 +35,13 @@ const char* config_get_free_numbers(const config_data_t* config);
 int config_is_free_number(const config_data_t* config, const char* number);
 int config_get_idle_timeout_seconds(const config_data_t* config);
 
+/* Card Configuration */
+int config_get_card_enabled(const config_data_t* config);
+const char* config_get_card_free_cards(const config_data_t* config);
+const char* config_get_card_admin_cards(const config_data_t* config);
+int config_is_free_card(const config_data_t* config, const char* card_number);
+int config_is_admin_card(const config_data_t* config, const char* card_number);
+
 /* Logging Configuration */
 const char* config_get_log_level(const config_data_t* config);
 const char* config_get_log_file(const config_data_t* config);

--- a/host/event_processor.c
+++ b/host/event_processor.c
@@ -14,6 +14,7 @@ event_processor_t *event_processor_create(void) {
     processor->call_state_handler = NULL;
     processor->hook_handler = NULL;
     processor->keypad_handler = NULL;
+    processor->card_handler = NULL;
     
     return processor;
 }
@@ -63,6 +64,13 @@ void event_processor_process_event(event_processor_t *processor, event_t *event)
         break;
         
     case EVENT_CARD:
+        if (processor->card_handler) {
+            processor->card_handler((card_event_t *)event);
+        } else {
+            fprintf(stderr, "EventProcessor: No card handler registered\n");
+        }
+        break;
+
     case EVENT_COIN_EEPROM_UPLOAD_START:
     case EVENT_COIN_EEPROM_UPLOAD_END:
     case EVENT_COIN_EEPROM_VALIDATION_START:
@@ -99,5 +107,11 @@ void event_processor_register_hook_handler(event_processor_t *processor, hook_ha
 void event_processor_register_keypad_handler(event_processor_t *processor, keypad_handler_func_t handler) {
     if (processor) {
         processor->keypad_handler = handler;
+    }
+}
+
+void event_processor_register_card_handler(event_processor_t *processor, card_handler_func_t handler) {
+    if (processor) {
+        processor->card_handler = handler;
     }
 }

--- a/host/event_processor.h
+++ b/host/event_processor.h
@@ -11,6 +11,7 @@ typedef void (*coin_handler_func_t)(coin_event_t *event);
 typedef void (*call_state_handler_func_t)(call_state_event_t *event);
 typedef void (*hook_handler_func_t)(hook_state_change_event_t *event);
 typedef void (*keypad_handler_func_t)(keypad_event_t *event);
+typedef void (*card_handler_func_t)(card_event_t *event);
 
 /* Event processor structure */
 struct event_processor {
@@ -19,6 +20,7 @@ struct event_processor {
     call_state_handler_func_t call_state_handler;
     hook_handler_func_t hook_handler;
     keypad_handler_func_t keypad_handler;
+    card_handler_func_t card_handler;
 };
 
 /* Function declarations */
@@ -31,5 +33,6 @@ void event_processor_register_coin_handler(event_processor_t *processor, coin_ha
 void event_processor_register_call_state_handler(event_processor_t *processor, call_state_handler_func_t handler);
 void event_processor_register_hook_handler(event_processor_t *processor, hook_handler_func_t handler);
 void event_processor_register_keypad_handler(event_processor_t *processor, keypad_handler_func_t handler);
+void event_processor_register_card_handler(event_processor_t *processor, card_handler_func_t handler);
 
 #endif /* EVENT_PROCESSOR_H */

--- a/host/plugins.c
+++ b/host/plugins.c
@@ -48,6 +48,7 @@ int plugins_register(const char *name, const char *description,
                     keypad_handler_t keypad_handler,
                     hook_handler_t hook_handler,
                     call_state_handler_t call_state_handler,
+                    card_handler_t card_handler,
                     activation_handler_t activation_handler,
                     tick_handler_t tick_handler) {
     if (plugin_count >= MAX_PLUGINS) {
@@ -76,6 +77,7 @@ int plugins_register(const char *name, const char *description,
     plugins[plugin_count].handle_keypad = keypad_handler;
     plugins[plugin_count].handle_hook = hook_handler;
     plugins[plugin_count].handle_call_state = call_state_handler;
+    plugins[plugin_count].handle_card = card_handler;
     plugins[plugin_count].handle_activation = activation_handler;
     plugins[plugin_count].handle_tick = tick_handler;
     
@@ -192,6 +194,16 @@ int plugins_handle_call_state(int call_state) {
         }
     }
     return -1; /* No active plugin or handler */
+}
+
+int plugins_handle_card(const char *card_number) {
+    if (active_plugin_index >= 0 && active_plugin_index < plugin_count) {
+        plugin_t *active_plugin = &plugins[active_plugin_index];
+        if (active_plugin->handle_card) {
+            return active_plugin->handle_card(card_number);
+        }
+    }
+    return -1;
 }
 
 void plugins_tick(void) {

--- a/host/plugins.h
+++ b/host/plugins.h
@@ -9,6 +9,7 @@ typedef int (*coin_handler_t)(int coin_value, const char *coin_code);
 typedef int (*keypad_handler_t)(char key);
 typedef int (*hook_handler_t)(int hook_up, int hook_down);
 typedef int (*call_state_handler_t)(int call_state);
+typedef int (*card_handler_t)(const char *card_number);
 typedef void (*activation_handler_t)(void);
 typedef void (*tick_handler_t)(void);
 
@@ -20,6 +21,7 @@ typedef struct {
     keypad_handler_t handle_keypad;
     hook_handler_t handle_hook;
     call_state_handler_t handle_call_state;
+    card_handler_t handle_card;
     activation_handler_t handle_activation;
     tick_handler_t handle_tick;
 } plugin_t;
@@ -32,6 +34,7 @@ int plugins_register(const char *name, const char *description,
                     keypad_handler_t keypad_handler,
                     hook_handler_t hook_handler,
                     call_state_handler_t call_state_handler,
+                    card_handler_t card_handler,
                     activation_handler_t activation_handler,
                     tick_handler_t tick_handler);
 int plugins_activate(const char *plugin_name);
@@ -43,6 +46,7 @@ int plugins_handle_coin(int coin_value, const char *coin_code);
 int plugins_handle_keypad(char key);
 int plugins_handle_hook(int hook_up, int hook_down);
 int plugins_handle_call_state(int call_state);
+int plugins_handle_card(const char *card_number);
 void plugins_tick(void);
 
 /* Built-in plugin registration functions */

--- a/host/plugins/fortune_teller.c
+++ b/host/plugins/fortune_teller.c
@@ -238,6 +238,7 @@ void register_fortune_teller_plugin(void) {
                     fortune_teller_handle_keypad,
                     fortune_teller_handle_hook,
                     fortune_teller_handle_call_state,
+                    NULL,
                     fortune_teller_on_activation,
                     NULL);
 }

--- a/host/plugins/jukebox.c
+++ b/host/plugins/jukebox.c
@@ -469,6 +469,7 @@ void register_jukebox_plugin(void) {
                     jukebox_handle_keypad,
                     jukebox_handle_hook,
                     jukebox_handle_call_state,
+                    NULL,
                     jukebox_on_activation,
                     NULL);
 }

--- a/host/tests/test_card_swipe.scenario
+++ b/host/tests/test_card_swipe.scenario
@@ -1,0 +1,35 @@
+# Test: Magstripe card swipe for free calling
+# Verifies that swiping a registered free-call card allows dialing
+# without inserting coins.
+
+# Configure a free calling card
+config card.free_cards 1234567890123456
+
+# Lift the handset
+hook_up
+assert_display Insert
+
+# Swipe the free calling card
+card 1234567890123456
+assert_display Card accepted
+assert_display Dial number
+
+# Dial a 10-digit number without any coins
+keys 2125551234
+call_active
+assert_display Card call
+assert_display Hang up
+
+# Hang up — resets card state
+hook_down
+
+# Lift again — no card active, back to normal
+hook_up
+assert_display Insert
+
+# Swipe an unregistered card
+card 0000000000000000
+assert_display Unknown card
+
+# Hang up
+hook_down


### PR DESCRIPTION
## Summary
- Routes `EVENT_CARD` through the event processor to the active plugin, completing the card event pipeline that was previously logged and discarded
- Adds `card_handler_t` to the plugin interface; classic phone plugin accepts free-call cards (configured via `card.free_cards`) to bypass coin requirements, and recognizes admin cards (`card.admin_cards`) with display feedback
- Adds `config` command to the scenario simulator so tests can set config values at runtime
- 5 new unit tests for card config + 1 new scenario test for full card swipe flow; all existing tests continue to pass

Closes #6

## Test plan
- [x] All 41 unit tests pass (including 5 new card config tests)
- [x] All scenario tests pass (including new `test_card_swipe.scenario`)
- [ ] CI passes on GitHub Actions


Made with [Cursor](https://cursor.com)