### PR TITLE
docs: markdown quality pass — fix ASCII art alignment and text

### DIFF
--- a/Arduino/PINOUT.md
+++ b/Arduino/PINOUT.md
@@ -15,27 +15,27 @@ definitions only change the USB VID/PID so the Pi can distinguish them via
 
 ## Keypad Arduino (Millennium Alpha, A1)
 
-| Arduino Pin | ATmega32U4 Pin | Function             | Direction    | Notes                              |
-|-------------|----------------|----------------------|--------------|------------------------------------|
-| 0           | PD2 (RXD1)     | MagStripe RDT (data) | Input (ISR)  | Shared with HW UART RX — see note  |
-| 1           | PD3 (TXD1)     | MagStripe RCL (clock)| Input (ISR)  | Shared with HW UART TX — see note  |
-| 4           | PD4            | Hook down sense      | Input pullup |                                    |
-| 5           | PC6            | Hook up sense        | Input pullup |                                    |
-| 6           | PD7            | Keypad row 3 (* 0 #) | I/O         |                                    |
-| 7           | PE6            | Keypad row 2 (7 8 9) | I/O         |                                    |
-| 8           | PB4            | Keypad row 1 (4 5 6) | I/O         |                                    |
-| 9           | PB5            | Keypad row 0 (1 2 3) | I/O         |                                    |
-| 10          | PB6            | Keypad col 0         | I/O          |                                    |
-| 11          | PB7            | Keypad col 1         | I/O          |                                    |
-| 12          | PD6            | Keypad col 2         | I/O          |                                    |
-| 13          | PC7            | Keypad col 3         | I/O          | Extra columns (A-P keys)           |
-| 18 (A0)     | PF7            | Keypad col 4         | I/O          | Extra columns (A-P keys)           |
-| 19 (A1)     | PF6            | Keypad col 5         | I/O          | Extra columns (A-P keys)           |
-| 20 (A2)     | PF5            | Keypad col 6         | I/O          | Extra columns (A-P keys)           |
-| 21 (A3)     | PF4            | Hook common pin      | Output       | Driven LOW to scan, HIGH at idle   |
-| 22 (A4)     | PF1 (ADC1)     | MagStripe CLS (card present) | Input |                                    |
-| 2 (SDA)     | PD1            | I2C SDA (master)     | I/O          | To display Arduino                 |
-| 3 (SCL)     | PD0            | I2C SCL (master)     | I/O          | To display Arduino                 |
+| Arduino Pin | ATmega32U4 Pin | Function                     | Direction    | Notes                              |
+|-------------|----------------|------------------------------|--------------|------------------------------------|
+| 0           | PD2 (RXD1)     | MagStripe RDT (data)         | Input (ISR)  | Shared with HW UART RX — see note  |
+| 1           | PD3 (TXD1)     | MagStripe RCL (clock)        | Input (ISR)  | Shared with HW UART TX — see note  |
+| 4           | PD4            | Hook down sense              | Input pullup |                                    |
+| 5           | PC6            | Hook up sense                | Input pullup |                                    |
+| 6           | PD7            | Keypad row 3 (* 0 #)         | I/O          |                                    |
+| 7           | PE6            | Keypad row 2 (7 8 9)         | I/O          |                                    |
+| 8           | PB4            | Keypad row 1 (4 5 6)         | I/O          |                                    |
+| 9           | PB5            | Keypad row 0 (1 2 3)         | I/O          |                                    |
+| 10          | PB6            | Keypad col 0                 | I/O          |                                    |
+| 11          | PB7            | Keypad col 1                 | I/O          |                                    |
+| 12          | PD6            | Keypad col 2                 | I/O          |                                    |
+| 13          | PC7            | Keypad col 3                 | I/O          | Extra columns (A-P keys)           |
+| 18 (A0)     | PF7            | Keypad col 4                 | I/O          | Extra columns (A-P keys)           |
+| 19 (A1)     | PF6            | Keypad col 5                 | I/O          | Extra columns (A-P keys)           |
+| 20 (A2)     | PF5            | Keypad col 6                 | I/O          | Extra columns (A-P keys)           |
+| 21 (A3)     | PF4            | Hook common pin              | Output       | Driven LOW to scan, HIGH at idle   |
+| 22 (A4)     | PF1 (ADC1)     | MagStripe CLS (card present) | Input        |                                    |
+| 2 (SDA)     | PD1            | I2C SDA (master)             | I/O          | To display Arduino                 |
+| 3 (SCL)     | PD0            | I2C SCL (master)             | I/O          | To display Arduino                 |
 
 ### Notes
 
@@ -57,26 +57,26 @@ keypad PCB (volume, language, etc.).
 
 | Arduino Pin | ATmega32U4 Pin | Function             | Direction | Notes                        |
 |-------------|----------------|----------------------|-----------|------------------------------|
-| 0 (RX)      | PD2 (RXD1)     | VFD RD (read strobe) | Output   |                              |
-| 1 (TX)      | PD3 (TXD1)     | VFD AD (address)     | Output   |                              |
-| 4           | PD4            | VFD WR (write strobe)| Output   |                              |
-| 5           | PC6            | VFD D0               | Output   |                              |
-| 6           | PD7            | VFD D1               | Output   |                              |
-| 7           | PE6            | VFD D2               | Output   |                              |
-| 8           | PB4            | VFD D3               | Output   |                              |
-| 9           | PB5            | VFD D4               | Output   |                              |
-| 10          | PB6            | VFD D5               | Output   |                              |
-| 11          | PB7            | VFD D6               | Output   |                              |
-| 12          | PD6            | VFD D7               | Output   |                              |
-| 13          | PC7            | VFD RESET            | Output   |                              |
-| 14 (MISO)   | PB3            | Coin validator RX    | Input    | SoftwareSerial at 600 baud   |
-| 15          | PB1            | Coin validator RESET | Output   | Active-low reset              |
-| 16          | PB2            | VFD TEST             | Output   |                              |
-| 17 (SS)     | PB0            | VFD CS (chip select) | Output   |                              |
-| 23          | N/A            | Coin validator TX    | Output   | SoftwareSerial (pin 23 is TX)|
-| 2 (SDA)     | PD1            | I2C SDA (slave)      | I/O      | Slave address 0              |
-| 3 (SCL)     | PD0            | I2C SCL (slave)      | I/O      |                              |
-| USB         | Native USB     | SerialUSB to Pi      | I/O      | 9600 baud                    |
+| 0 (RX)      | PD2 (RXD1)     | VFD RD (read strobe) | Output    |                              |
+| 1 (TX)      | PD3 (TXD1)     | VFD AD (address)     | Output    |                              |
+| 4           | PD4            | VFD WR (write strobe)| Output    |                              |
+| 5           | PC6            | VFD D0               | Output    |                              |
+| 6           | PD7            | VFD D1               | Output    |                              |
+| 7           | PE6            | VFD D2               | Output    |                              |
+| 8           | PB4            | VFD D3               | Output    |                              |
+| 9           | PB5            | VFD D4               | Output    |                              |
+| 10          | PB6            | VFD D5               | Output    |                              |
+| 11          | PB7            | VFD D6               | Output    |                              |
+| 12          | PD6            | VFD D7               | Output    |                              |
+| 13          | PC7            | VFD RESET            | Output    |                              |
+| 14 (MISO)   | PB3            | Coin validator RX    | Input     | SoftwareSerial at 600 baud   |
+| 15          | PB1            | Coin validator RESET | Output    | Active-low reset             |
+| 16          | PB2            | VFD TEST             | Output    |                              |
+| 17 (SS)     | PB0            | VFD CS (chip select) | Output    |                              |
+| 23          | N/A            | Coin validator TX    | Output    | SoftwareSerial (pin 23 is TX)|
+| 2 (SDA)     | PD1            | I2C SDA (slave)      | I/O       | Slave address 0              |
+| 3 (SCL)     | PD0            | I2C SCL (slave)      | I/O       |                              |
+| USB         | Native USB     | SerialUSB to Pi      | I/O       | 9600 baud                    |
 
 ### VFD Pin Mapping (Noritake CU20026SCPB-T23A)
 
@@ -110,30 +110,30 @@ The keypad Arduino sends short I2C messages to the display Arduino. The display
 Arduino's `receiveEvent` ISR immediately forwards each byte over USB serial to
 the Pi.
 
-| Event       | I2C Bytes | USB Serial to Pi |
-|-------------|-----------|------------------|
-| Key press   | `K` + key char (e.g. `K5`) | `K5`    |
-| Hook up     | `H` `U`   | `HU`            |
-| Hook down   | `H` `D`   | `HD`            |
-| Card swipe  | `C` + PAN (up to 16 chars) | `C1234567890123456` |
+| Event       | I2C Bytes                    | USB Serial to Pi      |
+|-------------|------------------------------|-----------------------|
+| Key press   | `K` + key char (e.g. `K5`)   | `K5`                  |
+| Hook up     | `H` `U`                      | `HU`                  |
+| Hook down   | `H` `D`                      | `HD`                  |
+| Card swipe  | `C` + PAN (up to 16 chars)   | `C1234567890123456`   |
 
 ### Pi → Display Arduino (USB Serial)
 
-| Command | Bytes                          | Action                                    |
-|---------|--------------------------------|-------------------------------------------|
-| Display | `0x02` + length + data bytes   | Clear and write text to VFD               |
-| Coin cmd| `0x03` + byte                  | Send byte to coin validator (`@` = reset) |
-| EEPROM  | `0x04`                         | Program coin validator EEPROM (256 bytes) |
-| Verify  | `0x05`                         | Read back and verify coin validator EEPROM|
-| Keepalive | `0x06`                       | No-op; resets serial watchdog when idle (#59) |
+| Command   | Bytes                        | Action                                          |
+|-----------|------------------------------|-------------------------------------------------|
+| Display   | `0x02` + length + data bytes | Clear and write text to VFD                     |
+| Coin cmd  | `0x03` + byte                | Send byte to coin validator (`@` = reset)       |
+| EEPROM    | `0x04`                       | Program coin validator EEPROM (256 bytes)       |
+| Verify    | `0x05`                       | Read back and verify coin validator EEPROM      |
+| Keepalive | `0x06`                       | No-op; resets serial watchdog when idle (#59)   |
 
 ### Coin Validator → Pi
 
 When the coin validator sends a byte over SoftwareSerial, the display Arduino
 prefixes it with `V` and forwards over USB serial:
 
-| USB Serial | Meaning |
-|------------|---------|
+| USB Serial | Meaning                                             |
+|------------|-----------------------------------------------------|
 | `V` + byte | Coin validator event (byte value encodes coin type) |
 
 ## Custom Board Definitions
@@ -145,11 +145,11 @@ The custom boards are appended to the stock Arduino AVR `boards.txt` at:
 
 Key differences from stock Arduino Micro:
 
-| Property       | Stock Micro    | Millennium Alpha   | Millennium Beta    |
-|----------------|----------------|--------------------|--------------------|
-| USB PID (app)  | 0x0037         | 0x0045             | 0x0046             |
-| USB PID (boot) | 0x8037         | 0x8045             | 0x8046             |
-| Product name   | Arduino Micro  | Millennium Alpha   | Millennium Beta    |
+| Property       | Stock Micro    | Millennium Alpha                | Millennium Beta                |
+|----------------|----------------|---------------------------------|--------------------------------|
+| USB PID (app)  | 0x0037         | 0x0045                          | 0x0046                         |
+| USB PID (boot) | 0x8037         | 0x8045                          | 0x8046                         |
+| Product name   | Arduino Micro  | Millennium Alpha                | Millennium Beta                |
 | Bootloader     | Caterina-Micro | Caterina-Micro-Millennium-Alpha | Caterina-Micro-Millennium-Beta |
 
 **Issue**: The custom bootloader hex files (`Caterina-Micro-Millennium-Alpha.hex`,

--- a/Arduino/README.md
+++ b/Arduino/README.md
@@ -2,10 +2,10 @@
 
 Two Arduino Micro boards (ATmega32U4) run the keypad/peripheral I/O:
 
-| Board             | FQBN                            | Sketch            | Role                                    |
-|-------------------|---------------------------------|-------------------|-----------------------------------------|
-| Millennium Alpha  | `arduino:avr:millennium_alpha`  | `sketches/keypad` | 4x7 keypad, magstripe reader, hook switch |
-| Millennium Beta   | `arduino:avr:millennium_beta`   | `sketches/display`| VFD display, coin validator, I2C→USB bridge |
+| Board             | FQBN                            | Sketch             | Role                                        |
+|-------------------|---------------------------------|--------------------|---------------------------------------------|
+| Millennium Alpha  | `arduino:avr:millennium_alpha`  | `sketches/keypad`  | 4x7 keypad, magstripe reader, hook switch   |
+| Millennium Beta   | `arduino:avr:millennium_beta`   | `sketches/display` | VFD display, coin validator, I2C→USB bridge |
 
 See [PINOUT.md](PINOUT.md) for complete pin assignments, I2C protocol, and serial command reference.
 

--- a/README.md
+++ b/README.md
@@ -32,34 +32,32 @@ This project reimagines the functionality of the Nortel Millennium telephone by 
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────┐
-│                 Raspberry Pi Zero 2 W               │
-│                                                     │
-│  ┌──────────┐  ┌──────────┐  ┌───────────────────┐ │
-│  │  Daemon   │  │  PJSIP   │  │   Web Dashboard   │ │
-│  │          │──│  (VoIP)  │  │   :8081            │ │
-│  │ Plugins: │  └──────────┘  │ - Phone state      │ │
-│  │ - Phone  │                │ - Plugin switching  │ │
-│  │ - Fortune│  ┌──────────┐  │ - OTA updates      │ │
-│  │ - Jukebox│  │  ALSA    │  │ - Health/metrics   │ │
-│  │          │  │  Audio   │  └───────────────────┘ │
-│  └────┬─────┘  └──────────┘                         │
-│       │ USB Serial (9600 baud)                      │
-└───────┼─────────────────────────────────────────────┘
-        │
-┌───────┴──────────────────────────────────────────┐
-│              Custom PCB (phonev5)                 │
-│                                                  │
-│  ┌─────────────────┐    I2C    ┌───────────────┐ │
-│  │ Display Arduino  │◄────────│ Keypad Arduino │ │
-│  │ (millennium_beta)│         │(millennium_alpha)│
-│  │                  │         │                 │ │
-│  │ ► VFD Display    │         │ ► 4x7 Keypad   │ │
-│  │   (parallel 8b)  │         │ ► MagStripe    │ │
-│  │ ► Coin Validator  │         │ ► Hook Switch  │ │
-│  │   (SoftSerial)   │         │                 │ │
-│  └──────────────────┘         └─────────────────┘ │
-└──────────────────────────────────────────────────┘
+┌────────────────────────── Raspberry Pi Zero 2 W ───────────────────────────┐
+│                                                                            │
+│  ┌──────────────┐     ┌──────────────┐      ┌──────────────────────────┐   │
+│  │ Daemon       │────▶│ PJSIP (VoIP) │      │ Web Dashboard :8081      │   │
+│  │              │     └──────────────┘      │                          │   │
+│  │ Plugins:     │                           │ - phone state            │   │
+│  │ - Phone      │     ┌──────────────┐      │ - plugin switching       │   │
+│  │ - Fortune    │     │ ALSA Audio   │      │ - OTA updates            │   │
+│  │ - Jukebox    │     └──────────────┘      │ - health / metrics       │   │
+│  │ - +4 games   │                           └──────────────────────────┘   │
+│  └──────┬───────┘                                                          │
+│         │ USB serial (9600 baud)                                           │
+└─────────┬──────────────────────────────────────────────────────────────────┘
+          │
+┌─────────┴───────────────── Custom PCB (phonev5) ───────────────────────────┐
+│                                                                            │
+│  ┌──────────────────────┐ I2C      ┌────────────────────────┐              │
+│  │ Display Arduino      │◀─────────│ Keypad Arduino         │              │
+│  │ (millennium_beta)    │          │ (millennium_alpha)     │              │
+│  │                      │          │                        │              │
+│  │ - VFD display        │          │ - 4x7 keypad           │              │
+│  │   (parallel 8-bit)   │          │ - magstripe reader     │              │
+│  │ - coin validator     │          │ - hook switch          │              │
+│  │   (SoftSerial)       │          └────────────────────────┘              │
+│  └──────────────────────┘                                                  │
+└────────────────────────────────────────────────────────────────────────────┘
 ```
 
 **Data flow**: Keypad/hook/card events originate on the Keypad Arduino, are sent via I2C to the Display Arduino, which forwards them to the Raspberry Pi over USB serial. The daemon processes events through an event processor, dispatches them to the active plugin, and sends display updates back down the same path. VoIP calls are handled by PJSIP (PJSUA C API) with audio routed through ALSA (dmix + route plugins for mono channel splitting).

--- a/case/README.md
+++ b/case/README.md
@@ -4,16 +4,16 @@ An enclosure for the custom PCB, designed in Blender and printed in PLA+.
 
 ## Dimensions
 
-| Measurement        | Value      |
-|--------------------|------------|
+| Measurement        | Value                   |
+|--------------------|-------------------------|
 | Outer size         | 109.5 × 134.0 × 38.0 mm |
-| Interior (approx)  | ~103 × 128 mm |
-| Wall thickness     | ~3 mm      |
-| Depth per half     | 19 mm      |
-| PCB size           | 88.9 × 124.5 mm |
-| PCB clearance (X)  | ~14.6 mm   |
-| PCB clearance (Y)  | ~3.5 mm    |
-| Triangle count     | 3,544      |
+| Interior (approx)  | ~103 × 128 mm           |
+| Wall thickness     | ~3 mm                   |
+| Depth per half     | 19 mm                   |
+| PCB size           | 88.9 × 124.5 mm         |
+| PCB clearance (X)  | ~14.6 mm                |
+| PCB clearance (Y)  | ~3.5 mm                 |
+| Triangle count     | 3,544                   |
 
 ## Design
 
@@ -45,14 +45,14 @@ The case is a two-piece clamshell that splits horizontally at the midplane:
 
 ### Recommended Settings
 
-| Setting           | Value                |
-|-------------------|----------------------|
-| Material          | PLA+ (or PETG for heat resistance) |
-| Layer height      | 0.2 mm               |
-| Infill            | 20–30%               |
-| Perimeters        | 3                    |
+| Setting           | Value                                  |
+|-------------------|----------------------------------------|
+| Material          | PLA+ (or PETG for heat resistance)     |
+| Layer height      | 0.2 mm                                 |
+| Infill            | 20–30%                                 |
+| Perimeters        | 3                                      |
 | Supports          | Not needed (flat bottom, no overhangs) |
-| Bed adhesion      | Brim recommended for the larger half |
+| Bed adhesion      | Brim recommended for the larger half   |
 
 The original was printed with PLA+ at default slicer settings. No supports
 are required since both halves print with the open face up.

--- a/host/SETUP.md
+++ b/host/SETUP.md
@@ -92,7 +92,7 @@ playback to the right channel. If needed, pin specific device IDs with
 `sip.snd_capture_dev` / `sip.snd_playback_dev` (the daemon logs available
 device IDs at startup).
 
-## 6. Clone and build the daemon
+## 5. Clone and build the daemon
 
 ```bash
 cd ~
@@ -101,7 +101,7 @@ cd millennium/host
 make daemon
 ```
 
-## 7. ALSA audio configuration
+## 6. ALSA audio configuration
 
 The USB audio card needs a custom ALSA config to split stereo into independent
 mono channels for the handset earpiece and ringer speaker. From the `host/`
@@ -127,7 +127,7 @@ speaker-test -D out_left_solo -c1 -twav   # should play through ringer
 speaker-test -D out_right_solo -c1 -twav  # should play through handset
 ```
 
-## 8. Configure the daemon
+## 7. Configure the daemon
 
 ```bash
 sudo mkdir -p /etc/millennium
@@ -153,7 +153,7 @@ With the custom board definitions flashed, the display Arduino appears as
 ls /dev/serial/by-id/
 ```
 
-## 9. Create the log and state directories
+## 8. Create the log and state directories
 
 ```bash
 sudo mkdir -p /var/log/millennium
@@ -162,7 +162,7 @@ sudo mkdir -p /var/lib/millennium
 sudo chown $USER:$USER /var/lib/millennium
 ```
 
-## 10. Install the systemd service
+## 9. Install the systemd service
 
 **Production** (recommended): Use `make install` for a system-wide service that
 starts at boot:
@@ -195,7 +195,7 @@ Ensure `/etc/millennium/daemon.conf` exists: `sudo cp daemon.conf.example /etc/m
 
 The web dashboard should now be accessible at `http://<pi-ip>:8081`.
 
-## 11. Disable unused services (optional cleanup)
+## 10. Disable unused services (optional cleanup)
 
 If you previously had PipeWire/WirePlumber installed, mask the leftover services:
 

--- a/pcb/DESIGN_OPTIONS.md
+++ b/pcb/DESIGN_OPTIONS.md
@@ -114,7 +114,7 @@ The display Arduino uses its only hardware UART (Serial1) for the VFD. Pi commun
 - Keypad doesn’t talk to the Pi directly today; everything goes through the display.
 - To use Pi UART, we’d need the keypad to talk to the Pi over UART instead of I2C→display→USB. That’s a protocol/architecture change.
 
-**Conclusion:** Direct Pi UART is possible if we repin the display (Option 2a) and add level shifters. It removes USB for that link and avoids hub/ enumeration issues, at the cost of pin changes, new parts, and firmware updates.
+**Conclusion:** Direct Pi UART is possible if we repin the display (Option 2a) and add level shifters. It removes USB for that link and avoids hub/enumeration issues, at the cost of pin changes, new parts, and firmware updates.
 
 ---
 

--- a/pcb/README.md
+++ b/pcb/README.md
@@ -23,10 +23,10 @@ channels, solving both the speaker coupling and quiet handset issues.
 ```
 USB audio card (stereo 3.5mm)
   ├─ Left channel → J7 tip → C_inA → TDA2822 IN_A (pin 3)
-  │                                    → OUT_A (pin 1) → C_outA → speaker_front+ → ringer
+  │                                  TDA2822 OUT_A (pin 1) → C_outA → speaker_front+ → ringer
   │
   └─ Right channel → J7 ring → C_inB → TDA2822 IN_B (pin 4)
-                                        → OUT_B (pin 5) → C_outB → speaker_receiver+ → J4 RJ9 → handset
+                                       TDA2822 OUT_B (pin 5) → C_outB → speaker_receiver+ → J4 RJ9 → handset
 ```
 
 Each channel has its own input coupling capacitor (100nF) and output coupling
@@ -128,7 +128,7 @@ self-resets when the fault is cleared.
 
 ### Power Indicator (D4, R3)
 
-A green LED on the 5V_MAIN rail provides visual confirmation that the board is
+A red LED on the 5V_MAIN rail provides visual confirmation that the board is
 powered, useful when debugging inside the payphone enclosure.
 
 ## Connector Pinouts
@@ -211,10 +211,10 @@ The board is powered from an external 5V supply. Power flows as follows:
 | TP6   | 12V_COIN | Boosted 12V rail for coin validator |
 
 **Note on USB connectivity**: Arduino ↔ Pi communication is via USB through an
-external hub. There are no discrete USB serial TX/RX nets on the PCB; TP6 and
-TP7 in older docs referred to USB serial, but that path does not exist as PCB
-nets. Only the test points above (5V_MAIN, GND, 12V_COIN, I2C) are actual PCB
-nets.
+external hub. There are no discrete USB serial TX/RX nets on the PCB. Older docs
+listed extra test points for USB serial, but that path does not exist as PCB
+nets. Only the test points above (5V_MAIN, 3.3V, GND, SDA, SCL, 12V_COIN) are
+actual PCB nets.
 
 ## Schematic Audit
 

--- a/pcb/SCHEMATIC_D2_CHANGES.md
+++ b/pcb/SCHEMATIC_D2_CHANGES.md
@@ -18,7 +18,7 @@ Clamps transient voltage between signal and GND (~10.5V max). In stock at DigiKe
 
 ### Net Reference
 
-| Net                 | Nodes                                        |
+| Net                 | Nodes                                         |
 |---------------------|-----------------------------------------------|
 | coin_rx             | A2 MISO, J1 Pin_3                             |
 | speaker_front+      | C_outA pin 2, J2 Pin_19, **D2 pin 2**         |


### PR DESCRIPTION
A repo-wide Markdown quality pass: every ASCII-art diagram is now correctly fenced and aligned, and table sources are column-consistent.

## ASCII art
- **README architecture diagram** redrawn cleanly — previously ragged (broken inter-box connector, a missing box border, mismatched box widths). The new diagram is generated so every box border and the inter-box connector align by construction (all box lines exactly 78 cols, connector at a single column).
- **pcb/README audio signal-path diagram** aligned so each amplifier channel's input→output reads in one column.

## Text quality
- **pcb/README**: fixed the self-contradictory USB test-point note and completed the net list; corrected the power-LED color (green→red) to match the BOM (D4 = Red LED C2286).
- **host/SETUP**: fixed section numbering (it skipped 5).
- **Arduino/PINOUT, Arduino/README, case/README**: realigned all Markdown table source columns (whitespace-only — no pin/PID/dimension values changed).
- **pcb/DESIGN_OPTIONS, pcb/SCHEMATIC_D2_CHANGES**: minor wording + table alignment.

## Verification
Across all 35 markdown files: all ASCII art is fenced, all code fences are balanced, and all tables are column-consistent (checked programmatically).

## Not included / flags
- `pcb/phonev6/*.md` got the same fixes on disk but is untracked WIP, so it's left out of this PR.
- `HARDWARE.md` still names the board "Raspberry Pi Zero W" while the rest of the repo says "Zero 2 W"; its 150 mA / 38 °C figures were measured on the original Zero W, so the name wasn't blindly swapped (would create a new inaccuracy). Flagged for a follow-up with real Zero 2 W numbers.
- A few PCB docs have part-number/test-point-count discrepancies (e.g. R3/R4/R5 LCSC codes; TP1–5 vs TP1–6; AUDIT.md listing the old THT Q1/TVS). Left untouched — they need verification against the actual schematic/BOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)