### PR TITLE
Compile audio_tones.c with C99 for ALSA header compatibility

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -58,7 +58,7 @@ version.o: version.c version.h
 	gcc version.c -o version.o -c $(CFLAGS) $(VERSION_CFLAGS)
 
 audio_tones.o: audio_tones.c audio_tones.h logger.h
-	gcc audio_tones.c -o audio_tones.o -c $(CFLAGS) -lm
+	gcc audio_tones.c -o audio_tones.o -c $(C99_CFLAGS) -lm
 
 updater.o: updater.c updater.h version.h logger.h
 	gcc updater.c -o updater.o -c $(CFLAGS)


### PR DESCRIPTION
## Summary

On Raspbian, the ALSA `pcm.h` header uses the C99 `inline` keyword. Compiling `audio_tones.c` with `-std=c89` causes parse errors:

```
/usr/include/alsa/pcm.h:1030:14: error: expected ';' before 'void'
 static inline void snd_pcm_pack_audio_tstamp_config(unsigned int *data,
```

Use `C99_CFLAGS` for `audio_tones.o` so the ALSA headers parse correctly.

## Test plan
- [ ] `make daemon` on Raspberry Pi with Raspbian

Made with [Cursor](https://cursor.com)