### PR TITLE
Set status_code 200 on logs API response

### DIFF
--- a/host/web_server.c
+++ b/host/web_server.c
@@ -1083,6 +1083,7 @@ struct http_response web_server_handle_api_control(const struct http_request* re
 struct http_response web_server_handle_api_logs(const struct http_request* request) {
     struct http_response response;
     memset(&response, 0, sizeof(response));
+    response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
     
     /* Get log level parameter */


### PR DESCRIPTION
The `web_server_handle_api_logs` handler returned `status_code = 0` (from memset), producing `HTTP/1.1 0 Unknown`, which can cause the browser's fetch to fail or treat the response as invalid.

Explicitly set `response.status_code = 200` so the logs API returns a valid HTTP response.

## Test plan
- [ ] Load web dashboard and verify "System Logs" panel loads without "Failed to load logs"

Made with [Cursor](https://cursor.com)