### PR TITLE
Harden Arduino firmware and add serial keepalive

### DIFF
--- a/host/README.md
+++ b/host/README.md
@@ -67,6 +67,11 @@ sudo make install  # Install daemon binary, ALSA config, and systemd service
 
 ```bash
 sudo make install
-sudo systemctl enable millennium-daemon
-sudo systemctl start millennium-daemon
+```
+
+This installs the daemon and enables the `daemon.service` unit. The service
+runs system-wide but as your user (for `~/.baresip/`). Check status:
+
+```bash
+sudo systemctl status daemon.service
 ```

--- a/host/events.h
+++ b/host/events.h
@@ -17,6 +17,7 @@ struct call;
 #define EVENT_TYPE_COIN_VALIDATION_END 'F'
 #define EVENT_TYPE_EEPROM_ERROR 'E'
 #define EVENT_TYPE_HOOK 'H'
+#define EVENT_TYPE_HEARTBEAT 'P'
 #define EVENT_TYPE_CALL_STATE '1'
 
 /* Event type enumeration */

--- a/host/millennium_sdk.h
+++ b/host/millennium_sdk.h
@@ -106,9 +106,8 @@ void millennium_sdk_get_sip_status(int *registered, char *last_error, size_t las
 /* Constants */
 #define BAUD_RATE B9600
 #define ASYNC_WORKERS 4
-#define SERIAL_WATCHDOG_SECONDS 300
+#define SERIAL_WATCHDOG_SECONDS 60
 #define SERIAL_MAX_BACKOFF_SECONDS 60
-/* Disabled until keepalive is implemented (issue #59) */
-#define SERIAL_WATCHDOG_ENABLED 0
+#define SERIAL_WATCHDOG_ENABLED 1
 
 #endif /* MILLENNIUM_SDK_H */


### PR DESCRIPTION
## Summary

- **Watchdog timers**: Both Arduino sketches now enable a 4-second watchdog (`WDTO_4S`) in `setup()`, pet it every `loop()` iteration, and inside the long EEPROM program/verify loops
- **ISR ring buffer**: `receiveEvent()` in display.ino no longer writes directly to SerialUSB from the I2C ISR — data is buffered in a 64-byte ring buffer and drained in `loop()`
- **Buffer overflow protection**: Display text command rejects `num_bytes > sizeof(buf)` to prevent stack corruption
- **Protocol constants**: All magic numbers replaced with named `CMD_*` and `EVT_*` defines in both sketches
- **Coin EEPROM documentation**: Block comment above `coinEeprom[]` explaining the TRC-6500 validator structure
- **Hook scan optimization**: Removed unnecessary `pinMode` toggling every loop — pin stays OUTPUT, only digital value toggles
- **Serial keepalive (issue #59)**: Display Arduino sends `'P'` heartbeat every 10 seconds; daemon parses and silently consumes it; serial watchdog re-enabled at 60-second timeout
- **PINOUT.md**: All 8 known issues marked as resolved
- **README.md**: Updated systemctl commands to match system-wide service

Addresses PINOUT.md known issues #4, #6, #8 and issue #59.

## Test plan

- [ ] Build simulator: `make simulator` — verify no compile errors from events.h/millennium_sdk changes
- [ ] Run unit tests: `make test` — all pass
- [ ] Flash display.ino to Millennium Beta and verify heartbeat appears in daemon logs
- [ ] Flash keypad.ino to Millennium Alpha and verify keypad/hook still work
- [ ] Verify serial watchdog no longer falsely marks link dead during idle
- [ ] Confirm watchdog resets Arduino on firmware hang (can test by adding infinite loop)


Made with [Cursor](https://cursor.com)