### PR TITLE
pcb: Correct D1/D2 package to SOT-143 (fixes #73)

### DIFF
--- a/pcb/AUDIT.md
+++ b/pcb/AUDIT.md
@@ -27,7 +27,7 @@ This document captures audit findings for the phonev4 schematic and PCB design, 
 | BOM vs schematic refs | ✓ Fixed | D3, TP1-TP5, U1; see phonev4.csv |
 | Q1 part number | Open | Si2319 vs Si2301; verify pin compatibility |
 | Missing footprints | ✓ Fixed | THT assigned for D3, F1, TP1–TP5 |
-| PRTR package | Open | SOT-143 in schem, BOM SOT-23; verify which used |
+| PRTR package | ✓ Fixed | PRTR5V0U2X is SOT-143 only; BOM/README updated |
 | Test points | ✓ Fixed | TP1-TP5 only; no TX/RX on PCB |
 
 ---
@@ -45,7 +45,7 @@ This document captures audit findings for the phonev4 schematic and PCB design, 
 ### 3. Part Discrepancies
 
 - **Q1**: Schematic shows Si2319CDS, README/BOM specify Si2301. Both are P-ch MOSFETs. Check datasheets for pinout; update schematic symbol or BOM to match the actual part.
-- **D1, D2 (PRTR5V0U2X)**: Schematic footprint SOT-143; BOM says SOT-23. PRTR5V0U2X is available in SOT-143 (4-pin) and possibly SOT-23 variants. Confirm which package is used and align.
+- **D1, D2 (PRTR5V0U2X)**: ✓ Fixed. PRTR5V0U2X is SOT-143 only (Nexperia datasheet). BOM and README updated from SOT-23 to SOT-143.
 
 ### 4. Missing Footprints
 

--- a/pcb/README.md
+++ b/pcb/README.md
@@ -78,8 +78,8 @@ eliminating the crosstalk present in the v4 LM386 design.
 | C_ripple | 4.7µF electrolytic         | 1   | Radial D5mm                      | TDA2822 ripple rejection         |
 | C_dec | 100nF ceramic                 | 1   | 0603 SMD                         | TDA2822 Vcc decoupling           |
 | C-*   | 100nF ceramic                 | 5   | SMD / small axial                | Decoupling (see below)           |
-| D1    | PRTR5V0U2X                    | 1   | SOT-23                           | ESD clamp on J4 signal pins (handset) |
-| D2    | PRTR5V0U2X                    | 1   | SOT-23                           | ESD clamp on J1 signal pins (coin TX/RX) |
+| D1    | PRTR5V0U2X                    | 1   | SOT-143 (4-pin)                  | ESD clamp on J4 signal pins (handset) |
+| D2    | PRTR5V0U2X                    | 1   | SOT-143 (4-pin)                  | ESD clamp on J1 signal pins (coin TX/RX) |
 | Q1    | Si2301 P-ch MOSFET            | 1   | SOT-23                           | Reverse polarity protection      |
 | F1    | 1A PTC fuse                   | 1   | Radial D10mm THT                 | Resettable overcurrent fuse      |
 | D3    | Green LED                     | 1   | 5mm THT                          | Power indicator                  |

--- a/pcb/phonev4.csv
+++ b/pcb/phonev4.csv
@@ -13,8 +13,8 @@
 12;"C_ripple";"CP_Radial_D5.0mm_P2.00mm";1;"4.7uF (TDA2822 ripple rejection)";;;
 13;"C_dec";"0603";1;"100nF (TDA2822 Vcc decoupling)";;;
 14;"C-arduino1,C-arduino-display1,C-card1,C-coin1,C-raspi1";"C_Small";5;"100nF";;;
-15;"D1";"SOT-23";1;"PRTR5V0U2X (ESD protection, J4 RJ9)";;;
-16;"D2";"SOT-23";1;"PRTR5V0U2X (ESD protection, J1 coin)";;;
+15;"D1";"SOT-143";1;"PRTR5V0U2X (ESD protection, J4 RJ9, 4-pin only)";;;
+16;"D2";"SOT-143";1;"PRTR5V0U2X (ESD protection, J1 coin, 4-pin only)";;;
 17;"Q1";"SOT-23";1;"Si2301 P-ch MOSFET (reverse polarity protection)";;;
 18;"F1";"Fuse_Radial_D10.0mm_P5.00mm";1;"1A PTC resettable fuse (radial THT)";;;
 19;"D3";"LED_D5.0mm";1;"Green power indicator LED (5mm THT)";;;


### PR DESCRIPTION
Fixes #73

PRTR5V0U2X (Nexperia) is only available in SOT-143 (4-pin), not SOT-23.

- BOM: D1, D2 footprint SOT-23 → SOT-143
- README: BOM table updated
- AUDIT.md: Mark PRTR package item as fixed

Made with [Cursor](https://cursor.com)