### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report a problem with the daemon, firmware, PCB, or web dashboard
+labels: bug
+---
+
+**Component** (check one):
+- [ ] Host daemon
+- [ ] Arduino firmware (keypad or display)
+- [ ] PCB / wiring
+- [ ] Web dashboard
+- [ ] Other
+
+**Describe the bug**
+A clear description of the problem.
+
+**Steps to reproduce**
+1. ...
+2. ...
+
+**Expected behavior**
+What should happen.
+
+**Logs / screenshots**
+Paste relevant daemon log output, serial monitor output, or screenshots.
+
+**Environment**
+- Raspbian version:
+- Baresip version:
+- Daemon git hash (`daemon --version` or web dashboard):
+- Arduino board definitions:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an improvement or new feature
+labels: enhancement
+---
+
+**Component** (check one):
+- [ ] Host daemon
+- [ ] Arduino firmware
+- [ ] PCB / hardware
+- [ ] Web dashboard
+- [ ] Documentation
+- [ ] Other
+
+**Describe the feature**
+What you'd like to add or change, and why.
+
+**Alternatives considered**
+Other approaches you thought of.
+
+**Additional context**
+Datasheets, reference implementations, or related issues.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- 1-3 bullet points describing what this PR does and why -->
+
+## Test plan
+
+- [ ] `make test` passes (unit tests + scenario tests)
+- [ ] Tested on hardware (if applicable)
+- [ ] Documentation updated (if applicable)
+
+## Related issues
+
+<!-- Link related issues: Closes #N, Fixes #N, etc. -->


### PR DESCRIPTION
## Summary
- Adds bug report and feature request issue templates under `.github/ISSUE_TEMPLATE/`
- Adds pull request template with test checklist at `.github/pull_request_template.md`

Addresses #37

## Test plan
- [ ] Verify issue creation shows the template picker
- [ ] Verify PR creation pre-fills the template body


Made with [Cursor](https://cursor.com)