### PR TITLE
fix: make install when daemon masked or running

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -128,6 +128,7 @@ clean:
 	rm -rf *.o daemon simulator unit_tests plugins/*.o tests/*.o
 
 install: daemon
+	sudo systemctl stop daemon.service 2>/dev/null || true
 	sudo mkdir -p /etc/millennium
 	sudo mkdir -p /var/log/millennium
 	sudo mkdir -p /var/lib/millennium
@@ -137,7 +138,9 @@ install: daemon
 	sudo cp daemon /usr/local/bin/millennium-daemon
 	sudo cp systemd/daemon.service /etc/systemd/system/
 	sudo systemctl daemon-reload
+	sudo systemctl unmask daemon.service 2>/dev/null || true
 	sudo systemctl enable daemon.service
+	sudo systemctl start daemon.service
 
 uninstall:
 	sudo systemctl stop daemon.service

--- a/host/SETUP.md
+++ b/host/SETUP.md
@@ -283,6 +283,15 @@ If you see:
   StandardInput=null
   ```
 
+- **Unit file daemon.service is masked** — Unmask before enabling: `sudo systemctl unmask daemon.service`, then run `make install` again.
+
+- **No such file or directory** (for millennium-daemon) — You're running from the repo without `make install`. Use the dev service:
+  ```bash
+  cp systemd/daemon-dev.service ~/.config/systemd/user/daemon.service
+  systemctl --user daemon-reload
+  systemctl --user restart daemon.service
+  ```
+
 - **Failed to open state file for writing** — Create the state directory and make it writable:
   ```bash
   sudo mkdir -p /var/lib/millennium


### PR DESCRIPTION
- Stop daemon before overwriting binary (fixes 'Text file busy')
- Unmask daemon.service before enable (fixes masked unit)
- Start daemon after install
- Add SETUP troubleshooting for masked and no-such-file errors

Made with [Cursor](https://cursor.com)