### PR TITLE
Fix blank web portal page

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -140,6 +140,8 @@ install: daemon
 	sudo cp daemon.conf.example /etc/millennium/daemon.conf
 	sudo cp asoundrc.example /etc/asound.conf
 	sudo cp daemon /usr/local/bin/millennium-daemon
+	sudo mkdir -p /usr/local/share/millennium
+	sudo cp web_portal.html /usr/local/share/millennium/
 	sudo cp systemd/daemon.service /etc/systemd/system/
 	@if [ -f $$HOME/.baresip/config ] && grep -qE '^[[:space:]]*module[[:space:]]*stdio\.so' $$HOME/.baresip/config 2>/dev/null; then \
 		sed -i.bak 's/^[[:space:]]*module[[:space:]]*stdio\.so/# module stdio.so/' $$HOME/.baresip/config; \
@@ -156,6 +158,7 @@ uninstall:
 	sudo systemctl stop daemon.service
 	sudo systemctl disable daemon.service
 	sudo rm -f /usr/local/bin/millennium-daemon
+	sudo rm -rf /usr/local/share/millennium
 	sudo rm -rf /etc/systemd/system/daemon.service.d
 	sudo rm -f /etc/systemd/system/daemon.service
 	sudo systemctl daemon-reload

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -834,7 +834,7 @@ int main(int argc, char *argv[]) {
         web_server = web_server_create(config_get_web_server_port(config));
         
         /* Add the web portal as a file route (streaming) */
-        web_server_add_file_route(web_server, "/", "web_portal.html", "text/html");
+        web_server_add_file_route(web_server, "/", "/usr/local/share/millennium/web_portal.html", "text/html");
         
         web_server_start(web_server);
         logger_infof_with_category("Daemon", "Web server started on port %d", 


### PR DESCRIPTION
## Problem
Visiting http://&lt;device&gt;:8081 showed a blank page.

## Root cause
- Daemon used relative path `web_portal.html`
- systemd `WorkingDirectory=/tmp` → looked for `/tmp/web_portal.html` (doesn't exist)
- `make install` never copied the portal anywhere

## Fix
- Use absolute path `/usr/local/share/millennium/web_portal.html`
- Add `web_portal.html` to `make install`
- Add removal to `make uninstall`

Made with [Cursor](https://cursor.com)