### PR TITLE
web/metrics: serve dashboard on port 80, re-enable metrics server

### DIFF
--- a/.claude/skills/deploy-arduino/SKILL.md
+++ b/.claude/skills/deploy-arduino/SKILL.md
@@ -40,7 +40,7 @@ the Mac.
 
 3. **Verify** after flashing — the display should re-init and the daemon should
    resume seeing serial events. Quick check (see the `phone-status` skill):
-   `curl -s http://<pi>:8081/api/state`, then lift/replace the handset and
+   `curl -s http://<pi>:80/api/state`, then lift/replace the handset and
    confirm `HU`/`HD` hook events appear in `journalctl -u daemon.service -f`.
 
 ## Notes

--- a/.claude/skills/deploy-daemon/SKILL.md
+++ b/.claude/skills/deploy-daemon/SKILL.md
@@ -26,7 +26,7 @@ non-interactive key in this environment (passwordless sudo on the Pi).
 
 Pi layout: scratch build dir `~/millennium-pjsip/host` · installed binary
 `/usr/local/bin/millennium-daemon` · systemd unit `daemon.service` · config
-`/etc/millennium/daemon.conf` · web API on `:8081`, metrics on `:8080`.
+`/etc/millennium/daemon.conf` · web API on `:80`, metrics on `:8080`.
 
 ## Steps
 
@@ -63,7 +63,7 @@ Pi layout: scratch build dir `~/millennium-pjsip/host` · installed binary
    ```bash
    $SSH $PI 'systemctl is-active daemon.service; \
      echo NRestarts=$(systemctl show daemon.service -p NRestarts --value); \
-     curl -s --max-time 4 http://127.0.0.1:8081/api/state'
+     curl -s --max-time 4 http://127.0.0.1:80/api/state'
    ```
    Expect `active`, `NRestarts=0`, `"sip_registered":1`, empty `sip_last_error`.
    On failure: check `sip.*` keys in `/etc/millennium/daemon.conf` and

--- a/.claude/skills/phone-status/SKILL.md
+++ b/.claude/skills/phone-status/SKILL.md
@@ -26,7 +26,7 @@ $SSH $PI '
   echo "== service =="; systemctl is-active daemon.service; \
   echo "NRestarts=$(systemctl show daemon.service -p NRestarts --value)"; \
   echo "uptime: $(systemctl show daemon.service -p ActiveEnterTimestamp --value)"; \
-  echo "== state =="; curl -s --max-time 4 http://127.0.0.1:8081/api/state; echo; \
+  echo "== state =="; curl -s --max-time 4 http://127.0.0.1:80/api/state; echo; \
   echo "== recent errors =="; \
   sudo journalctl -u daemon.service --since "10 min ago" --no-pager \
     | grep -iE "error|fail|warn|segf|core|underrun" | tail -15'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Single-process C daemon. Key files:
 | `plugin_sdk.c` / `plugin_sdk.h` | Friendly facade for plugin authors (display, audio, calls, state, balance, logging, RNG) — see `host/PLUGIN_AUTHORING.md` |
 | `display_manager.c` | VFD abstraction with auto-scrolling for lines >20 chars |
 | `audio_tones.c` | ALSA tone generator: dial tone, DTMF, ringback, busy, coin chime |
-| `web_server.c` | HTTP+WebSocket server on port 8081; REST API + real-time events |
+| `web_server.c` | HTTP+WebSocket server on port 80; REST API + real-time events |
 | `metrics.c` / `metrics_server.c` | Prometheus/JSON metrics on port 8080 |
 | `health_monitor.c` | Background checks: serial connection, SIP registration |
 | `config.c` | `key=value` config file parser with environment variable fallback |
@@ -142,7 +142,7 @@ New plugins should be written against `plugin_sdk.h`, which wraps the hardware/s
 
 ### Web API
 
-Base URL: `http://<pi>:8081`
+Base URL: `http://<pi>` (port 80)
 
 - `GET /api/state` — phone state, coins, keypad, SIP status
 - `GET /api/metrics` — Prometheus or JSON metrics
@@ -162,7 +162,7 @@ Pure ALSA (`libasound`), no PipeWire. Left channel → ringer (TDA2822M ch A), r
 
 ## Configuration
 
-Config file: `/etc/millennium/daemon.conf` (key=value). See `host/daemon.conf.example` for all options. Key settings: `hardware.display_device`, `call.cost_cents`, `call.free_numbers`, `card.enabled`, `web_server.port` (8081), `metrics_server.port` (8080), `persistence.state_file`.
+Config file: `/etc/millennium/daemon.conf` (key=value). See `host/daemon.conf.example` for all options. Key settings: `hardware.display_device`, `call.cost_cents`, `call.free_numbers`, `card.enabled`, `web_server.port` (80, via `CAP_NET_BIND_SERVICE`), `metrics_server.port` (8080), `persistence.state_file`.
 
 ## PCB Design (`pcb/`)
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This project reimagines the functionality of the Nortel Millennium telephone by 
 ┌────────────────────────── Raspberry Pi Zero 2 W ───────────────────────────┐
 │                                                                            │
 │  ┌──────────────┐     ┌──────────────┐      ┌──────────────────────────┐   │
-│  │ Daemon       │────▶│ PJSIP (VoIP) │      │ Web Dashboard :8081      │   │
+│  │ Daemon       │────▶│ PJSIP (VoIP) │      │ Web Dashboard :80        │   │
 │  │              │     └──────────────┘      │                          │   │
 │  │ Plugins:     │                           │ - phone state            │   │
 │  │ - Phone      │     ┌──────────────┐      │ - plugin switching       │   │
@@ -150,7 +150,7 @@ The daemon reads configuration from `/etc/millennium/daemon.conf`. See `host/dae
 | `card.free_cards` | *(empty)* | Comma-separated card numbers for free calling |
 | `card.admin_cards` | *(empty)* | Comma-separated card numbers for admin access |
 | `web_server.enabled` | `true` | Enable the web dashboard |
-| `web_server.port` | `8081` | Web dashboard port |
+| `web_server.port` | `80` | Web dashboard port |
 | `system.source_dir` | `/home/matzen/millennium` | Source directory for OTA updates |
 
 ---

--- a/host/BUILD_SUCCESS.md
+++ b/host/BUILD_SUCCESS.md
@@ -84,18 +84,18 @@ on the Pi, in the scenario simulator, and in unit tests. See
 
 ### Plugin Switching Commands
 ```bash
-# Switch to Fortune Teller (web dashboard/API is port 8081)
-curl -X POST http://localhost:8081/api/control \
+# Switch to Fortune Teller (web dashboard/API is port 80)
+curl -X POST http://localhost:80/api/control \
   -H "Content-Type: application/json" \
   -d '{"action": "activate_plugin:Fortune Teller"}'
 
 # Switch to Jukebox
-curl -X POST http://localhost:8081/api/control \
+curl -X POST http://localhost:80/api/control \
   -H "Content-Type: application/json" \
   -d '{"action": "activate_plugin:Jukebox"}'
 
 # Return to Classic Phone
-curl -X POST http://localhost:8081/api/control \
+curl -X POST http://localhost:80/api/control \
   -H "Content-Type: application/json" \
   -d '{"action": "activate_plugin:Classic Phone"}'
 ```
@@ -106,7 +106,7 @@ curl -X POST http://localhost:8081/api/control \
 ./daemon
 
 # Access web portal
-# http://localhost:8081   (metrics are on 8080)
+# http://localhost:80   (metrics are on 8080)
 ```
 
 ## Architecture Benefits

--- a/host/DEVICE_TEST.md
+++ b/host/DEVICE_TEST.md
@@ -10,7 +10,7 @@ Run integration tests against the real Millennium payphone when it's connected a
 ## Prerequisites
 
 - Daemon running on the device (`sudo systemctl status daemon.service`)
-- Device reachable on the network (port 8081 for HTTP API)
+- Device reachable on the network (port 80 for HTTP API)
 
 ## Run API Tests (from your machine)
 
@@ -38,5 +38,5 @@ ssh matzen@192.168.86.145 'cd millennium/host && make api-test'
 If tests fail with "Cannot reach":
 
 1. Check daemon is running: `ssh matzen@192.168.86.145 'sudo systemctl status daemon.service'`
-2. Verify port 8081 is listening: `ssh matzen@192.168.86.145 'ss -tlnp | grep 8081'`
-3. Confirm network connectivity: `curl -s http://192.168.86.145:8081/api/health`
+2. Verify port 80 is listening: `ssh matzen@192.168.86.145 'ss -tlnp | grep ":80 "'`
+3. Confirm network connectivity: `curl -s http://192.168.86.145/api/health`

--- a/host/PLUGIN_SYSTEM_SUMMARY.md
+++ b/host/PLUGIN_SYSTEM_SUMMARY.md
@@ -51,10 +51,10 @@ Game plugins read optional per-plugin settings from `daemon.conf` (see
 
 ## Switching plugins
 
-From the dashboard (`http://<pi>:8081`) use the **Plugins** panel, or via REST:
+From the dashboard (`http://<pi>:80`) use the **Plugins** panel, or via REST:
 
 ```bash
-curl -X POST http://<pi>:8081/api/control \
+curl -X POST http://<pi>:80/api/control \
   -H 'Content-Type: application/json' \
   -d '{"action":"activate_plugin","plugin":"Trivia"}'
 ```

--- a/host/SETUP.md
+++ b/host/SETUP.md
@@ -142,7 +142,7 @@ hardware.baud_rate=9600
 call.cost_cents=50
 call.timeout_seconds=300
 web_server.enabled=true
-web_server.port=8081
+web_server.port=80
 ```
 
 The `hardware.display_device` path depends on the Arduino's USB product name.
@@ -193,7 +193,7 @@ systemctl --user start daemon.service
 
 Ensure `/etc/millennium/daemon.conf` exists: `sudo cp daemon.conf.example /etc/millennium/daemon.conf`.
 
-The web dashboard should now be accessible at `http://<pi-ip>:8081`.
+The web dashboard should now be accessible at `http://<pi-ip>:80`.
 
 ## 10. Disable unused services (optional cleanup)
 
@@ -221,7 +221,7 @@ systemctl --user disable audio-mux.service
    through the handset earpiece. If no audio, verify the ALSA config and USB
    audio card detection.
 
-4. **Web dashboard**: Open `http://<pi-ip>:8081` in a browser. You should see
+4. **Web dashboard**: Open `http://<pi-ip>:80` in a browser. You should see
    the phone state, active plugin, and health status.
 
 5. **API integration test**: From the Pi (or any machine that can reach it):

--- a/host/config.c
+++ b/host/config.c
@@ -433,5 +433,6 @@ int config_get_web_server_enabled(const config_data_t* config) {
 }
 
 int config_get_web_server_port(const config_data_t* config) {
-    return config_get_int(config, "web_server.port", 8081);
+    /* Privileged port 80; the systemd unit grants CAP_NET_BIND_SERVICE. */
+    return config_get_int(config, "web_server.port", 80);
 }

--- a/host/daemon.conf.example
+++ b/host/daemon.conf.example
@@ -58,14 +58,17 @@ system.source_dir=/home/matzen/millennium
 # State Persistence
 persistence.state_file=/var/lib/millennium/state
 
-# Metrics Server Configuration - DISABLED for single-core optimization
-# Metrics are now collected in the main loop instead of a separate thread
-metrics_server.enabled=false
+# Metrics Server Configuration
+# Standalone Prometheus/JSON metrics endpoint. (Metrics are also always exposed
+# via the web server at /api/metrics regardless of this setting.) Was disabled
+# on the single-core Pi Zero W; re-enabled after the multicore upgrade.
+metrics_server.enabled=true
 metrics_server.port=8080
 
 # Web Server Configuration
+# Port 80 (privileged) — granted via CAP_NET_BIND_SERVICE in the systemd unit.
 web_server.enabled=true
-web_server.port=8081
+web_server.port=80
 
 # Plugin Configuration
 # Each plugin can read its own keys from this file. Built-in game plugins:

--- a/host/systemd/daemon.service
+++ b/host/systemd/daemon.service
@@ -21,6 +21,14 @@ StandardError=journal
 PrivateDevices=no
 ProtectSystem=no
 NoNewPrivileges=no
+# Capabilities for the non-root daemon user (User= comes from the install-time
+# daemon.service.d/override.conf):
+#   CAP_NET_BIND_SERVICE — bind the web dashboard on privileged port 80
+#   CAP_SYS_NICE + CAP_IPC_LOCK / LimitRTPRIO + LimitMEMLOCK — real-time audio
+#     scheduling and mlock for the ALSA threads
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_SYS_NICE CAP_IPC_LOCK
+LimitRTPRIO=99
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=default.target

--- a/host/tests/api_test.sh
+++ b/host/tests/api_test.sh
@@ -8,7 +8,7 @@
 
 set -e
 HOST="${HOST:-${1:-localhost}}"
-BASE="http://${HOST}:8081"
+BASE="http://${HOST}:80"
 FAILED=0
 
 run() {

--- a/host/tests/break_test.sh
+++ b/host/tests/break_test.sh
@@ -4,7 +4,7 @@
 # Verifies: daemon doesn't crash, JSON responses stay valid
 set -e
 HOST="${HOST:-${1:-192.168.86.145}}"
-BASE="http://${HOST}:8081"
+BASE="http://${HOST}:80"
 FAILED=0
 
 # Verify JSON is parseable (python -c "import json; json.loads(...)")


### PR DESCRIPTION
## Summary

- **Dashboard moved to port 80** so the bare `http://<pi>` URL works (no `:8081`).
- **Metrics server re-enabled** on `:8080` — it had been disabled "for single-core optimization," which no longer applies after the **multicore upgrade**.

## Changes

**Port 80**
- `host/systemd/daemon.service`: add `CAP_NET_BIND_SERVICE` (lets the non-root daemon user bind the privileged port) plus the RT-audio caps/limits (`CAP_SYS_NICE`, `CAP_IPC_LOCK`, `LimitRTPRIO`, `LimitMEMLOCK`) that were previously only hand-set on the device and missing from the repo — so a fresh `make install` now reproduces the working config.
- `host/config.c` default and `host/daemon.conf.example`: `web_server.port` → `80`.

**Metrics**
- `host/daemon.conf.example`: `metrics_server.enabled` → `true`, comment updated for the multicore upgrade. (Metrics are also always at `:80/api/metrics` via the web server.)

**Docs/skills/tests swept off `:8081`**
- `CLAUDE.md`, `README.md`, `host/SETUP.md`, `host/DEVICE_TEST.md`, `host/BUILD_SUCCESS.md`, `host/PLUGIN_SYSTEM_SUMMARY.md`
- `.claude/skills/{phone-status,deploy-daemon,deploy-arduino}`
- `host/tests/api_test.sh`, `host/tests/break_test.sh`

## Testing

Applied live on the Pi and verified from another host:
```
http://192.168.86.152/            -> 200
http://192.168.86.152/api/state   -> 200
http://192.168.86.152:8080/api/metrics -> 200
```
Daemon `active`, `NRestarts=0`, SIP registered. `make test` passes locally.

> Note: the live device config (`/etc/millennium/daemon.conf`, the systemd drop-in) was edited directly and backed up (`*.bak`); this PR brings the repo in line with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)