### PR TITLE
Add daemon-dev.service for development (no make install)

### DIFF
--- a/host/systemd/daemon-dev.service
+++ b/host/systemd/daemon-dev.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Millennium Tools Daemon (development)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Development: run from repo build (no make install). %h = your home directory
+ExecStart=%h/millennium/host/daemon --config /etc/millennium/daemon.conf
+ExecStartPre=/bin/bash -c 'until /bin/ping -c1 -W1 8.8.8.8 >/dev/null 2>/dev/null; do sleep 1; done'
+Restart=on-failure
+RestartSec=2
+WorkingDirectory=%h/millennium/host
+StandardInput=null
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
- `daemon-dev.service` uses `%h/millennium/host/daemon` for repo builds
- Update SETUP to recommend daemon-dev.service for development
- Add troubleshooting for 'No such file or directory' (millennium-daemon)

Made with [Cursor](https://cursor.com)