### PR TITLE
Add asoundrc.example to install, fix setup step order

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -131,6 +131,7 @@ install: daemon
 	sudo mkdir -p /etc/millennium
 	sudo mkdir -p /var/log/millennium
 	sudo cp daemon.conf.example /etc/millennium/daemon.conf
+	sudo cp asoundrc.example /etc/asound.conf
 	sudo cp daemon /usr/local/bin/millennium-daemon
 	sudo cp systemd/daemon.service /etc/systemd/system/
 	sudo systemctl daemon-reload

--- a/host/README.md
+++ b/host/README.md
@@ -37,7 +37,7 @@ The following must be installed on the Raspberry Pi Zero 2 W:
 
 Audio routing uses pure ALSA configuration (no PipeWire or WirePlumber needed). The USB audio device is a C-Media USB sound card with stereo output. The ALSA config splits this into mono channels so one channel drives the handset earpiece and the other drives the ringer/speaker.
 
-1. Copy the ALSA configuration:
+1. Copy the ALSA configuration (or run `sudo make install`, which includes this):
    ```bash
    sudo cp host/asoundrc.example /etc/asound.conf
    ```
@@ -60,7 +60,7 @@ The config provides several PCM devices:
 make daemon        # Build the full daemon (requires Baresip/libre)
 make test          # Build simulator + unit tests, run both
 make clean         # Remove all build artifacts
-sudo make install  # Install daemon binary and systemd service
+sudo make install  # Install daemon binary, ALSA config, and systemd service
 ```
 
 ## Systemd Setup

--- a/host/SETUP.md
+++ b/host/SETUP.md
@@ -118,13 +118,23 @@ Replace the phone number, provider hostname, and password with your actual SIP
 account details. The `transport=tls` and STUN server settings work well with
 Twilio but may differ for other providers.
 
-## 6. ALSA audio configuration
-
-The USB audio card needs a custom ALSA config to split stereo into independent
-mono channels for the handset earpiece and ringer speaker.
+## 6. Clone and build the daemon
 
 ```bash
-sudo cp ~/millennium/host/asoundrc.example /etc/asound.conf
+cd ~
+git clone https://github.com/kmatzen/millennium.git
+cd millennium/host
+make daemon
+```
+
+## 7. ALSA audio configuration
+
+The USB audio card needs a custom ALSA config to split stereo into independent
+mono channels for the handset earpiece and ringer speaker. From the `host/`
+directory (where you just ran `make daemon`):
+
+```bash
+sudo cp asoundrc.example /etc/asound.conf
 ```
 
 Verify the USB audio card is detected as card 1:
@@ -141,15 +151,6 @@ Test audio output:
 ```bash
 speaker-test -D out_left_solo -c1 -twav   # should play through ringer
 speaker-test -D out_right_solo -c1 -twav  # should play through handset
-```
-
-## 7. Clone and build the daemon
-
-```bash
-cd ~
-git clone https://github.com/kmatzen/millennium.git
-cd millennium/host
-make daemon
 ```
 
 ## 8. Configure the daemon


### PR DESCRIPTION
Closes #54

## Summary
- **Makefile**: `make install` now copies `asoundrc.example` to `/etc/asound.conf`
- **SETUP.md**: Reordered steps so clone (step 6) comes before ALSA config (step 7). The ALSA step previously referenced `~/millennium/host/asoundrc.example` before the repo was cloned. Now uses `sudo cp asoundrc.example /etc/asound.conf` when run from `host/`.
- **README.md**: Note that `make install` includes the ALSA config

## Test plan
- [x] `make install` runs without error (asoundrc.example exists in host/)
- [ ] Verify fresh setup flow: clone → build → ALSA copy works in order

Made with [Cursor](https://cursor.com)