### PR TITLE
Add hardware assembly reference, improve case documentation

### DIFF
--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -1,0 +1,107 @@
+# Hardware Assembly Reference
+
+Physical hardware inside the Millennium payphone, how everything connects,
+and notes from the current build.
+
+## Components
+
+| Component                    | Model / Part             | Notes                           |
+|------------------------------|--------------------------|---------------------------------|
+| Single-board computer        | Raspberry Pi Zero W      | Single USB port, needs hub      |
+| Keypad microcontroller       | Arduino Micro (custom)   | "Millennium Alpha" board def    |
+| Display microcontroller      | Arduino Micro (custom)   | "Millennium Beta" board def     |
+| USB audio card               | C-Media CM109 (Unitek Y-247A) | USB class-compliant, stereo out + mono mic in |
+| USB hub                      | Huasheng USB2.0 HUB      | 2 hubs daisy-chained for 3 ports |
+| Boost converter              | XL6009 module            | Converts phone line voltage to 5V |
+| Custom PCB                   | phonev4                  | Connects all peripherals        |
+| VFD display                  | Noritake CU20026SCPB-T23A | 20×2 character VFD             |
+| Coin validator               | Original Millennium part | 600 baud serial protocol        |
+| Magstripe reader             | Original Millennium part | Clock + data signals            |
+| Handset                      | Original Millennium part | RJ9 connector (4P4C)            |
+| Ringer speaker               | Original Millennium part | Front-mounted                   |
+| Keypad                       | Original Millennium part | 4×7 matrix, 20-pin ribbon       |
+| 3D-printed case              | PLA+                     | Houses the PCB                  |
+
+## USB Topology
+
+The Raspberry Pi Zero W has a single micro-USB OTG port. A USB hub provides
+connectivity for all USB peripherals:
+
+```
+Pi Zero W (USB OTG)
+  └─ USB Hub #1
+       ├─ USB Hub #2
+       │    ├─ Arduino "Millennium Alpha" (keypad)
+       │    └─ Arduino "Millennium Beta" (display)
+       └─ C-Media USB Audio Adapter
+```
+
+The two Arduinos enumerate as USB serial devices:
+- `/dev/serial/by-id/usb-Arduino_LLC_Millennium_Alpha-if00`
+- `/dev/serial/by-id/usb-Arduino_LLC_Millennium_Beta-if00`
+
+The USB audio card appears as ALSA `hw:1,0`.
+
+## Cable Routing
+
+Inside the payphone, cables route from the original hardware to the custom PCB:
+
+| Cable              | From                | To                     | Connector     |
+|--------------------|---------------------|------------------------|---------------|
+| Keypad ribbon      | Keypad matrix       | PCB J2 (2×10 header)   | 20-pin IDC    |
+| Display ribbon     | VFD display         | PCB J3 (2×13 header)   | 26-pin IDC    |
+| Coin validator     | Coin mechanism      | PCB J1 (2×5 header)    | 10-pin IDC    |
+| Magstripe reader   | Card slot           | PCB J6 (2×7 header)    | 14-pin IDC    |
+| Handset            | Handset cord        | PCB J4 (RJ9 jack)      | 4P4C RJ9      |
+| Mic audio          | USB audio card out  | PCB J5 (3.5mm jack)    | 3.5mm stereo  |
+| Speaker audio      | USB audio card out  | PCB J7 (3.5mm jack)    | 3.5mm stereo  |
+| USB (display)      | PCB Arduino Beta    | Pi via USB hub          | Micro-USB     |
+| USB (audio)        | USB audio card      | Pi via USB hub          | USB-A         |
+| Power              | Phone line pair     | PCB XL6009 input        | Screw terminal |
+
+## Power
+
+Phone line voltage (typically 48V DC on-hook, varies) enters the XL6009
+boost converter module which outputs regulated 5V. The 5V rail powers
+everything: both Arduinos, the Raspberry Pi (via GPIO 5V pins), the VFD
+display logic, and the audio amplifier.
+
+Total estimated current draw:
+
+| Component              | Current (typical) |
+|------------------------|-------------------|
+| Raspberry Pi Zero W    | 150 mA            |
+| Arduino Micro × 2      | 50 mA each        |
+| VFD display            | 100 mA            |
+| USB audio card         | 50 mA             |
+| Coin validator         | 50 mA             |
+| Audio amplifier        | 50–200 mA (playing) |
+| USB hub                | 50 mA             |
+| **Total**              | **~550–700 mA**   |
+
+## Thermal
+
+The Pi Zero W runs at approximately 38°C inside the closed case with no
+active cooling. This is well within operating limits (throttling starts at
+80°C). The phone's metal enclosure acts as a passive heat sink.
+
+## Physical Mounting
+
+The custom PCB sits inside a 3D-printed PLA+ case (see `case/README.md`).
+The case mounts inside the payphone's internal cavity. The original
+Millennium control board is removed and replaced with this assembly.
+
+Original hardware (keypad, display, coin validator, magstripe reader, handset,
+ringer) remains in place and connects to the PCB via ribbon cables and the
+RJ9/3.5mm jacks.
+
+## Serial Numbers and Device IDs
+
+| Device           | USB VID:PID  | Serial Name          |
+|------------------|--------------|----------------------|
+| Keypad Arduino   | 2341:8045    | Millennium Alpha     |
+| Display Arduino  | 2341:8046    | Millennium Beta      |
+| USB Audio        | 0d8c:0014    | Audio Adapter        |
+
+The custom Arduino board definitions assign unique VID/PID pairs so the
+Arduinos can be identified by name in `/dev/serial/by-id/`.

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ This project reimagines the functionality of the Nortel Millennium telephone by 
 ## Directory Structure
 
 - **`Arduino/`**: Arduino sketches for the keypad and display microcontrollers, plus a Makefile for building and flashing.
-- **`case/`**: 3D model files (`.blend` and `.stl`) for a custom enclosure.
+- **`case/`**: 3D model files (`.blend` and `.stl`) for a custom enclosure. See [case/README.md](case/README.md) for dimensions and print settings.
 - **`pcb/`**: KiCad schematic, PCB layout, BOM, and Gerber files for the custom PCB (phonev4).
+- **`HARDWARE.md`**: Physical assembly reference — USB topology, cable routing, power budget, and component list.
 - **`host/`**: Raspberry Pi software:
   - `daemon.c` — Main daemon loop and event routing
   - `plugins/` — Plugin implementations (classic_phone, fortune_teller, jukebox)

--- a/case/README.md
+++ b/case/README.md
@@ -1,29 +1,115 @@
 # 3D-Printed Case
 
+An enclosure for the custom PCB, designed in Blender and printed in PLA+.
+
+## Dimensions
+
+| Measurement        | Value      |
+|--------------------|------------|
+| Outer size         | 109.5 × 134.0 × 38.0 mm |
+| Interior (approx)  | ~103 × 128 mm |
+| Wall thickness     | ~3 mm      |
+| Depth per half     | 19 mm      |
+| PCB size           | 88.9 × 124.5 mm |
+| PCB clearance (X)  | ~14.6 mm   |
+| PCB clearance (Y)  | ~3.5 mm    |
+| Triangle count     | 3,544      |
+
+## Design
+
+The case is a two-piece clamshell that splits horizontally at the midplane:
+
+- **Bottom half** — has rectangular cutouts on one edge for USB cables and
+  connectors (2 large + 1 small), allowing cables to pass through to the
+  Raspberry Pi and Arduinos while the case is closed.
+- **Top half** — plain walls, no cutouts. Acts as the lid.
+- **6 notch tabs** — 3 on each long side, designed for rubber bands to hold
+  the halves together.
+
+<img src="prusaslicer_screenshot.png" alt="PrusaSlicer view of both halves" style="height:400px;">
+
 ## Files
 
-The following files are included in this directory:
-- `case.blend`: Blender file for the 3D model, editable for customizations.
-- `case.stl`: Ready-to-print STL file for the case.
+- `case.blend` — Blender source file (editable)
+- `case.stl` — Ready-to-print STL mesh (both halves as a single object)
+- `prusaslicer_screenshot.png` — Preview of the sliced halves
 
-<img src="prusaslicer_screenshot.png" alt="prusaslicer screenshot" style="height:400px;">
+## Printing
 
----
+### Preparation
 
-## Printing Instructions
+1. Load `case.stl` into your slicer (e.g., PrusaSlicer, Cura, OrcaSlicer).
+2. The STL contains the full case as one piece. Use the slicer's cut tool to
+   split it at Z = 0 mm (the midplane) into two separate halves.
+3. Orient each half with the open face up (flat bottom on the print bed).
 
-1. **Prepare the Model**:
-   - Load `case.stl` into your slicer (e.g., [PrusaSlicer](https://www.prusa3d.com/prusaslicer/) or Cura).
+### Recommended Settings
 
-2. **Slice the Model**:
-   - Horizontally slice the model into two halves at an appropriate plane.
-   - Ensure that both halves are correctly oriented and positioned for printing.
+| Setting           | Value                |
+|-------------------|----------------------|
+| Material          | PLA+ (or PETG for heat resistance) |
+| Layer height      | 0.2 mm               |
+| Infill            | 20–30%               |
+| Perimeters        | 3                    |
+| Supports          | Not needed (flat bottom, no overhangs) |
+| Bed adhesion      | Brim recommended for the larger half |
 
-3. **Print Settings**:
-   - The case was printed using **PLA+** with all slicer parameters set to their defaults.
+The original was printed with PLA+ at default slicer settings. No supports
+are required since both halves print with the open face up.
 
----
+### Print Time
 
-## Assembly Instructions
+Approximately 3–4 hours per half on a standard FDM printer at 0.2 mm layer
+height.
 
-I just used rubber bands to hold the halves together.  There are six notches that can be used for this purpose.
+## Assembly
+
+1. Place the PCB into the bottom half. The PCB sits on the flat interior
+   floor — there are no standoffs or mounting posts.
+2. Route cables through the rectangular cutouts: USB cables for the Pi and
+   Arduinos, audio cables, and the handset/keypad ribbon cables.
+3. Place the top half over the bottom and align the notch tabs.
+4. Loop rubber bands around the 3 pairs of opposing notch tabs to clamp the
+   halves together.
+
+## Known Limitations
+
+1. **No PCB standoffs**: The PCB rests directly on the case floor. This risks
+   shorting traces on the bottom copper layer against any printing artifacts.
+   Adding 4 standoff posts (matching the PCB corner positions) would lift the
+   board and provide proper mechanical mounting.
+
+2. **No screw bosses**: The halves are held together only by rubber bands.
+   Adding M3 screw bosses at the corners would provide a more secure and
+   permanent closure.
+
+3. **No ventilation**: The case is fully enclosed with no airflow openings.
+   The Pi Zero W runs at ~38°C in this enclosure which is fine, but a few
+   small vent slots on the top half would improve airflow if the system is
+   under sustained load.
+
+4. **Tight Y clearance**: The PCB has only ~3.5 mm of clearance in the Y
+   direction. Components or solder joints that protrude from the board edge
+   may interfere with the case walls.
+
+5. **No cable strain relief**: The cutouts are simple rectangular openings
+   with no strain relief features. Cables can be pulled out accidentally.
+
+6. **No labeling**: The case has no external markings for connector
+   identification or orientation.
+
+## Modification Tips
+
+The Blender source file (`case.blend`) can be edited to address the
+limitations above. Common modifications:
+
+- **Add standoffs**: Extrude 4 cylindrical posts (2.5 mm diameter, 3 mm
+  tall) from the interior floor at the PCB mounting hole positions.
+- **Add screw bosses**: Replace the notch tabs with cylindrical bosses and
+  matching holes for M3 × 16 mm screws.
+- **Add vents**: Boolean-subtract a row of 2 mm slots from the top half.
+- **Add cable guides**: Extrude small channels or clips near the cutouts to
+  route and retain cables.
+
+Export the modified model as STL from Blender (File → Export → STL) with
+"Selection Only" if you've kept the case as a single object.


### PR DESCRIPTION
## Summary
- Adds `HARDWARE.md` — complete physical assembly reference documenting all components, USB topology (Pi Zero W → hub chain → 3 devices), cable routing between original phone hardware and the PCB, power budget (~550-700mA), thermal measurements (38°C), and USB VID/PID table for device identification.
- Rewrites `case/README.md` with STL-measured dimensions (109.5 × 134.0 × 38.0 mm), PCB fitment analysis showing ~3.5mm Y clearance, recommended print settings (PLA+, 0.2mm layers, 20-30% infill), step-by-step assembly instructions, 6 documented limitations, and Blender modification tips for adding standoffs, screw bosses, and ventilation.

Addresses #48

## Test plan
- [x] STL dimensions verified by parsing binary STL data
- [x] PCB dimensions cross-referenced with KiCad Edge.Cuts layer
- [x] Thermal and USB data gathered from live hardware


Made with [Cursor](https://cursor.com)