### PR TITLE
pcb: Fix 100µF radial pitch to P3.80mm per Digi-Key availability

### DIFF
--- a/pcb/AUDIT.md
+++ b/pcb/AUDIT.md
@@ -96,13 +96,15 @@ Output includes: component table, net labels, BOM vs schematic comparison, docum
 
 ## Capacitor Package Audit (see #83)
 
-Aligned BOM and README with schematic footprints (THT priority):
+Aligned BOM, README, schematic with Digi-Key availability research:
 
 | Ref | Value | Footprint | Notes |
 |-----|-------|-----------|-------|
-| C_outA, C_outB, C_vcc | 100µF 16V | CP_Radial_D8.0mm_P2.00mm | Was P3.80mm in BOM |
-| C_ripple | 4.7µF | CP_Radial_D5.0mm_P2.00mm | Consistent |
-| C_inA, C_inB, C_dec, C-* | 100nF | C_Axial_L3.8mm_D2.6mm_P7.50mm | Was C_Small/0603; THT |
+| C_outA, C_outB, C_vcc | 100µF 16V | CP_Radial_D8.0mm_P3.80mm | P2mm uncommon for 8mm; P3.8mm matches PCB, Digi-Key stock |
+| C_ripple | 4.7µF | CP_Radial_D5.0mm_P2.00mm | Standard 5×11mm; readily available |
+| C_inA, C_inB, C_dec, C-* | 100nF | C_Axial_L3.8mm_D2.6mm_P7.50mm | KEMET C1046 etc.; THT available |
+
+**Digi-Key research:** 100µF 16V radial — common parts (Panasonic EEU-FC) use 6.3mm/2.5mm; 8mm parts typically 3.5–5mm pitch. Schematic had P2.00mm (not in KiCad lib); PCB uses P3.80mm. Restored P3.80mm for availability.
 
 ---
 

--- a/pcb/README.md
+++ b/pcb/README.md
@@ -72,9 +72,9 @@ eliminating the crosstalk present in the v4 LM386 design.
 | R3    | 1kΩ resistor                  | 1   | Axial                            | Power LED current limit          |
 | C_inA | 100nF ceramic                 | 1   | Axial L3.8mm THT                 | TDA2822 ch A input coupling      |
 | C_inB | 100nF ceramic                 | 1   | Axial L3.8mm THT                 | TDA2822 ch B input coupling      |
-| C_outA| 100µF 16V electrolytic        | 1   | Radial D8mm P2.0mm               | TDA2822 ch A output coupling     |
-| C_outB| 100µF 16V electrolytic        | 1   | Radial D8mm P2.0mm               | TDA2822 ch B output coupling     |
-| C_vcc | 100µF 16V electrolytic        | 1   | Radial D8mm P2.0mm               | TDA2822 Vcc bypass               |
+| C_outA| 100µF 16V electrolytic        | 1   | Radial D8mm P3.8mm                | TDA2822 ch A output coupling     |
+| C_outB| 100µF 16V electrolytic        | 1   | Radial D8mm P3.8mm                | TDA2822 ch B output coupling     |
+| C_vcc | 100µF 16V electrolytic        | 1   | Radial D8mm P3.8mm                | TDA2822 Vcc bypass               |
 | C_ripple | 4.7µF electrolytic         | 1   | Radial D5mm P2.0mm               | TDA2822 ripple rejection         |
 | C_dec | 100nF ceramic                 | 1   | Axial L3.8mm THT                 | TDA2822 Vcc decoupling           |
 | C-*   | 100nF ceramic                 | 5   | Axial L3.8mm THT                 | Decoupling (see below)           |

--- a/pcb/phonev4.csv
+++ b/pcb/phonev4.csv
@@ -5,11 +5,11 @@
 4;"U1";"XL6009_module";1;"XL6009 boost converter (12V for coin validator)";;;
 5;"U2";"DIP-8";1;"TDA2822M dual audio amplifier";;;
 6;"R1,R2";"R_Axial_DIN0204_L3.6mm_D1.6mm_P7.62mm_Horizontal";2;"4.7k";;;
-7;"C_outA";"CP_Radial_D8.0mm_P2.00mm";1;"100uF 16V (TDA2822 ch A output coupling)";;;
-8;"C_outB";"CP_Radial_D8.0mm_P2.00mm";1;"100uF 16V (TDA2822 ch B output coupling)";;;
+7;"C_outA";"CP_Radial_D8.0mm_P3.80mm";1;"100uF 16V (TDA2822 ch A output coupling)";;;
+8;"C_outB";"CP_Radial_D8.0mm_P3.80mm";1;"100uF 16V (TDA2822 ch B output coupling)";;;
 9;"C_inA";"C_Axial_L3.8mm_D2.6mm_P7.50mm";1;"100nF (TDA2822 ch A input coupling)";;;
 10;"C_inB";"C_Axial_L3.8mm_D2.6mm_P7.50mm";1;"100nF (TDA2822 ch B input coupling)";;;
-11;"C_vcc";"CP_Radial_D8.0mm_P2.00mm";1;"100uF 16V (TDA2822 Vcc bypass)";;;
+11;"C_vcc";"CP_Radial_D8.0mm_P3.80mm";1;"100uF 16V (TDA2822 Vcc bypass)";;;
 12;"C_ripple";"CP_Radial_D5.0mm_P2.00mm";1;"4.7uF (TDA2822 ripple rejection)";;;
 13;"C_dec";"C_Axial_L3.8mm_D2.6mm_P7.50mm";1;"100nF (TDA2822 Vcc decoupling, THT)";;;
 14;"C-arduino1,C-arduino-display1,C-card1,C-coin1,C-raspi1";"C_Axial_L3.8mm_D2.6mm_P7.50mm";5;"100nF decoupling (THT)";;;

--- a/pcb/phonev4.kicad_sch
+++ b/pcb/phonev4.kicad_sch
@@ -11858,7 +11858,7 @@
 				(hide yes)
 			)
 		)
-		(property "Footprint" "Capacitor_THT:CP_Radial_D8.0mm_P2.00mm"
+		(property "Footprint" "Capacitor_THT:CP_Radial_D8.0mm_P3.80mm"
 			(at 113.03 146.05 0)
 			(effects
 				(font
@@ -13153,7 +13153,7 @@
 				(hide yes)
 			)
 		)
-		(property "Footprint" "Capacitor_THT:CP_Radial_D8.0mm_P2.00mm"
+		(property "Footprint" "Capacitor_THT:CP_Radial_D8.0mm_P3.80mm"
 			(at 137.16 146.05 0)
 			(effects
 				(font
@@ -15562,7 +15562,7 @@
 				(hide yes)
 			)
 		)
-		(property "Footprint" "Capacitor_THT:CP_Radial_D8.0mm_P2.00mm"
+		(property "Footprint" "Capacitor_THT:CP_Radial_D8.0mm_P3.80mm"
 			(at 137.16 156.21 0)
 			(effects
 				(font


### PR DESCRIPTION
Follow-up to #84. Digi-Key research: 100µF 16V 8mm parts typically use 3.5–5mm pitch; P2mm uncommon. Schematic had P2.00mm (not in KiCad lib); PCB uses P3.80mm. Restore P3.80mm for schematic/BOM/README; add research notes to AUDIT.md.

Fixes #83 (capacitor audit)

Made with [Cursor](https://cursor.com)