### PR TITLE
pcb: Document Q1 Si2319/Si2301 pin compatibility (fixes #71)

### DIFF
--- a/pcb/AUDIT.md
+++ b/pcb/AUDIT.md
@@ -25,7 +25,7 @@ This document captures audit findings for the phonev4 schematic and PCB design, 
 |----------|--------|--------|
 | Power labels (5v, 12v) | ✓ Fixed | Renamed to 5V_MAIN, 12V_COIN |
 | BOM vs schematic refs | ✓ Fixed | D3, TP1-TP5, U1; see phonev4.csv |
-| Q1 part number | Open | Si2319 vs Si2301; verify pin compatibility |
+| Q1 part number | ✓ Doc | Si2319/Si2301 pin-compatible (G-S-D); either acceptable |
 | Missing footprints | ✓ Fixed | THT assigned for D3, F1, TP1–TP5 |
 | PRTR package | ✓ Fixed | PRTR5V0U2X is SOT-143 only; BOM/README updated |
 | Test points | ✓ Fixed | TP1-TP5 only; no TX/RX on PCB |
@@ -44,7 +44,7 @@ This document captures audit findings for the phonev4 schematic and PCB design, 
 
 ### 3. Part Discrepancies
 
-- **Q1**: Schematic shows Si2319CDS, README/BOM specify Si2301. Both are P-ch MOSFETs. Check datasheets for pinout; update schematic symbol or BOM to match the actual part.
+- **Q1**: Schematic Si2319CDS, BOM Si2301. Both P-ch, SOT-23, identical pinout (Gate-Source-Drain). Pin-compatible; use whichever is available.
 - **D1, D2 (PRTR5V0U2X)**: ✓ Fixed. PRTR5V0U2X is SOT-143 only (Nexperia datasheet). BOM and README updated from SOT-23 to SOT-143.
 
 ### 4. Missing Footprints

--- a/pcb/README.md
+++ b/pcb/README.md
@@ -106,7 +106,7 @@ eliminating the crosstalk present in the v4 LM386 design.
 
 ### Reverse Polarity Protection (Q1)
 
-A P-channel MOSFET (Si2301 or equivalent) on the incoming 5V rail protects
+A P-channel MOSFET (Si2301 or Si2319; same SOT-23 pinout) on the incoming 5V rail protects
 against accidental reverse-polarity connections. Q1 is placed on the power
 input *before* distribution and *before* feeding U1 IN+. The MOSFET's body
 diode conducts during normal operation with near-zero voltage drop, and blocks

--- a/pcb/phonev4.csv
+++ b/pcb/phonev4.csv
@@ -15,7 +15,7 @@
 14;"C-arduino1,C-arduino-display1,C-card1,C-coin1,C-raspi1";"C_Small";5;"100nF";;;
 15;"D1";"SOT-143";1;"PRTR5V0U2X (ESD protection, J4 RJ9, 4-pin only)";;;
 16;"D2";"SOT-143";1;"PRTR5V0U2X (ESD protection, J1 coin, 4-pin only)";;;
-17;"Q1";"SOT-23";1;"Si2301 P-ch MOSFET (reverse polarity protection)";;;
+17;"Q1";"SOT-23";1;"Si2301/Si2319 P-ch MOSFET (reverse polarity; pin-compatible)";;;
 18;"F1";"Fuse_Radial_D10.0mm_P5.00mm";1;"1A PTC resettable fuse (radial THT)";;;
 19;"D3";"LED_D5.0mm";1;"Green power indicator LED (5mm THT)";;;
 20;"R3";"R_Axial_DIN0204";1;"1k (LED current limit)";;;


### PR DESCRIPTION
Fixes #71

Si2319CDS (schematic) and Si2301 (BOM) are pin-compatible: both P-ch, SOT-23, Gate-Source-Drain.

- README: note Si2319 as equivalent
- BOM: Si2301/Si2319 in designation
- AUDIT: mark as documented

Made with [Cursor](https://cursor.com)