### PR TITLE
ci: compile-check daemon sources the simulator build skips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,15 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
 
+      # Compile the real daemon sources (incl. the ALSA paths in audio_tones.c,
+      # web_server, websocket, health_monitor) that the simulator/unit-test
+      # builds stub out. Catches type/syntax breakage that would otherwise only
+      # surface on the Pi's `make daemon`. pjsip_interface.c is excluded — it
+      # needs libpjproject, which isn't available here.
+      - name: Compile-check daemon sources
+        working-directory: host
+        run: make compile-check
+
       - name: Build simulator
         working-directory: host
         run: make simulator

--- a/host/Makefile
+++ b/host/Makefile
@@ -150,6 +150,24 @@ test: simulator unit_tests
 	@./simulator tests/*.scenario
 	@echo ""
 
+# Compile-check every daemon translation unit EXCEPT pjsip_interface.o (the only
+# one needing libpjproject, which isn't available off the Pi). The simulator and
+# unit-test builds stub the hardware layer, so daemon-only code — notably the
+# ALSA paths in audio_tones.c, plus web_server/websocket/health_monitor — is
+# never compiled by `make test`. This target catches type/syntax errors in that
+# code on any Linux box with libasound2-dev (e.g. CI), short of a full link.
+COMPILE_CHECK_OBJS = daemon.o daemon_state.o millennium_sdk.o events.o \
+	event_processor.o config.o logger.o health_monitor.o metrics.o \
+	metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o \
+	plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o \
+	plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o \
+	plugins/trivia.o state_persistence.o display_manager.o version.o \
+	audio_tones.o updater.o
+
+.PHONY: compile-check
+compile-check: $(COMPILE_CHECK_OBJS)
+	@echo "compile-check OK: all daemon sources (except pjsip_interface) compiled"
+
 clean:
 	rm -rf *.o daemon simulator unit_tests pjsip_smoke plugins/*.o tests/*.o
 


### PR DESCRIPTION
## Problem

CI built only the **simulator** and **unit tests**, both of which stub out the hardware layer (`simulator.c` provides its own `audio_tones_*`, etc.). So the real daemon translation units were **never compiled by CI**:

- `audio_tones.c` (the ALSA tone paths — e.g. today's earpiece-routing change)
- `web_server.c`, `websocket.c`, `health_monitor.c`, `metrics_server.c`
- `daemon.c`, `millennium_sdk.c`

A type or syntax error in any of them passed CI green and only broke later on the Pi's `make daemon`. The fix for today's audio change had to be validated by hand-building on the Pi for exactly this reason.

## Change

- New `compile-check` make target compiles **every daemon TU except `pjsip_interface.o`** (the only one that needs `libpjproject`, which isn't available off the Pi).
- CI runs it after installing `libasound2-dev` (already a CI dependency) — no new tooling.

## Coverage after this

| Build | Before | After |
|-------|--------|-------|
| simulator + unit tests (stubbed) | ✅ | ✅ |
| `audio_tones.c` / web / websocket / health / daemon / sdk | ❌ never compiled | ✅ compile-checked |
| `pjsip_interface.c` (needs PJSIP) | ❌ | ❌ (still Pi-only) |

## Testing

Ran `make compile-check` on a Linux+ALSA box — exit 0, all listed sources compile. It surfaced some **pre-existing `-Wmaybe-uninitialized` warnings in `websocket.c`** (base64/digest); left for a follow-up since the target fails only on hard errors, not warnings.

## Known remaining gaps (follow-ups, not in this PR)

- `pjsip_interface.c` still isn't compiled in CI (would need libpjproject installed/built in the runner).
- No `-Werror` yet (blocked on the websocket warnings above).
- Arduino sketches aren't compiled in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)