### PR TITLE
fix(#109): Sync daemon_state.inserted_cents when plugin deducts/refunds

### DIFF
--- a/host/daemon.c
+++ b/host/daemon.c
@@ -90,6 +90,16 @@ time_t get_daemon_start_time(void) {
     return daemon_start_time;
 }
 
+/* #109: Keep daemon_state.inserted_cents in sync when plugin deducts/refunds */
+void plugins_adjust_inserted_cents(int delta) {
+    if (!daemon_state) return;
+    pthread_mutex_lock(&daemon_state_mutex);
+    daemon_state->inserted_cents += delta;
+    if (daemon_state->inserted_cents < 0) daemon_state->inserted_cents = 0;
+    daemon_state_update_activity(daemon_state);
+    pthread_mutex_unlock(&daemon_state_mutex);
+}
+
 struct daemon_state_info get_daemon_state_info(void) {
     struct daemon_state_info info;
     memset(&info, 0, sizeof(info));

--- a/host/plugins.h
+++ b/host/plugins.h
@@ -41,6 +41,9 @@ int plugins_activate(const char *plugin_name);
 const char* plugins_get_active_name(void);
 int plugins_list(char *buffer, size_t buffer_size);
 
+/* #109: Sync inserted_cents when plugin deducts/refunds (e.g. call cost). */
+void plugins_adjust_inserted_cents(int delta);
+
 /* Plugin event handler functions */
 int plugins_handle_coin(int coin_value, const char *coin_code);
 int plugins_handle_keypad(char key);

--- a/host/plugins/classic_phone.c
+++ b/host/plugins/classic_phone.c
@@ -142,6 +142,7 @@ static int classic_phone_handle_call_state(int call_state) {
         if (classic_phone_data.is_dialing) {
             /* #91: Call failed during dial - refund and show failure */
             classic_phone_data.inserted_cents += classic_phone_data.call_cost_cents;
+            plugins_adjust_inserted_cents(classic_phone_data.call_cost_cents);  /* #109: sync daemon_state */
             classic_phone_data.is_dialing = 0;
             display_manager_set_text("Call failed", "Coins refunded");
             logger_info_with_category("ClassicPhone", "Call failed - coins refunded");
@@ -331,6 +332,7 @@ static void classic_phone_start_call(void) {
 
     if (!classic_phone_data.is_emergency_call && !classic_phone_data.is_card_call) {
         classic_phone_data.inserted_cents -= classic_phone_data.call_cost_cents;
+        plugins_adjust_inserted_cents(-classic_phone_data.call_cost_cents);  /* #109: sync daemon_state */
     }
 
     millennium_client_call(client, classic_phone_data.current_number);

--- a/host/simulator.c
+++ b/host/simulator.c
@@ -3,6 +3,9 @@
 #include "events.h"
 #include "config.h"
 #include "daemon_state.h"
+
+/* Forward declaration for stubs that run before daemon_state is initialized */
+extern daemon_state_data_t *daemon_state;
 #include "logger.h"
 #include "metrics.h"
 #include "event_processor.h"
@@ -210,6 +213,14 @@ void millennium_client_check_serial(millennium_client_t *c) {
 
 void millennium_client_serial_activity(millennium_client_t *c) {
     (void)c;
+}
+
+/* #109: Keep daemon_state in sync when plugin deducts/refunds */
+void plugins_adjust_inserted_cents(int delta) {
+    if (daemon_state) {
+        daemon_state->inserted_cents += delta;
+        if (daemon_state->inserted_cents < 0) daemon_state->inserted_cents = 0;
+    }
 }
 
 /* Audio tone stubs */

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -41,6 +41,14 @@ void millennium_client_check_serial(millennium_client_t *c) { (void)c; }
 void millennium_client_serial_activity(millennium_client_t *c) { (void)c; }
 void list_audio_devices(void) {}
 
+/* #109: Keep daemon_state in sync when plugin deducts/refunds */
+void plugins_adjust_inserted_cents(int delta) {
+    if (daemon_state) {
+        daemon_state->inserted_cents += delta;
+        if (daemon_state->inserted_cents < 0) daemon_state->inserted_cents = 0;
+    }
+}
+
 /* Audio tone stubs */
 void audio_tones_init(void) {}
 void audio_tones_cleanup(void) {}


### PR DESCRIPTION
Fixes #109

**Problem:** `daemon_state->inserted_cents` and `classic_phone_data.inserted_cents` could desync when the plugin deducted for paid calls (only plugin updated) or refunded on call failure (only plugin updated).

**Fix:**
- Add `plugins_adjust_inserted_cents(int delta)` so plugins can sync daemon_state when they deduct or refund coins
- classic_phone calls it when deducting for paid call and when refunding on call-failed-during-dial (#91 path)
- daemon implements with mutex; simulator and unit_tests have stubs

**Result:** API, persistence, and display all agree on coin balance.

Made with [Cursor](https://cursor.com)