### PR TITLE
pjsip: tighten audio buffering + raise resample quality (multicore)

### DIFF
--- a/host/pjsip_interface.c
+++ b/host/pjsip_interface.c
@@ -191,11 +191,17 @@ int pjsip_iface_start(const pjsip_iface_account_t *acc,
      * the resample under the audio thread. */
     media_cfg.snd_clock_rate = 48000;
     media_cfg.channel_count = 1;        /* mono handset */
-    /* Big playback buffer: the playback ALSA chain (route+softvol+dmix) starves
-     * on this single core and underruns (crackle). A larger buffer absorbs the
-     * scheduling jitter, trading a little extra audio latency for clean sound. */
-    media_cfg.snd_play_latency = 200;
-    media_cfg.snd_rec_latency = 100;
+    /* Higher resampler quality for cleaner 8<->48 kHz conversion. The CPU cost
+     * of the larger resample filter is fine after the multicore upgrade (it was
+     * what the old single-core build avoided). 10 = best. */
+    media_cfg.quality = 10;
+    /* Playback/capture buffering. These were inflated (200/100 ms) on the old
+     * single core so the ALSA chain (route+softvol+dmix) wouldn't starve and
+     * underrun (crackle). The multicore CPU no longer needs that cushion, so
+     * trim them for noticeably lower call latency. If crackle returns under
+     * load, raise snd_play_latency back toward 200. */
+    media_cfg.snd_play_latency = 120;
+    media_cfg.snd_rec_latency = 60;
     /* No echo canceller: this is a handset (not a speakerphone), so AEC isn't
      * needed and only muddies the audio and burns CPU on the single-core Pi.
      * baresip ran with no AEC module, so this restores that behaviour. */


### PR DESCRIPTION
## Summary

Revisits the PJSIP media config settings that were conservatively tuned for the **old single-core CPU**, now that the phone runs on the **multicore board**. Goal: better call audio (lower latency + cleaner resampling).

## Changes (`pjsip_interface.c`)

| Setting | Before | After | Why |
|---------|--------|-------|-----|
| `snd_play_latency` | 200 ms | **120 ms** | Big buffer only existed to stop the route+softvol+dmix chain underrunning on one core; multicore has headroom → lower call latency |
| `snd_rec_latency` | 100 ms | **60 ms** | same |
| `media_cfg.quality` | default | **10** | higher-quality 8↔48 kHz resampler; CPU cost the single-core build avoided |

**Left unchanged on purpose:** `ec_tail_len=0` (no AEC — correct for a *handset*, not a CPU saving), `snd_auto_close_time=0` (frees ALSA for the tone generator between calls), and `clock_rate=8000` (true wideband needs a wideband codec negotiated with the provider — a separate change).

## Testing

Built on the Pi and deployed; **call audio confirmed clearer and snappier by ear, no crackle**. Daemon `active`, SIP registered. Note `pjsip_interface.c` only compiles on the Pi (needs libpjproject), so it isn't covered by the Mac/CI build — validated by the on-device build + a live call.

If underruns/crackle reappear under load, bump `snd_play_latency` back toward 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)