### PR TITLE
Add OTA self-update mechanism with web dashboard trigger

### DIFF
--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -459,6 +459,16 @@ static void test_version_no_update_initially(void) {
     TEST_ASSERT_NULL((void *)updater_get_latest_version());
 }
 
+static void test_updater_apply_null_dir(void) {
+    TEST_ASSERT_EQ_INT(-1, updater_apply(NULL));
+    TEST_ASSERT(strstr(updater_get_apply_status(), "no source") != NULL);
+}
+
+static void test_updater_apply_bad_dir(void) {
+    TEST_ASSERT_EQ_INT(-1, updater_apply("/nonexistent/path/to/repo"));
+    TEST_ASSERT(strstr(updater_get_apply_status(), "git pull failed") != NULL);
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -509,6 +519,8 @@ int main(void) {
     TEST_SUITE_RUN(test_version_compare_patch);
     TEST_SUITE_RUN(test_version_compare_with_v_prefix);
     TEST_SUITE_RUN(test_version_no_update_initially);
+    TEST_SUITE_RUN(test_updater_apply_null_dir);
+    TEST_SUITE_RUN(test_updater_apply_bad_dir);
 
     TEST_REPORT();
 }

--- a/host/updater.h
+++ b/host/updater.h
@@ -26,4 +26,20 @@ const char *updater_get_latest_version(void);
 /* Returns 1 if the latest version is newer than the running version. */
 int updater_is_update_available(void);
 
+/*
+ * Apply an update: git pull, rebuild, then restart the daemon via
+ * systemd.  The function builds the new binary before restarting so
+ * that a failed build does not interrupt service.
+ *
+ * source_dir: absolute path to the repo checkout (e.g. /home/matzen/millennium)
+ *
+ * Returns  0 on success (note: successful restart means this function
+ *          never returns — systemd kills the old process).
+ * Returns -1 if git pull or build fails (daemon continues running).
+ */
+int updater_apply(const char *source_dir);
+
+/* Get a human-readable status message from the last updater_apply call. */
+const char *updater_get_apply_status(void);
+
 #endif /* UPDATER_H */

--- a/host/web_server.h
+++ b/host/web_server.h
@@ -151,6 +151,7 @@ struct http_response web_server_handle_api_state(const struct http_request* requ
 struct http_response web_server_handle_api_control(const struct http_request* request);
 struct http_response web_server_handle_api_logs(const struct http_request* request);
 struct http_response web_server_handle_api_plugins(const struct http_request* request);
+struct http_response web_server_handle_api_update(const struct http_request* request);
 
 /* Utility functions */
 int web_server_is_in_call(void);


### PR DESCRIPTION
## Summary
- Implements `updater_apply()` which does `git pull --ff-only`, `make clean && make daemon`, `make install`, and `systemctl restart` — the full OTA update pipeline
- Adds `POST /api/update` endpoint callable from the web dashboard
- Dashboard now shows an "Apply Update" button (green) when `Check Updates` finds a newer version; confirms before applying, shows progress status, and handles the restart gracefully
- Source directory is configurable via `system.source_dir` config key (defaults to `/home/matzen/millennium`)

Closes #10

## Test plan
- [x] 38 unit tests pass (including 2 new for updater_apply error paths)
- [x] All scenario tests pass
- [ ] CI passes on GitHub Actions
- [ ] Manual test on Raspberry Pi with a real GitHub release


Made with [Cursor](https://cursor.com)