### PR TITLE
fix: stop coin validator motor running every 30s when phone idle

### DIFF
--- a/host/millennium_sdk.c
+++ b/host/millennium_sdk.c
@@ -774,6 +774,8 @@ void millennium_client_set_ua(struct millennium_client *client, void *ua) {
 void millennium_client_write_command(struct millennium_client *client, uint8_t command, const uint8_t *data, size_t data_size) {
     logger_debugf_with_category("SDK", "Writing command to display: %d", command);
 
+    if (!client) return;
+
     /* Step 1: Write the command */
     while (1) {
         ssize_t bytes_written = write(client->display_fd, &command, 1);
@@ -822,4 +824,7 @@ void millennium_client_write_command(struct millennium_client *client, uint8_t c
 
         logger_debugf_with_category("SDK", "Successfully wrote %lu bytes of data to display.", (unsigned long)total_bytes_written);
     }
+
+    /* Any successful write counts as serial activity for the watchdog */
+    millennium_client_serial_activity(client);
 }

--- a/host/millennium_sdk.h
+++ b/host/millennium_sdk.h
@@ -103,7 +103,7 @@ void list_audio_devices(void);
 /* Constants */
 #define BAUD_RATE B9600
 #define ASYNC_WORKERS 4
-#define SERIAL_WATCHDOG_SECONDS 30
+#define SERIAL_WATCHDOG_SECONDS 300
 #define SERIAL_MAX_BACKOFF_SECONDS 60
 
 #endif /* MILLENNIUM_SDK_H */


### PR DESCRIPTION
The serial watchdog only counted reads as activity. When idle, the Arduino sends nothing, so after 30 seconds the watchdog falsely marked the link dead and triggered reconnect. Reconnect sends 'f' to re-init the coin validator, which spins the motor.

**Changes:**
- Treat writes (display + coin validator) as serial activity
- Increase SERIAL_WATCHDOG_SECONDS from 30 to 300 (5 min) to avoid false positives during normal idle periods

Made with [Cursor](https://cursor.com)