### PR TITLE
fix: daemon service config/epoll/state, disable serial watchdog

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -130,18 +130,20 @@ clean:
 install: daemon
 	sudo mkdir -p /etc/millennium
 	sudo mkdir -p /var/log/millennium
+	sudo mkdir -p /var/lib/millennium
+	@if command -v logname >/dev/null 2>&1; then sudo chown $$(logname):$$(logname) /var/lib/millennium 2>/dev/null || true; fi
 	sudo cp daemon.conf.example /etc/millennium/daemon.conf
 	sudo cp asoundrc.example /etc/asound.conf
 	sudo cp daemon /usr/local/bin/millennium-daemon
 	sudo cp systemd/daemon.service /etc/systemd/system/
 	sudo systemctl daemon-reload
-	sudo systemctl enable millennium-daemon.service
+	sudo systemctl enable daemon.service
 
 uninstall:
-	sudo systemctl stop millennium-daemon.service
-	sudo systemctl disable millennium-daemon.service
+	sudo systemctl stop daemon.service
+	sudo systemctl disable daemon.service
 	sudo rm -f /usr/local/bin/millennium-daemon
-	sudo rm -f /etc/systemd/system/millennium-daemon.service
+	sudo rm -f /etc/systemd/system/daemon.service
 	sudo systemctl daemon-reload
 
 .PHONY: all clean install uninstall test unit_tests

--- a/host/config.c
+++ b/host/config.c
@@ -103,6 +103,14 @@ int config_load_from_environment(config_data_t* config) {
         config_set_value(config, "logging.file", log_file);
     }
     
+    /* State persistence (used when config file fails to load) */
+    {
+        const char *state_file = getenv("MILLENNIUM_STATE_FILE");
+        if (state_file != NULL) {
+            config_set_value(config, "persistence.state_file", state_file);
+        }
+    }
+    
     return 1;
 }
 

--- a/host/millennium_sdk.c
+++ b/host/millennium_sdk.c
@@ -477,11 +477,12 @@ int millennium_client_serial_is_healthy(struct millennium_client *client) {
 }
 
 void millennium_client_check_serial(struct millennium_client *client) {
+    if (!client || client->display_fd == -1) return;
+
+#if SERIAL_WATCHDOG_ENABLED
     struct timespec now;
     long elapsed;
     int backoff;
-
-    if (!client || client->display_fd == -1) return;
 
     clock_gettime(CLOCK_MONOTONIC, &now);
     elapsed = now.tv_sec - client->last_serial_activity.tv_sec;
@@ -522,6 +523,7 @@ void millennium_client_check_serial(struct millennium_client *client) {
                 "Serial reconnect failed, next attempt in %d seconds", backoff);
         }
     }
+#endif /* SERIAL_WATCHDOG_ENABLED - disabled until keepalive (issue #59) */
 }
 
 void millennium_client_update(struct millennium_client *client) {

--- a/host/millennium_sdk.h
+++ b/host/millennium_sdk.h
@@ -105,5 +105,7 @@ void list_audio_devices(void);
 #define ASYNC_WORKERS 4
 #define SERIAL_WATCHDOG_SECONDS 300
 #define SERIAL_MAX_BACKOFF_SECONDS 60
+/* Disabled until keepalive is implemented (issue #59) */
+#define SERIAL_WATCHDOG_ENABLED 0
 
 #endif /* MILLENNIUM_SDK_H */

--- a/host/systemd/daemon.service
+++ b/host/systemd/daemon.service
@@ -5,13 +5,18 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-# Run the binary directly (no shell needed)
-ExecStart=/home/matzen/millennium/host/daemon --config /home/matzen/millennium/host/daemon.conf
-# Optional: wait for network before starting (use absolute path + correct bash)
-ExecStartPre=/bin/bash -c 'until /bin/ping -c1 -W1 8.8.8.8 >/dev/null; do sleep 1; done'
+# Use /etc/millennium/daemon.conf (run: sudo cp daemon.conf.example /etc/millennium/daemon.conf)
+# For development: use full path to binary, e.g. /home/USER/millennium/host/daemon
+ExecStart=/usr/local/bin/millennium-daemon --config /etc/millennium/daemon.conf
+# Optional: wait for network before starting
+ExecStartPre=/bin/bash -c 'until /bin/ping -c1 -W1 8.8.8.8 >/dev/null 2>/dev/null; do sleep 1; done'
 Restart=on-failure
 RestartSec=2
-WorkingDirectory=/home/matzen/millennium/host
+WorkingDirectory=/tmp
+# Baresip/libre tries to use stdin for UI; systemd gives none. Redirect to avoid epoll errors.
+StandardInput=null
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=default.target

--- a/host/updater.c
+++ b/host/updater.c
@@ -147,7 +147,7 @@ int updater_apply(const char *source_dir) {
 
     snprintf(apply_status, sizeof(apply_status), "Restarting daemon...");
     logger_info_with_category("Updater", "Restarting daemon via systemd");
-    run_command("sudo systemctl restart millennium-daemon.service");
+    run_command("sudo systemctl restart daemon.service");
 
     snprintf(apply_status, sizeof(apply_status), "Update applied successfully");
     return 0;


### PR DESCRIPTION
## Daemon service fixes

- Use `/etc/millennium/daemon.conf` in systemd unit, add `StandardInput=null` to avoid baresip epoll errors
- Create `/var/lib/millennium` on install, chown for user services
- Add `MILLENNIUM_STATE_FILE` env var when config file fails to load
- Fix service name (daemon.service) in Makefile and updater
- Add SETUP troubleshooting for config, epoll, and state file errors

## Serial watchdog

- Disable until keepalive implemented (issue #59)
- Nothing writes to serial when idle, so watchdog still false-positives after 5 min

Made with [Cursor](https://cursor.com)