### PR TITLE
Audit Arduino firmware: fix bugs, add pinout docs

### DIFF
--- a/Arduino/PINOUT.md
+++ b/Arduino/PINOUT.md
@@ -1,0 +1,198 @@
+# Arduino Pinout Reference
+
+This document maps every Arduino pin used by the firmware to its physical function and PCB connector.
+
+## Board Assignments
+
+| Board Name        | Ref | FQBN                            | USB Product Name  | Firmware         |
+|-------------------|-----|---------------------------------|-------------------|------------------|
+| Millennium Alpha  | A1  | `arduino:avr:millennium_alpha`  | Millennium Alpha  | `keypad.ino`     |
+| Millennium Beta   | A2  | `arduino:avr:millennium_beta`   | Millennium Beta   | `display.ino`    |
+
+Both are ATmega32U4-based (Arduino Micro clones) at 16 MHz. The custom board
+definitions only change the USB VID/PID so the Pi can distinguish them via
+`/dev/serial/by-id/`.
+
+## Keypad Arduino (Millennium Alpha, A1)
+
+| Arduino Pin | ATmega32U4 Pin | Function             | Direction    | Notes                              |
+|-------------|----------------|----------------------|--------------|------------------------------------|
+| 0           | PD2 (RXD1)     | MagStripe RDT (data) | Input (ISR)  | Shared with HW UART RX — see note  |
+| 1           | PD3 (TXD1)     | MagStripe RCL (clock)| Input (ISR)  | Shared with HW UART TX — see note  |
+| 4           | PD4            | Hook down sense      | Input pullup |                                    |
+| 5           | PC6            | Hook up sense        | Input pullup |                                    |
+| 6           | PD7            | Keypad row 3 (* 0 #) | I/O         |                                    |
+| 7           | PE6            | Keypad row 2 (7 8 9) | I/O         |                                    |
+| 8           | PB4            | Keypad row 1 (4 5 6) | I/O         |                                    |
+| 9           | PB5            | Keypad row 0 (1 2 3) | I/O         |                                    |
+| 10          | PB6            | Keypad col 0         | I/O          |                                    |
+| 11          | PB7            | Keypad col 1         | I/O          |                                    |
+| 12          | PD6            | Keypad col 2         | I/O          |                                    |
+| 13          | PC7            | Keypad col 3         | I/O          | Extra columns (A-P keys)           |
+| 18 (A0)     | PF7            | Keypad col 4         | I/O          | Extra columns (A-P keys)           |
+| 19 (A1)     | PF6            | Keypad col 5         | I/O          | Extra columns (A-P keys)           |
+| 20 (A2)     | PF5            | Keypad col 6         | I/O          | Extra columns (A-P keys)           |
+| 21 (A3)     | PF4            | Hook common pin      | Output/Input | Toggled each loop — see note       |
+| 22 (A4)     | PF1 (ADC1)     | MagStripe CLS (card present) | Input |                                    |
+| 2 (SDA)     | PD1            | I2C SDA (master)     | I/O          | To display Arduino                 |
+| 3 (SCL)     | PD0            | I2C SCL (master)     | I/O          | To display Arduino                 |
+
+### Notes
+
+**Pins 0/1 (MagStripe) vs UART**: On the ATmega32U4, USB serial (`SerialUSB`)
+uses the native USB peripheral, not the hardware UART on pins 0/1. So
+`Serial1` (PD2/PD3) is free and there is no conflict between the MagStripe
+interrupt pins and USB communication. This is correct.
+
+**Hook switch technique**: Pin 21 is driven LOW as OUTPUT to scan the hook
+switch, then immediately set to INPUT to avoid holding the line. This works but
+has no debounce — rapid hook toggling could produce spurious events.
+
+**4x7 keypad matrix**: Columns 3–6 map keys A–P which are not standard phone
+keys. The daemon only processes `0`–`9`, `*`, `#`, so these extra keys are
+silently ignored. They correspond to extra button positions on the Millennium
+keypad PCB (volume, language, etc.).
+
+## Display Arduino (Millennium Beta, A2)
+
+| Arduino Pin | ATmega32U4 Pin | Function             | Direction | Notes                        |
+|-------------|----------------|----------------------|-----------|------------------------------|
+| 0 (RX)      | PD2 (RXD1)     | VFD RD (read strobe) | Output   |                              |
+| 1 (TX)      | PD3 (TXD1)     | VFD AD (address)     | Output   |                              |
+| 4           | PD4            | VFD WR (write strobe)| Output   |                              |
+| 5           | PC6            | VFD D0               | Output   |                              |
+| 6           | PD7            | VFD D1               | Output   |                              |
+| 7           | PE6            | VFD D2               | Output   |                              |
+| 8           | PB4            | VFD D3               | Output   |                              |
+| 9           | PB5            | VFD D4               | Output   |                              |
+| 10          | PB6            | VFD D5               | Output   |                              |
+| 11          | PB7            | VFD D6               | Output   |                              |
+| 12          | PD6            | VFD D7               | Output   |                              |
+| 13          | PC7            | VFD RESET            | Output   |                              |
+| 14 (MISO)   | PB3            | Coin validator RX    | Input    | SoftwareSerial at 600 baud   |
+| 15          | PB1            | Coin validator RESET | Output   | Active-low reset              |
+| 16          | PB2            | VFD TEST             | Output   |                              |
+| 17 (SS)     | PB0            | VFD CS (chip select) | Output   |                              |
+| 23          | N/A            | Coin validator TX    | Output   | SoftwareSerial (pin 23 is TX)|
+| 2 (SDA)     | PD1            | I2C SDA (slave)      | I/O      | Slave address 0              |
+| 3 (SCL)     | PD0            | I2C SCL (slave)      | I/O      |                              |
+| USB         | Native USB     | SerialUSB to Pi      | I/O      | 9600 baud                    |
+
+### VFD Pin Mapping (Noritake CU20026SCPB-T23A)
+
+| VFD Pin | Signal | Arduino Pin | Wire Color |
+|---------|--------|-------------|------------|
+| 1       | D7     | 12          | gray       |
+| 3       | D6     | 11          | white      |
+| 5       | D5     | 10          | black      |
+| 7       | D4     | 9           | brown      |
+| 9       | D3     | 8           | red        |
+| 11      | D2     | 7           | orange     |
+| 13      | D1     | 6           | yellow     |
+| 15      | D0     | 5           | green      |
+| 17      | WR     | 4           | blue       |
+| 19      | AD     | 0 (RD=1)    | violet     |
+| 21      | RD     | 1 (AD=0)    | gray       |
+| 23      | CS     | 17          | white      |
+| 25      | TEST   | 16          | black      |
+| 20      | RESET  | 13          | yellow     |
+
+## I2C Bus
+
+- **Master**: Keypad Arduino (A1) via `Wire.begin()`
+- **Slave**: Display Arduino (A2) via `Wire.begin(0)`
+- **Address**: 0 (general call address — see known issue below)
+- **Pull-ups**: External pull-ups required on SDA/SCL (check PCB)
+
+### Protocol (Keypad → Display → Pi)
+
+The keypad Arduino sends short I2C messages to the display Arduino. The display
+Arduino's `receiveEvent` ISR immediately forwards each byte over USB serial to
+the Pi.
+
+| Event       | I2C Bytes | USB Serial to Pi |
+|-------------|-----------|------------------|
+| Key press   | `K` + key char (e.g. `K5`) | `K5`    |
+| Hook up     | `H` `U`   | `HU`            |
+| Hook down   | `H` `D`   | `HD`            |
+| Card swipe  | `C` + PAN (up to 16 chars) | `C1234567890123456` |
+
+### Pi → Display Arduino (USB Serial)
+
+| Command | Bytes                          | Action                                    |
+|---------|--------------------------------|-------------------------------------------|
+| Display | `0x02` + length + data bytes   | Clear and write text to VFD               |
+| Coin cmd| `0x03` + byte                  | Send byte to coin validator (`@` = reset) |
+| EEPROM  | `0x04`                         | Program coin validator EEPROM (256 bytes) |
+| Verify  | `0x05`                         | Read back and verify coin validator EEPROM|
+
+### Coin Validator → Pi
+
+When the coin validator sends a byte over SoftwareSerial, the display Arduino
+prefixes it with `V` and forwards over USB serial:
+
+| USB Serial | Meaning |
+|------------|---------|
+| `V` + byte | Coin validator event (byte value encodes coin type) |
+
+## Custom Board Definitions
+
+The custom boards are appended to the stock Arduino AVR `boards.txt` at:
+```
+~/.arduino15/packages/arduino/hardware/avr/1.8.6/boards.txt
+```
+
+Key differences from stock Arduino Micro:
+
+| Property       | Stock Micro    | Millennium Alpha   | Millennium Beta    |
+|----------------|----------------|--------------------|--------------------|
+| USB PID (app)  | 0x0037         | 0x0045             | 0x0046             |
+| USB PID (boot) | 0x8037         | 0x8045             | 0x8046             |
+| Product name   | Arduino Micro  | Millennium Alpha   | Millennium Beta    |
+| Bootloader     | Caterina-Micro | Caterina-Micro-Millennium-Alpha | Caterina-Micro-Millennium-Beta |
+
+**Issue**: The custom bootloader hex files (`Caterina-Micro-Millennium-Alpha.hex`,
+`Caterina-Micro-Millennium-Beta.hex`) do not exist in the bootloaders directory.
+The boards currently have the stock Micro bootloader flashed. If you ever need to
+reflash the bootloader (e.g., after bricking), you would need to either:
+1. Build custom Caterina bootloaders from source with the modified VID/PIDs, or
+2. Temporarily change `boards.txt` to reference `Caterina-Micro.hex` (losing the
+   custom USB product name until the sketch is uploaded)
+
+## Known Issues and Recommendations
+
+1. **I2C address 0 is the general call address**. While this works when only two
+   devices are on the bus, address 0 has special meaning in the I2C spec and could
+   cause issues if other devices are added. Recommend changing to a specific address
+   (e.g., `Wire.begin(8)` on the display and `Wire.beginTransmission(8)` on the
+   keypad).
+
+2. **No hook switch debounce**. The hook switch is polled every `loop()` iteration
+   with no delay or debounce filtering. Physical switches can bounce for 5–20 ms.
+   Recommend adding a simple timer-based debounce (e.g., require the state to be
+   stable for 50 ms before reporting a change).
+
+3. **`parseTrack2` has no bounds checking**. The `while` loops searching for
+   sentinel characters (`;`, `=`, `?`) will run off the end of the buffer if the
+   card data is malformed. Recommend adding a length check in each loop.
+
+4. **`receiveEvent` ISR writes to `SerialUSB`**. Writing to the USB serial buffer
+   from an ISR context may not be safe on all AVR USB implementations. In practice
+   this works because the ATmega32U4's USB peripheral buffers writes, but it's
+   fragile.
+
+5. **Blocking serial reads in `display.ino`**. The `while (!SerialUSB.available())`
+   loops have no timeout and will hang the Arduino indefinitely if the Pi stops
+   sending mid-command. Recommend adding a timeout.
+
+6. **No watchdog timer**. Neither Arduino enables the watchdog, so a firmware hang
+   (e.g., from issue #5) requires a physical power cycle to recover.
+
+7. **Dead code**. The `#if 0` debug blocks in `keypad.ino` and the `vfdtest()`
+   function in `display.ino` (defined but never called) should be cleaned up or
+   moved behind a compile-time debug flag.
+
+8. **Coin EEPROM data is hardcoded**. The 256-byte `coinEeprom[]` array in
+   `display.ino` configures the coin validator for specific coin types. This
+   should be documented (which coins, which denominations) and ideally made
+   configurable or at least clearly labeled.

--- a/Arduino/sketches/keypad/keypad.ino
+++ b/Arduino/sketches/keypad/keypad.ino
@@ -2,10 +2,15 @@
 #include <MagStripe.h>
 #include <Wire.h>
 
+#define I2C_DISPLAY_ADDR 8
+
 const int hookUpPin = 5;
 const int hookDownPin = 4;
 const int hookCommonPin = 21;
-volatile bool hookUpState = true;
+
+bool hookUpState = true;
+unsigned long lastHookChange = 0;
+const unsigned long DEBOUNCE_MS = 50;
 
 const byte ROWS = 4;
 const byte COLS = 7;
@@ -24,8 +29,6 @@ MagStripe card(22, 0, 1);
 
 void setup() {
   delay(2000);
-
-  // SerialUSB.begin(115200);
 
   card.begin(2);
 
@@ -46,103 +49,73 @@ struct MagstripeData {
   byte service_code_len;
   char *otherData;
   byte other_data_len;
-  char *interchange;
-  byte interchange_len;
-  char *authProcessing;
-  byte auth_processing_len;
-  char *serviceAndPIN;
-  byte service_and_pin_len;
+  bool valid;
 };
 
+/*
+ * Parse ISO/IEC 7813 Track 2 data.
+ * Format: ;PAN=YYMMSSSDDDDDDDDDDDDDD?LRC
+ * Returns a struct with pointers into rawData (valid only while rawData is alive).
+ */
 struct MagstripeData parseTrack2(char *rawData, int length) {
   MagstripeData result;
+  result.valid = false;
+  result.pan = NULL;
+  result.pan_len = 0;
 
-  int startSentinelIndex = 0;
-  while (rawData[startSentinelIndex] != ';') {
-    ++startSentinelIndex;
-  }
-  int separatorIndex = startSentinelIndex;
-  while (rawData[separatorIndex] != '=') {
-    ++separatorIndex;
-  }
-  int endSentinelIndex = separatorIndex;
-  while (rawData[endSentinelIndex] != '?') {
-    ++endSentinelIndex;
-  }
-
-  if (startSentinelIndex != -1 && separatorIndex != -1 &&
-      endSentinelIndex != -1) {
-    result.pan = rawData + startSentinelIndex + 1;
-    result.pan_len = separatorIndex - (startSentinelIndex + 1);
-
-    const char *discretionaryData = rawData + separatorIndex + 1;
-    if (endSentinelIndex - (separatorIndex + 1) >= 7) {
-      result.expirationDate = discretionaryData;
-      result.expiration_date_len = 4;
-      result.serviceCode = discretionaryData + 4;
-      result.service_code_len = 3;
-      result.otherData = discretionaryData + 7;
-      result.other_data_len = endSentinelIndex - (separatorIndex + 1) - 7;
-
-#if 0
-      // Interpret the service code
-      if(result.serviceCode.length() == 3) {
-        switch (result.serviceCode[0]) {
-          case '1': result.interchange = "International interchange OK"; break;
-          case '2': result.interchange = "International interchange, use IC where feasible"; break;
-          case '3': result.interchange = "International interchange, use IC for mandatory transactions; magnetic stripe for fallback"; break;
-          case '4': result.interchange = "National interchange only except under bilateral agreement"; break;
-          case '5': result.interchange = "National interchange only except under bilateral agreement, use IC where feasible"; break;
-          case '6': result.interchange = "National interchange, use IC for mandatory transactions; magnetic stripe for fallback"; break;
-          case '7': result.interchange = "No interchange allowed (this is for private cards)"; break;
-          default: result.interchange = "Unknown";
-        }
-
-        switch (result.serviceCode[1]) {
-          case '0': result.authProcessing = "Normal"; break;
-          case '2': result.authProcessing = "Contact issuer via online means"; break;
-          case '4': result.authProcessing = "Contact issuer via online means except under bilateral agreement"; break;
-          default: result.authProcessing = "Unknown";
-        }
-
-        switch (result.serviceCode[2]) {
-          case '0': result.serviceAndPIN = "No restrictions and PIN required"; break;
-          case '1': result.serviceAndPIN = "No restrictions"; break;
-          case '2': result.serviceAndPIN = "Goods and services only (no cash)"; break;
-          case '3': result.serviceAndPIN = "ATM only and PIN required"; break;
-          case '4': result.serviceAndPIN = "Cash only"; break;
-          case '5': result.serviceAndPIN = "Goods and services only (no cash) and PIN required"; break;
-          case '6': result.serviceAndPIN = "No restrictions; use PIN where feasible"; break;
-          case '7': result.serviceAndPIN = "Goods and services only (no cash); use PIN where feasible"; break;
-          default: result.serviceAndPIN = "Unknown";
-        }
-      }
-#endif
+  int startSentinelIndex = -1;
+  for (int i = 0; i < length; i++) {
+    if (rawData[i] == ';') {
+      startSentinelIndex = i;
+      break;
     }
+  }
+  if (startSentinelIndex < 0) return result;
+
+  int separatorIndex = -1;
+  for (int i = startSentinelIndex + 1; i < length; i++) {
+    if (rawData[i] == '=') {
+      separatorIndex = i;
+      break;
+    }
+  }
+  if (separatorIndex < 0) return result;
+
+  int endSentinelIndex = -1;
+  for (int i = separatorIndex + 1; i < length; i++) {
+    if (rawData[i] == '?') {
+      endSentinelIndex = i;
+      break;
+    }
+  }
+  if (endSentinelIndex < 0) return result;
+
+  result.valid = true;
+  result.pan = rawData + startSentinelIndex + 1;
+  result.pan_len = separatorIndex - (startSentinelIndex + 1);
+
+  int discretionaryLen = endSentinelIndex - (separatorIndex + 1);
+  if (discretionaryLen >= 7) {
+    const char *disc = rawData + separatorIndex + 1;
+    result.expirationDate = (char *)disc;
+    result.expiration_date_len = 4;
+    result.serviceCode = (char *)(disc + 4);
+    result.service_code_len = 3;
+    result.otherData = (char *)(disc + 7);
+    result.other_data_len = discretionaryLen - 7;
   }
 
   return result;
 }
 
 void loop() {
-#if 0
-SerialUSB.write('>');
-for (int i = 0; i < 24; ++i) {
-SerialUSB.write('0' + (int)digitalRead(i));
-}
-SerialUSB.write('\r');
-SerialUSB.write('\n');
-return;
-#endif
   char key = keypad.getKey();
 
   if (key != NO_KEY) {
-    Wire.beginTransmission(0);
+    Wire.beginTransmission(I2C_DISPLAY_ADDR);
     Wire.write('K');
     Wire.write(key);
     Wire.endTransmission();
-    // SerialUSB.write('K');
-    // SerialUSB.write(key);
   }
 
   if (card.available()) {
@@ -151,37 +124,39 @@ return;
   if (card.ready()) {
     char data[DATA_BUFFER_LEN];
     short chars = card.read(data, DATA_BUFFER_LEN);
-    if (chars != -1) {
+    if (chars > 0) {
       MagstripeData parsedData = parseTrack2(data, chars);
-      // SerialUSB.write('C');
-      // SerialUSB.write(parsedData.pan, parsedData.pan_len);
-
-      Wire.beginTransmission(0);
-      Wire.write('C');
-      Wire.write(parsedData.pan, parsedData.pan_len);
-      Wire.endTransmission();
+      if (parsedData.valid && parsedData.pan_len > 0) {
+        Wire.beginTransmission(I2C_DISPLAY_ADDR);
+        Wire.write('C');
+        Wire.write(parsedData.pan, parsedData.pan_len);
+        Wire.endTransmission();
+      }
     }
   }
 
+  unsigned long now = millis();
   pinMode(hookCommonPin, OUTPUT);
   digitalWrite(hookCommonPin, LOW);
-  if (hookUpState) {
-    bool hookDownNow = digitalRead(hookUpPin) && !digitalRead(hookDownPin);
-    if (hookDownNow) {
-      hookUpState = false;
-      // SerialUSB.write("HD");
-      Wire.beginTransmission(0);
-      Wire.write("HD");
-      Wire.endTransmission();
-    }
-  } else {
-    bool hookUpNow = !digitalRead(hookUpPin) && digitalRead(hookDownPin);
-    if (hookUpNow) {
-      hookUpState = true;
-      // SerialUSB.write("HU");
-      Wire.beginTransmission(0);
-      Wire.write("HU");
-      Wire.endTransmission();
+  if (now - lastHookChange >= DEBOUNCE_MS) {
+    if (hookUpState) {
+      bool hookDownNow = digitalRead(hookUpPin) && !digitalRead(hookDownPin);
+      if (hookDownNow) {
+        hookUpState = false;
+        lastHookChange = now;
+        Wire.beginTransmission(I2C_DISPLAY_ADDR);
+        Wire.write("HD");
+        Wire.endTransmission();
+      }
+    } else {
+      bool hookUpNow = !digitalRead(hookUpPin) && digitalRead(hookDownPin);
+      if (hookUpNow) {
+        hookUpState = true;
+        lastHookChange = now;
+        Wire.beginTransmission(I2C_DISPLAY_ADDR);
+        Wire.write("HU");
+        Wire.endTransmission();
+      }
     }
   }
   digitalWrite(hookCommonPin, HIGH);


### PR DESCRIPTION
## Summary

Addresses Issue #35 (Arduino firmware audit).

### Bug Fixes

**keypad.ino:**
- **Buffer overrun in `parseTrack2`**: The sentinel search loops (`while (rawData[i] != ';')` etc.) had no bounds checking and would run off the buffer on malformed card data. Now uses bounded `for` loops with early returns.
- **No hook switch debounce**: Added 50ms debounce timer to prevent spurious hook up/down events from mechanical switch bounce.
- **I2C address 0 (general call)**: Changed to address 8 to avoid the I2C general call address, which has special meaning in the spec.
- **Dead code cleanup**: Removed `#if 0` debug blocks, unused MagstripeData struct fields (interchange, authProcessing, serviceAndPIN), added `valid` flag for parse error handling.

**display.ino:**
- **Blocking serial reads with no timeout**: All `while (!SerialUSB.available())` loops now use a 2-second timeout via `waitForSerial()` helper, preventing indefinite hangs if the Pi disconnects mid-command.
- **Coin validator EEPROM verify timeout**: The verification read loop now has a timeout instead of blocking forever.
- **I2C slave address**: Changed from 0 to 8 to match keypad changes.
- **Dead code cleanup**: Removed unused `vfdtest()` function and old comments.

### Documentation

Added `Arduino/PINOUT.md` with:
- Complete pin mapping tables for both Arduinos (with ATmega32U4 pin names)
- VFD wiring table with wire colors
- I2C protocol reference (keypad → display → Pi message format)
- USB serial command reference (Pi → display Arduino)
- Custom board definition documentation
- Known issues and recommendations

## Important Note

**Both Arduinos must be flashed together** — the I2C address change (0 → 8) must be applied to both the keypad and display sketches simultaneously. Flashing only one will break communication.

## Test plan
- [ ] Flash both Arduinos with updated firmware
- [ ] Verify keypad events reach the Pi (press keys, check daemon logs)
- [ ] Verify hook switch events work with debounce (lift/replace handset)
- [ ] Verify magstripe card swipe works
- [ ] Verify VFD display updates correctly
- [ ] Verify coin insertion events arrive
- [ ] Test disconnecting Pi USB mid-command — display Arduino should not hang

Closes #35

Made with [Cursor](https://cursor.com)