### PR TITLE
Add API integration test for live daemon

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -160,4 +160,11 @@ uninstall:
 	sudo rm -f /etc/systemd/system/daemon.service
 	sudo systemctl daemon-reload
 
-.PHONY: all clean install uninstall test unit_tests
+# API integration test (requires live daemon)
+# Usage: make api-test [HOST=localhost]  e.g. make api-test HOST=192.168.86.145
+HOST ?= localhost
+api-test:
+	@chmod +x tests/api_test.sh
+	@HOST=$(HOST) ./tests/api_test.sh $(HOST)
+
+.PHONY: all clean install uninstall test unit_tests api-test

--- a/host/SETUP.md
+++ b/host/SETUP.md
@@ -244,6 +244,12 @@ systemctl --user disable audio-mux.service
 4. **Web dashboard**: Open `http://<pi-ip>:8081` in a browser. You should see
    the phone state, active plugin, and health status.
 
+5. **API integration test**: From the Pi (or any machine that can reach it):
+   ```bash
+   cd ~/millennium/host && make api-test
+   # Or: HOST=192.168.86.145 ./tests/api_test.sh
+   ```
+
 ## Updating
 
 To update the daemon after pulling new code:

--- a/host/tests/api_test.sh
+++ b/host/tests/api_test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# API integration test — run against a live daemon
+# Usage: ./api_test.sh [HOST]
+#   HOST=localhost ./api_test.sh          # run on same machine as daemon
+#   ssh pi 'cd ~/millennium/host && make api-test'   # run on Pi
+#   HOST=192.168.86.145 ./api_test.sh     # run from another machine (if reachable)
+# Requires: curl
+
+set -e
+HOST="${HOST:-${1:-localhost}}"
+BASE="http://${HOST}:8081"
+FAILED=0
+
+run() {
+    local name="$1"
+    local cmd="$2"
+    local want="$3"
+    local got
+    got=$(eval "$cmd" 2>/dev/null || true)
+    if echo "$got" | grep -q "$want"; then
+        echo "  PASS: $name"
+    else
+        echo "  FAIL: $name (expected '$want' in response)"
+        printf "    got: %.150s\n" "${got:-<empty or connection failed>}"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+# Quick connectivity check
+if ! curl -s -m 3 "$BASE/api/state" >/dev/null 2>&1; then
+    echo "Cannot reach $BASE — is the daemon running? (Try: ssh pi 'cd ~/millennium/host && make api-test')"
+    exit 1
+fi
+
+echo "=== API test against $BASE ==="
+echo ""
+
+# State and health
+run "GET /api/state returns JSON" "curl -s $BASE/api/state" "current_state"
+run "GET /api/state has sip_registered" "curl -s $BASE/api/state" "sip_registered"
+run "GET /api/health returns JSON" "curl -s $BASE/api/health" "overall_status"
+
+# Control: handset_up
+run "POST handset_up" \
+    "curl -s -X POST $BASE/api/control -H 'Content-Type: application/json' -d '{\"action\":\"handset_up\"}'" \
+    '"success":true'
+run "State reflects IDLE_UP after handset_up" "curl -s $BASE/api/state" '"current_state":2'
+
+# Control: coin_insert with cents
+run "POST coin_insert (cents)" \
+    "curl -s -X POST $BASE/api/control -H 'Content-Type: application/json' -d '{\"action\":\"coin_insert\",\"cents\":25}'" \
+    '"success":true'
+run "POST coin_insert (arg fallback)" \
+    "curl -s -X POST $BASE/api/control -H 'Content-Type: application/json' -d '{\"action\":\"coin_insert\",\"arg\":\"25\"}'" \
+    '"success":true'
+
+# Control: keypad_press with key
+run "POST keypad_press (key)" \
+    "curl -s -X POST $BASE/api/control -H 'Content-Type: application/json' -d '{\"action\":\"keypad_press\",\"key\":\"5\"}'" \
+    '"success":true'
+run "POST keypad_press (arg fallback)" \
+    "curl -s -X POST $BASE/api/control -H 'Content-Type: application/json' -d '{\"action\":\"keypad_press\",\"arg\":\"1\"}'" \
+    '"success":true'
+
+# Reset and handset_down
+run "POST reset_system" \
+    "curl -s -X POST $BASE/api/control -H 'Content-Type: application/json' -d '{\"action\":\"reset_system\"}'" \
+    '"success":true'
+run "POST handset_down" \
+    "curl -s -X POST $BASE/api/control -H 'Content-Type: application/json' -d '{\"action\":\"handset_down\"}'" \
+    '"success":true'
+
+# Plugin switch
+run "POST activate_plugin" \
+    "curl -s -X POST $BASE/api/control -H 'Content-Type: application/json' -d '{\"action\":\"activate_plugin\",\"plugin\":\"Classic Phone\"}'" \
+    '"success":true'
+
+echo ""
+if [ $FAILED -eq 0 ]; then
+    echo "All API tests passed."
+    exit 0
+else
+    echo "$FAILED test(s) failed."
+    exit 1
+fi


### PR DESCRIPTION
## Summary
Adds an API integration test script for testing the daemon's HTTP API against a live running instance.

## Changes
- **host/tests/api_test.sh**: Curl-based script that exercises:
  - GET /api/state (JSON, sip_registered)
  - GET /api/health
  - POST /api/control: handset_up, handset_down, coin_insert (cents + arg), keypad_press (key + arg), reset_system, activate_plugin
- **make api-test**: New Makefile target (HOST defaults to localhost)
- **SETUP.md**: Document in verification section

## Usage
```bash
cd ~/millennium/host && make api-test
# Or against remote: make api-test HOST=192.168.86.145
```

Made with [Cursor](https://cursor.com)