### PR TITLE
fix: run daemon as user for baresip config (fixes conf_configure/SEGV)

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -128,6 +128,10 @@ clean:
 	rm -rf *.o daemon simulator unit_tests plugins/*.o tests/*.o
 
 install: daemon
+	@systemctl --user stop daemon.service 2>/dev/null || true
+	@systemctl --user disable daemon.service 2>/dev/null || true
+	@rm -f $$HOME/.config/systemd/user/daemon.service 2>/dev/null || true
+	@systemctl --user daemon-reload 2>/dev/null || true
 	sudo systemctl stop daemon.service 2>/dev/null || true
 	sudo mkdir -p /etc/millennium
 	sudo mkdir -p /var/log/millennium
@@ -137,6 +141,8 @@ install: daemon
 	sudo cp asoundrc.example /etc/asound.conf
 	sudo cp daemon /usr/local/bin/millennium-daemon
 	sudo cp systemd/daemon.service /etc/systemd/system/
+	sudo mkdir -p /etc/systemd/system/daemon.service.d
+	@echo '[Service]' > /tmp/daemon-override.conf; echo 'User='$$(logname) >> /tmp/daemon-override.conf; sudo cp /tmp/daemon-override.conf /etc/systemd/system/daemon.service.d/override.conf
 	sudo systemctl daemon-reload
 	sudo systemctl unmask daemon.service 2>/dev/null || true
 	sudo systemctl enable daemon.service
@@ -146,6 +152,7 @@ uninstall:
 	sudo systemctl stop daemon.service
 	sudo systemctl disable daemon.service
 	sudo rm -f /usr/local/bin/millennium-daemon
+	sudo rm -rf /etc/systemd/system/daemon.service.d
 	sudo rm -f /etc/systemd/system/daemon.service
 	sudo systemctl daemon-reload
 

--- a/host/SETUP.md
+++ b/host/SETUP.md
@@ -283,6 +283,13 @@ If you see:
   StandardInput=null
   ```
 
+- **conf_configure failed / SEGV** — Daemon needs to run as the user who has `~/.baresip/` (accounts, config). `make install` creates an override with your user. If you installed without make, create `/etc/systemd/system/daemon.service.d/override.conf`:
+  ```ini
+  [Service]
+  User=YOUR_USERNAME
+  ```
+  Then `sudo systemctl daemon-reload` and `sudo systemctl restart daemon.service`.
+
 - **Unit file daemon.service is masked** — Unmask before enabling: `sudo systemctl unmask daemon.service`, then run `make install` again.
 
 - **No such file or directory** (for millennium-daemon) — You're running from the repo without `make install`. Use the dev service:

--- a/host/systemd/daemon.service
+++ b/host/systemd/daemon.service
@@ -5,7 +5,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-# Use /etc/millennium/daemon.conf (run: sudo cp daemon.conf.example /etc/millennium/daemon.conf)
+# Run as user who has ~/.baresip/ (accounts, config). make install creates daemon.service.d/override.conf with User=<you>
 # For development: use full path to binary, e.g. /home/USER/millennium/host/daemon
 ExecStart=/usr/local/bin/millennium-daemon --config /etc/millennium/daemon.conf
 # Optional: wait for network before starting


### PR DESCRIPTION
- make install creates daemon.service.d/override.conf with User=`logname`
- Baresip needs `~/.baresip/` (accounts, config) from the real user
- Disable user service (systemctl --user) before enabling system service  
- Add conf_configure failed / SEGV troubleshooting to SETUP

Made with [Cursor](https://cursor.com)