### PR TITLE
Fix API HTTP status code 0 causing curl/remote clients to fail

### DIFF
--- a/host/DEVICE_TEST.md
+++ b/host/DEVICE_TEST.md
@@ -1,0 +1,42 @@
+# Device Testing
+
+Run integration tests against the real Millennium payphone when it's connected and the daemon is running.
+
+## Remote Device
+
+- **Host:** 192.168.86.145
+- **User:** matzen
+
+## Prerequisites
+
+- Daemon running on the device (`sudo systemctl status daemon.service`)
+- Device reachable on the network (port 8081 for HTTP API)
+
+## Run API Tests (from your machine)
+
+```bash
+make api-test HOST=192.168.86.145
+```
+
+Or set the variable once:
+
+```bash
+export HOST=192.168.86.145
+make api-test
+```
+
+## Run API Tests (from the device)
+
+SSH into the device and run locally:
+
+```bash
+ssh matzen@192.168.86.145 'cd millennium/host && make api-test'
+```
+
+## Troubleshooting
+
+If tests fail with "Cannot reach":
+
+1. Check daemon is running: `ssh matzen@192.168.86.145 'sudo systemctl status daemon.service'`
+2. Verify port 8081 is listening: `ssh matzen@192.168.86.145 'ss -tlnp | grep 8081'`
+3. Confirm network connectivity: `curl -s http://192.168.86.145:8081/api/health`

--- a/host/Makefile
+++ b/host/Makefile
@@ -167,4 +167,9 @@ api-test:
 	@chmod +x tests/api_test.sh
 	@HOST=$(HOST) ./tests/api_test.sh $(HOST)
 
-.PHONY: all clean install uninstall test unit_tests api-test
+# Run API test against the remote device (matzen@192.168.86.145)
+# Override: make device-test HOST=other-ip
+device-test:
+	$(MAKE) api-test HOST=192.168.86.145
+
+.PHONY: all clean install uninstall test unit_tests api-test device-test

--- a/host/README.md
+++ b/host/README.md
@@ -14,6 +14,7 @@ The host software includes:
 ## Files
 
 - `Makefile` — Builds the daemon, simulator, and unit tests
+- `DEVICE_TEST.md` — Run API tests against the real device (192.168.86.145)
 - `daemon.conf.example` — Example configuration file (copy to `/etc/millennium/daemon.conf`)
 - `asoundrc.example` — Example ALSA configuration for the USB audio device
 - `systemd/daemon.service` — Systemd service for the daemon

--- a/host/web_server.c
+++ b/host/web_server.c
@@ -780,6 +780,7 @@ struct http_response web_server_handle_api_status(const struct http_request* req
     (void)request; /* Suppress unused parameter warning */
     struct http_response response;
     memset(&response, 0, sizeof(response));
+    response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
     
     /* Calculate actual uptime */
@@ -804,6 +805,7 @@ struct http_response web_server_handle_api_metrics(const struct http_request* re
     (void)request; /* Suppress unused parameter warning */
     struct http_response response;
     memset(&response, 0, sizeof(response));
+    response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
     
     /* Use C89 metrics API - simplified version */
@@ -821,6 +823,7 @@ struct http_response web_server_handle_api_health(const struct http_request* req
     (void)request; /* Suppress unused parameter warning */
     struct http_response response;
     memset(&response, 0, sizeof(response));
+    response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
     
     health_status_t overall_status = health_monitor_get_overall_status();
@@ -876,6 +879,7 @@ struct http_response web_server_handle_api_config(const struct http_request* req
     (void)request; /* Suppress unused parameter warning */
     struct http_response response;
     memset(&response, 0, sizeof(response));
+    response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
     
     config_data_t* config = config_get_instance();
@@ -935,6 +939,7 @@ struct http_response web_server_handle_api_state(const struct http_request* requ
     (void)request; /* Suppress unused parameter warning */
     struct http_response response;
     memset(&response, 0, sizeof(response));
+    response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
     
     char json[768];
@@ -973,6 +978,7 @@ struct http_response web_server_handle_api_state(const struct http_request* requ
 struct http_response web_server_handle_api_control(const struct http_request* request) {
     struct http_response response;
     memset(&response, 0, sizeof(response));
+    response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
     
     char json[512];
@@ -1286,6 +1292,7 @@ struct http_response web_server_handle_api_plugins(const struct http_request* re
     (void)request; /* Suppress unused parameter warning */
     struct http_response response;
     memset(&response, 0, sizeof(response));
+    response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
     
     char json[1024];


### PR DESCRIPTION
## Problem
API tests failed from host with `curl: (1) Unsupported HTTP/1 subversion in response`. The response was `HTTP/1.1 0 Unknown` because handlers did not set `response.status_code`.

## Fix
Set `response.status_code = 200` in all API handlers:
- status, metrics, health, config, state, control, plugins

## Testing
- Daemon rebuilt and restarted on device; all 12 API tests pass
- `make device-test` added; `DEVICE_TEST.md` documents the device

Made with [Cursor](https://cursor.com)