### PR TITLE
feat(dashboard): redesign as a telecom control unit

### DIFF
--- a/host/web_portal.html
+++ b/host/web_portal.html
@@ -1,1298 +1,634 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Millennium System Portal</title>
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        body {
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            min-height: 100vh;
-            color: #333;
-        }
-
-        .container {
-            max-width: 1400px;
-            margin: 0 auto;
-            padding: 20px;
-        }
-
-        .header {
-            background: rgba(255, 255, 255, 0.95);
-            border-radius: 15px;
-            padding: 20px;
-            margin-bottom: 20px;
-            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
-            backdrop-filter: blur(10px);
-        }
-
-        .header h1 {
-            color: #2c3e50;
-            text-align: center;
-            margin-bottom: 10px;
-            font-size: 2.5em;
-            font-weight: 300;
-        }
-
-        .status-bar {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            flex-wrap: wrap;
-            gap: 15px;
-        }
-
-        .status-item {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            padding: 8px 16px;
-            background: rgba(255, 255, 255, 0.8);
-            border-radius: 20px;
-            font-weight: 500;
-        }
-
-        .status-indicator {
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-            animation: pulse 2s infinite;
-        }
-
-        .status-healthy { background-color: #27ae60; }
-        .status-warning { background-color: #f39c12; }
-        .status-critical { background-color: #e74c3c; }
-        .status-unknown { background-color: #95a5a6; }
-
-        @keyframes pulse {
-            0% { opacity: 1; }
-            50% { opacity: 0.5; }
-            100% { opacity: 1; }
-        }
-
-        .dashboard {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-            gap: 20px;
-            margin-bottom: 20px;
-        }
-
-        .card {
-            background: rgba(255, 255, 255, 0.95);
-            border-radius: 15px;
-            padding: 25px;
-            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
-            backdrop-filter: blur(10px);
-            transition: transform 0.3s ease, box-shadow 0.3s ease;
-        }
-
-        .card:hover {
-            transform: translateY(-5px);
-            box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
-        }
-
-        .card h2 {
-            color: #2c3e50;
-            margin-bottom: 20px;
-            font-size: 1.4em;
-            font-weight: 500;
-            border-bottom: 2px solid #ecf0f1;
-            padding-bottom: 10px;
-        }
-
-        .system-state {
-            text-align: center;
-        }
-
-        .state-display {
-            font-size: 3em;
-            font-weight: bold;
-            margin: 20px 0;
-            padding: 20px;
-            border-radius: 10px;
-            background: linear-gradient(45deg, #3498db, #2980b9);
-            color: white;
-            text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-        }
-
-        .state-idle { background: linear-gradient(45deg, #95a5a6, #7f8c8d); }
-        .state-call-incoming { background: linear-gradient(45deg, #f39c12, #e67e22); }
-        .state-call-active { background: linear-gradient(45deg, #27ae60, #2ecc71); }
-
-        .metrics-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-            gap: 15px;
-        }
-
-        .metric-item {
-            text-align: center;
-            padding: 15px;
-            background: rgba(52, 152, 219, 0.1);
-            border-radius: 10px;
-            border-left: 4px solid #3498db;
-        }
-
-        .metric-value {
-            font-size: 1.8em;
-            font-weight: bold;
-            color: #2c3e50;
-        }
-
-        .metric-label {
-            font-size: 0.9em;
-            color: #7f8c8d;
-            margin-top: 5px;
-        }
-
-        .health-checks {
-            max-height: 300px;
-            overflow-y: auto;
-        }
-
-        .health-item {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            padding: 12px;
-            margin-bottom: 8px;
-            background: rgba(236, 240, 241, 0.5);
-            border-radius: 8px;
-            border-left: 4px solid #bdc3c7;
-        }
-
-        .health-item.healthy { border-left-color: #27ae60; }
-        .health-item.warning { border-left-color: #f39c12; }
-        .health-item.critical { border-left-color: #e74c3c; }
-
-        .control-panel {
-            grid-column: 1 / -1;
-        }
-
-        .control-buttons {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-            gap: 15px;
-        }
-
-        .btn {
-            padding: 12px 20px;
-            border: none;
-            border-radius: 8px;
-            font-size: 1em;
-            font-weight: 500;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-
-        .btn-primary {
-            background: linear-gradient(45deg, #3498db, #2980b9);
-            color: white;
-        }
-
-        .btn-success {
-            background: linear-gradient(45deg, #27ae60, #2ecc71);
-            color: white;
-        }
-
-        .btn-warning {
-            background: linear-gradient(45deg, #f39c12, #e67e22);
-            color: white;
-        }
-
-        .btn-danger {
-            background: linear-gradient(45deg, #e74c3c, #c0392b);
-            color: white;
-        }
-
-        .btn:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
-        }
-
-        .btn:active {
-            transform: translateY(0);
-        }
-
-        /* Hardware Simulation Styles */
-        .simulation-section {
-            margin-bottom: 20px;
-            padding: 15px;
-            background: rgba(236, 240, 241, 0.3);
-            border-radius: 8px;
-            border-left: 4px solid #3498db;
-        }
-
-        /* Plugin Management Styles */
-        .plugin-section {
-            margin-bottom: 20px;
-            padding: 15px;
-            background: rgba(155, 89, 182, 0.1);
-            border-radius: 8px;
-            border-left: 4px solid #9b59b6;
-        }
-
-        .plugin-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 15px;
-            margin-bottom: 15px;
-        }
-
-        .plugin-card {
-            background: white;
-            border-radius: 8px;
-            padding: 15px;
-            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-            border: 2px solid transparent;
-            transition: all 0.3s ease;
-        }
-
-        .plugin-card.active {
-            border-color: #27ae60;
-            background: rgba(39, 174, 96, 0.05);
-        }
-
-        .plugin-card:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);
-        }
-
-        .plugin-name {
-            font-weight: bold;
-            font-size: 1.1em;
-            color: #2c3e50;
-            margin-bottom: 8px;
-        }
-
-        .plugin-description {
-            color: #7f8c8d;
-            font-size: 0.9em;
-            margin-bottom: 12px;
-            line-height: 1.4;
-        }
-
-        .plugin-status {
-            display: inline-block;
-            padding: 4px 8px;
-            border-radius: 12px;
-            font-size: 0.8em;
-            font-weight: bold;
-            text-transform: uppercase;
-        }
-
-        .plugin-status.active {
-            background: #27ae60;
-            color: white;
-        }
-
-        .plugin-status.inactive {
-            background: #95a5a6;
-            color: white;
-        }
-
-        .simulation-section h3 {
-            color: #2c3e50;
-            margin-bottom: 10px;
-            font-size: 1.1em;
-            font-weight: 500;
-        }
-
-        .keypad-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 10px;
-            margin-bottom: 15px;
-            max-width: 200px;
-        }
-
-        .keypad-btn {
-            padding: 15px;
-            border: 2px solid #bdc3c7;
-            border-radius: 8px;
-            background: linear-gradient(45deg, #ecf0f1, #bdc3c7);
-            font-size: 1.2em;
-            font-weight: bold;
-            cursor: pointer;
-            transition: all 0.3s ease;
-            color: #2c3e50;
-        }
-
-        .keypad-btn:hover {
-            background: linear-gradient(45deg, #3498db, #2980b9);
-            color: white;
-            transform: translateY(-2px);
-            box-shadow: 0 4px 15px rgba(52, 152, 219, 0.3);
-        }
-
-        .keypad-btn:active {
-            transform: translateY(0);
-            box-shadow: 0 2px 8px rgba(52, 152, 219, 0.3);
-        }
-
-        .keypad-controls {
-            display: flex;
-            gap: 10px;
-        }
-
-        .coin-reader-controls {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-            gap: 8px;
-        }
-
-        .handset-controls {
-            display: flex;
-            gap: 10px;
-        }
-
-        .logs-panel {
-            grid-column: 1 / -1;
-            max-height: 400px;
-            overflow-y: auto;
-        }
-
-        .log-entry {
-            padding: 8px 12px;
-            margin-bottom: 4px;
-            border-radius: 4px;
-            font-family: 'Courier New', monospace;
-            font-size: 0.9em;
-            border-left: 3px solid #bdc3c7;
-        }
-
-        .log-info { border-left-color: #3498db; background: rgba(52, 152, 219, 0.1); }
-        .log-warn { border-left-color: #f39c12; background: rgba(243, 156, 18, 0.1); }
-        .log-error { border-left-color: #e74c3c; background: rgba(231, 76, 60, 0.1); }
-        .log-debug { border-left-color: #95a5a6; background: rgba(149, 165, 166, 0.1); }
-
-        .config-panel {
-            grid-column: 1 / -1;
-        }
-
-        .config-section {
-            margin-bottom: 20px;
-        }
-
-        .config-section h3 {
-            color: #2c3e50;
-            margin-bottom: 10px;
-            font-size: 1.1em;
-        }
-
-        .config-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 15px;
-        }
-
-        .config-item {
-            display: flex;
-            flex-direction: column;
-        }
-
-        .config-label {
-            font-weight: 500;
-            margin-bottom: 5px;
-            color: #34495e;
-        }
-
-        .config-value {
-            padding: 8px 12px;
-            background: rgba(236, 240, 241, 0.5);
-            border-radius: 4px;
-            font-family: 'Courier New', monospace;
-            font-size: 0.9em;
-            word-break: break-all;
-            overflow-wrap: break-word;
-            max-width: 100%;
-        }
-
-        .loading {
-            text-align: center;
-            padding: 20px;
-            color: #7f8c8d;
-        }
-
-        .error {
-            background: rgba(231, 76, 60, 0.1);
-            color: #c0392b;
-            padding: 15px;
-            border-radius: 8px;
-            border-left: 4px solid #e74c3c;
-            margin: 10px 0;
-        }
-
-        .refresh-indicator {
-            position: fixed;
-            top: 20px;
-            right: 20px;
-            background: rgba(255, 255, 255, 0.9);
-            padding: 10px 15px;
-            border-radius: 20px;
-            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
-            font-size: 0.9em;
-            color: #7f8c8d;
-            z-index: 1000;
-        }
-
-        .notification-container {
-            position: fixed;
-            top: 20px;
-            left: 50%;
-            transform: translateX(-50%);
-            z-index: 2000;
-            max-width: 400px;
-            width: 90%;
-        }
-
-        .notification {
-            margin-bottom: 10px;
-            padding: 15px 20px;
-            border-radius: 8px;
-            box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
-            font-weight: 500;
-            animation: slideIn 0.3s ease-out;
-        }
-
-        .notification.success {
-            background: linear-gradient(45deg, #27ae60, #2ecc71);
-            color: white;
-        }
-
-        .notification.error {
-            background: linear-gradient(45deg, #e74c3c, #c0392b);
-            color: white;
-        }
-
-        .notification.warning {
-            background: linear-gradient(45deg, #f39c12, #e67e22);
-            color: white;
-        }
-
-        @keyframes slideIn {
-            from {
-                opacity: 0;
-                transform: translateY(-20px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @media (max-width: 768px) {
-            .container {
-                padding: 10px;
-            }
-            
-            .dashboard {
-                grid-template-columns: 1fr;
-            }
-            
-            .status-bar {
-                flex-direction: column;
-                align-items: stretch;
-            }
-            
-            .control-buttons {
-                grid-template-columns: 1fr;
-            }
-        }
-    </style>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MILLENNIUM · Control Unit</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+<style>
+/* ======================================================================
+   MILLENNIUM PAYPHONE — operator control unit
+   Aesthetic: powered-on telecom equipment faceplate + VFD phosphor display
+   ====================================================================== */
+:root{
+  --bg:#080b0a;
+  --bg-2:#0b110f;
+  --panel:#101816;
+  --panel-2:#0c1311;
+  --bezel:#1b2a26;
+  --hairline:rgba(120,210,182,.12);
+  --hairline-2:rgba(120,210,182,.05);
+  --ink:#dcf2ea;
+  --ink-dim:#9ab8b0;
+  --ink-faint:#7c938c;
+  --phos:#4ff0c4;          /* VFD phosphor cyan-green — primary signal */
+  --phos-deep:#179c7d;
+  --amber:#ffb454;         /* coins / money / warn */
+  --amber-deep:#b87a23;
+  --red:#ff5d6e;           /* critical / hangup */
+  --blue:#62cbff;
+  --font-d:'Chakra Petch','Segoe UI',system-ui,sans-serif;
+  --font-m:'Share Tech Mono',ui-monospace,'Courier New',monospace;
+  --shadow:0 18px 40px -20px rgba(0,0,0,.9);
+}
+*{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  font-family:var(--font-d);
+  background:var(--bg);
+  color:var(--ink);
+  min-height:100vh;
+  letter-spacing:.2px;
+  -webkit-font-smoothing:antialiased;
+  background-image:
+    radial-gradient(1200px 700px at 78% -10%, rgba(31,174,143,.10), transparent 60%),
+    radial-gradient(900px 600px at 8% 110%, rgba(255,180,84,.05), transparent 55%),
+    linear-gradient(180deg,#0a0f0d 0%, #070a09 100%);
+  background-attachment:fixed;
+}
+/* atmosphere overlays --------------------------------------------------- */
+.grain,.scan{position:fixed;inset:0;pointer-events:none;z-index:9000}
+.grain{
+  opacity:.05;mix-blend-mode:overlay;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+.scan{
+  opacity:.35;
+  background:repeating-linear-gradient(to bottom,rgba(0,0,0,0) 0,rgba(0,0,0,0) 2px,rgba(0,0,0,.16) 3px,rgba(0,0,0,0) 4px);
+  animation:scandrift 9s linear infinite;
+}
+@keyframes scandrift{from{background-position:0 0}to{background-position:0 8px}}
+body::after{content:"";position:fixed;inset:0;pointer-events:none;z-index:9001;
+  box-shadow:inset 0 0 220px 40px rgba(0,0,0,.65)}
+
+/* ====================  FACEPLATE HEADER  ============================== */
+.faceplate{
+  position:relative;
+  display:flex;align-items:center;gap:28px;flex-wrap:wrap;
+  padding:18px 26px;
+  background:
+    linear-gradient(180deg, rgba(255,255,255,.025), transparent 40%),
+    linear-gradient(180deg,#0f1715,#0a100e);
+  border-bottom:1px solid var(--bezel);
+  box-shadow:0 1px 0 rgba(255,255,255,.03), var(--shadow);
+}
+.faceplate::before{ /* faceplate screw heads */
+  content:"";position:absolute;left:12px;top:12px;width:7px;height:7px;border-radius:50%;
+  background:radial-gradient(circle at 35% 30%,#2c3a36,#070b0a);box-shadow:
+    calc(100vw - 31px) 0 0 #070b0a, 0 0 0 1px rgba(0,0,0,.6),
+    inset 0 0 0 1px rgba(255,255,255,.05);}
+.brand{display:flex;flex-direction:column;gap:3px;min-width:max-content}
+.brand .mark{display:flex;align-items:baseline;gap:10px}
+.brand h1{
+  font-size:26px;font-weight:700;letter-spacing:7px;
+  color:#e9fbf4;text-shadow:0 0 22px rgba(79,240,196,.25);
+}
+.brand h1 b{color:var(--phos);font-weight:700}
+.brand .diamond{color:var(--phos);font-size:13px;transform:translateY(-2px);
+  filter:drop-shadow(0 0 6px var(--phos))}
+.brand .sub{font-family:var(--font-m);font-size:10.5px;letter-spacing:3px;color:var(--ink-faint);text-transform:uppercase}
+.spacer{flex:1}
+/* LED strip */
+.leds{display:flex;gap:18px;align-items:center}
+.led-unit{display:flex;align-items:center;gap:9px}
+.led{width:11px;height:11px;border-radius:50%;flex:none;
+  background:radial-gradient(circle at 35% 30%, #1a2422, #0a0f0e);
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.7), 0 0 0 1px rgba(255,255,255,.03);
+  transition:.4s}
+.led.on{background:radial-gradient(circle at 35% 30%, #b9ffe9, var(--phos) 55%, var(--phos-deep));
+  box-shadow:0 0 10px var(--phos),0 0 20px rgba(79,240,196,.5),inset 0 0 2px rgba(255,255,255,.6)}
+.led.warn{background:radial-gradient(circle at 35% 30%,#ffe2b0,var(--amber) 55%,var(--amber-deep));
+  box-shadow:0 0 10px var(--amber),0 0 20px rgba(255,180,84,.45),inset 0 0 2px rgba(255,255,255,.6)}
+.led.bad{background:radial-gradient(circle at 35% 30%,#ffb8c1,var(--red) 55%,#a02431);
+  box-shadow:0 0 10px var(--red),0 0 20px rgba(255,93,110,.45)}
+.led.pulse{animation:ledpulse 1.1s ease-in-out infinite}
+@keyframes ledpulse{0%,100%{opacity:1}50%{opacity:.35}}
+.led-unit span{font-family:var(--font-m);font-size:10px;letter-spacing:2px;color:var(--ink-dim);text-transform:uppercase}
+.readout-strip{display:flex;gap:26px;align-items:center;font-family:var(--font-m)}
+.ro{display:flex;flex-direction:column;gap:1px;line-height:1.1}
+.ro .k{font-size:9px;letter-spacing:2px;color:var(--ink-faint);text-transform:uppercase}
+.ro .v{font-size:14px;color:var(--ink);text-shadow:0 0 8px rgba(79,240,196,.15)}
+
+/* ========================  RACK / GRID  ============================== */
+.rack{
+  display:grid;gap:16px;padding:22px;
+  grid-template-columns:repeat(12,1fr);
+  max-width:1560px;margin:0 auto;
+}
+.panel{
+  grid-column:span 4;
+  position:relative;
+  background:linear-gradient(180deg,var(--panel),var(--panel-2));
+  border:1px solid var(--bezel);
+  border-radius:7px;
+  padding:18px 18px 16px;
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.04), var(--shadow);
+  opacity:0;transform:translateY(14px);
+  animation:rise .6s cubic-bezier(.2,.7,.2,1) forwards;
+}
+@keyframes rise{to{opacity:1;transform:none}}
+.panel:nth-child(1){animation-delay:.02s}
+.panel:nth-child(2){animation-delay:.08s}
+.panel:nth-child(3){animation-delay:.14s}
+.panel:nth-child(4){animation-delay:.20s}
+.panel:nth-child(5){animation-delay:.26s}
+.panel:nth-child(6){animation-delay:.32s}
+.panel:nth-child(7){animation-delay:.38s}
+.panel:nth-child(8){animation-delay:.44s}
+.panel::before{ /* corner tick */
+  content:"";position:absolute;top:9px;right:9px;width:9px;height:9px;
+  border-top:1px solid var(--hairline);border-right:1px solid var(--hairline)}
+.col-6{grid-column:span 6}
+.col-8{grid-column:span 8}
+.col-12{grid-column:span 12}
+.phead{display:flex;align-items:center;gap:10px;margin-bottom:15px}
+.phead h2{font-size:12px;font-weight:600;letter-spacing:3.5px;color:var(--ink);text-transform:uppercase}
+.phead .tag{font-family:var(--font-m);font-size:9.5px;letter-spacing:2px;color:var(--phos-deep);
+  border:1px solid var(--hairline);border-radius:3px;padding:2px 6px;margin-left:auto;text-transform:uppercase}
+.phead .bar{flex:none;width:18px;height:2px;background:var(--phos);box-shadow:0 0 8px var(--phos)}
+.psub{font-size:11px;font-weight:600;letter-spacing:2px;color:var(--ink-dim);text-transform:uppercase;margin:14px 0 9px}
+
+/* ========================  VFD / STATE  ============================== */
+.state-line{display:flex;align-items:center;gap:14px;margin-bottom:14px}
+.state-big{
+  font-family:var(--font-m);font-size:30px;letter-spacing:1px;line-height:1;
+  color:var(--phos);text-shadow:0 0 16px rgba(79,240,196,.6);transition:.3s;
+}
+.state-big.s-idle{color:var(--phos)}
+.state-big.s-incoming{color:var(--amber);text-shadow:0 0 16px rgba(255,180,84,.6);animation:ledpulse 1s ease-in-out infinite}
+.state-big.s-active{color:#7bffb0;text-shadow:0 0 18px rgba(83,215,105,.7)}
+.state-big.s-invalid{color:var(--red);text-shadow:0 0 16px rgba(255,93,110,.6)}
+.state-tag{margin-left:auto;font-family:var(--font-m);font-size:10px;letter-spacing:2px;color:var(--ink-faint)}
+/* the VFD window */
+.vfd{
+  position:relative;border-radius:5px;padding:14px 16px;margin:4px 0 16px;
+  background:
+    linear-gradient(180deg,#04130e,#020a07);
+  border:1px solid #0c241c;
+  box-shadow:inset 0 0 22px rgba(0,0,0,.9), inset 0 0 30px rgba(8,60,46,.25), 0 0 0 1px rgba(0,0,0,.5);
+  overflow:hidden;
+}
+.vfd::after{content:"";position:absolute;inset:0;pointer-events:none;
+  background:repeating-linear-gradient(to bottom,rgba(0,0,0,0) 0,rgba(0,0,0,0) 2px,rgba(0,0,0,.25) 3px);
+  opacity:.5}
+.vfd .vfd-lbl{font-family:var(--font-m);font-size:8.5px;letter-spacing:3px;color:#3a9e80;margin-bottom:7px;text-transform:uppercase}
+.vfd-row{font-family:var(--font-m);font-size:18px;line-height:1.5;letter-spacing:3px;white-space:pre;
+  color:#62f5cb;text-shadow:0 0 9px rgba(79,240,196,.85),0 0 2px rgba(79,240,196,.9)}
+.vfd-row .cur{animation:blink 1s steps(1) infinite;color:#8bffd9}
+@keyframes blink{50%{opacity:0}}
+/* state readouts row */
+.readouts{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+.ru{background:var(--panel-2);border:1px solid var(--hairline-2);border-radius:5px;padding:11px 13px}
+.ru .rl{font-family:var(--font-m);font-size:9px;letter-spacing:2px;color:var(--ink-faint);text-transform:uppercase;margin-bottom:5px}
+.ru .rv{font-family:var(--font-m);font-size:22px;color:var(--ink);word-break:break-all;line-height:1.1}
+.ru .rv.coin{color:var(--amber);text-shadow:0 0 12px rgba(255,180,84,.4)}
+.ru .rv.buf{color:var(--phos);font-size:18px;min-height:24px}
+.ru .rv.small{font-size:14px}
+
+/* ========================  DATA ROWS  =============================== */
+.rows{display:flex;flex-direction:column}
+.row{display:flex;align-items:center;gap:10px;padding:8px 0;border-bottom:1px solid var(--hairline-2);font-family:var(--font-m);break-inside:avoid;-webkit-column-break-inside:avoid}
+.row:last-child{border-bottom:none}
+.row .rk{font-size:11px;color:var(--ink-dim);letter-spacing:1px;text-transform:uppercase;white-space:nowrap}
+.row .dots{flex:1;border-bottom:1px dotted var(--ink-faint);height:1px;margin-bottom:3px;opacity:.5}
+.row .rval{font-size:13px;color:var(--ink);text-align:right;word-break:break-all}
+.row .rval.hl{color:var(--phos)}
+.row.health{justify-content:space-between}
+.row.health .hl-name{font-size:12px;color:var(--ink);letter-spacing:.5px;text-transform:capitalize;font-family:var(--font-d);font-weight:500}
+.row.health .hl-msg{font-size:10.5px;color:var(--ink-faint);margin-top:2px}
+
+/* ========================  BUTTONS  ================================= */
+.btns{display:flex;flex-wrap:wrap;gap:9px}
+.btn{
+  font-family:var(--font-d);font-size:11.5px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;
+  color:var(--ink);cursor:pointer;
+  background:linear-gradient(180deg,#16211e,#0d1614);
+  border:1px solid var(--bezel);border-radius:5px;
+  padding:10px 15px;
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.05),0 2px 0 rgba(0,0,0,.4);
+  transition:transform .08s, box-shadow .2s, border-color .2s, color .2s;
+}
+.btn:hover{border-color:var(--phos-deep);color:#eafff8;box-shadow:inset 0 1px 0 rgba(255,255,255,.06),0 0 16px rgba(31,156,125,.35),0 2px 0 rgba(0,0,0,.4)}
+.btn:active{transform:translateY(2px);box-shadow:inset 0 2px 6px rgba(0,0,0,.5)}
+.btn.primary{border-color:var(--phos-deep);color:var(--phos)}
+.btn.good{border-color:#2c7a4e;color:#7bffb0}
+.btn.good:hover{box-shadow:0 0 16px rgba(83,215,105,.4),0 2px 0 rgba(0,0,0,.4)}
+.btn.warn{border-color:var(--amber-deep);color:var(--amber)}
+.btn.warn:hover{box-shadow:0 0 16px rgba(255,180,84,.35),0 2px 0 rgba(0,0,0,.4)}
+.btn.bad{border-color:#7a2c38;color:var(--red)}
+.btn.bad:hover{box-shadow:0 0 16px rgba(255,93,110,.4),0 2px 0 rgba(0,0,0,.4)}
+.btn:disabled{opacity:.45;cursor:wait}
+
+/* ========================  KEYPAD  ================================== */
+.keypad{display:grid;grid-template-columns:repeat(3,1fr);gap:9px;margin-bottom:12px}
+.key{
+  position:relative;aspect-ratio:1.35/1;border-radius:7px;cursor:pointer;
+  display:flex;flex-direction:column;align-items:center;justify-content:center;gap:1px;
+  background:linear-gradient(180deg,#1a2623,#0e1715);
+  border:1px solid var(--bezel);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.07),0 3px 0 #050908,0 5px 8px rgba(0,0,0,.5);
+  transition:transform .07s, box-shadow .1s;
+}
+.key .d{font-family:var(--font-m);font-size:21px;color:var(--ink);line-height:1}
+.key .l{font-family:var(--font-m);font-size:7.5px;letter-spacing:1.5px;color:var(--ink-faint);height:8px}
+.key:hover{border-color:var(--phos-deep)}
+.key:hover .d{color:var(--phos);text-shadow:0 0 10px rgba(79,240,196,.5)}
+.key:active{transform:translateY(3px);box-shadow:inset 0 2px 5px rgba(0,0,0,.6)}
+.key:disabled{opacity:.5;cursor:wait}
+
+/* ========================  PLUGINS  ================================= */
+.plugins{display:flex;flex-direction:column;gap:9px}
+.plugin{
+  position:relative;border:1px solid var(--bezel);border-radius:6px;padding:12px 13px;
+  background:var(--panel-2);transition:.25s;overflow:hidden;
+}
+.plugin::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--ink-faint);transition:.25s}
+.plugin.active{border-color:var(--phos-deep);background:linear-gradient(90deg,rgba(31,156,125,.10),var(--panel-2) 50%)}
+.plugin.active::before{background:var(--phos);box-shadow:0 0 12px var(--phos)}
+.plugin .pn{display:flex;align-items:center;gap:9px;font-weight:600;font-size:13.5px;letter-spacing:.5px;color:var(--ink)}
+.plugin.active .pn{color:#eafff8}
+.plugin .pd{font-size:11px;color:var(--ink-dim);margin:5px 0 10px;line-height:1.45;font-family:var(--font-m)}
+.plugin .pstat{font-family:var(--font-m);font-size:9px;letter-spacing:2px;text-transform:uppercase;color:var(--ink-faint);
+  border:1px solid var(--hairline);border-radius:3px;padding:1px 6px}
+.plugin.active .pstat{color:var(--phos);border-color:var(--phos-deep)}
+.plugin .btn{width:100%;margin-top:2px}
+
+/* ========================  LOGS  =================================== */
+.logbox{
+  background:#04090a;border:1px solid #0c1614;border-radius:6px;padding:10px 12px;
+  max-height:260px;overflow-y:auto;font-family:var(--font-m);font-size:11.5px;line-height:1.7;
+  box-shadow:inset 0 0 24px rgba(0,0,0,.8);
+}
+.logbox::-webkit-scrollbar{width:8px}
+.logbox::-webkit-scrollbar-track{background:transparent}
+.logbox::-webkit-scrollbar-thumb{background:#1c2c28;border-radius:4px}
+.logline{display:flex;gap:9px;padding:1px 0;white-space:nowrap;color:var(--ink-dim)}
+.logline .lt{color:var(--ink-faint)}
+.logline .lv{font-weight:700;width:46px;flex:none}
+.logline .lm{color:var(--ink);white-space:normal;word-break:break-word}
+.logline.l-info .lv{color:var(--phos)}
+.logline.l-warn .lv,.logline.l-warning .lv{color:var(--amber)}
+.logline.l-error .lv,.logline.l-critical .lv{color:var(--red)}
+.logline.l-debug .lv{color:var(--ink-faint)}
+
+.muted{color:var(--ink-faint);font-family:var(--font-m);font-size:12px;letter-spacing:1px}
+.err{color:var(--red);font-family:var(--font-m);font-size:12px}
+
+/* ====================  TOASTS / REFRESH  =========================== */
+.toasts{position:fixed;right:20px;bottom:20px;z-index:9100;display:flex;flex-direction:column;gap:8px;align-items:flex-end}
+.toast{
+  font-family:var(--font-m);font-size:12px;letter-spacing:.5px;
+  padding:11px 16px;border-radius:5px;color:var(--ink);
+  background:linear-gradient(180deg,#13201d,#0c1614);border:1px solid var(--bezel);
+  border-left:3px solid var(--phos);
+  box-shadow:var(--shadow);animation:toastin .3s cubic-bezier(.2,.8,.2,1);max-width:340px;
+}
+.toast.success{border-left-color:var(--phos)}
+.toast.warning{border-left-color:var(--amber)}
+.toast.error{border-left-color:var(--red)}
+@keyframes toastin{from{opacity:0;transform:translateX(24px)}to{opacity:1;transform:none}}
+.refresh{
+  position:fixed;left:20px;bottom:20px;z-index:9100;cursor:pointer;user-select:none;
+  font-family:var(--font-m);font-size:10.5px;letter-spacing:2px;text-transform:uppercase;
+  display:flex;align-items:center;gap:9px;color:var(--ink-dim);
+  background:linear-gradient(180deg,#101715,#0a100e);border:1px solid var(--bezel);
+  padding:9px 14px;border-radius:20px;box-shadow:var(--shadow);transition:.2s;
+}
+.refresh:hover{color:var(--ink)}
+.refresh .led{width:9px;height:9px}
+
+@media(max-width:1080px){.panel,.col-6,.col-8{grid-column:span 6}.col-12{grid-column:span 12}}
+@media(max-width:680px){.rack{grid-template-columns:1fr;padding:14px}.panel,.col-6,.col-8,.col-12{grid-column:span 1}
+  .faceplate{gap:16px}.readout-strip{display:none}}
+</style>
 </head>
 <body>
-    <div class="container">
-        <div class="header">
-            <h1>Millennium System Portal</h1>
-            <div class="status-bar">
-                <div class="status-item">
-                    <div class="status-indicator status-healthy" id="system-status"></div>
-                    <span>System Status</span>
-                </div>
-                <div class="status-item">
-                    <span>Last Update: <span id="last-update">--</span></span>
-                </div>
-            </div>
-        </div>
+<div class="grain"></div>
+<div class="scan"></div>
 
-        <div class="dashboard">
-            <!-- System State Card -->
-            <div class="card system-state">
-                <h2>System State</h2>
-                <div class="state-display state-idle" id="current-state">IDLE</div>
-                <div class="metrics-grid">
-                    <div class="metric-item">
-                        <div class="metric-value" id="inserted-cents">0</div>
-                        <div class="metric-label">Cents Inserted</div>
-                    </div>
-                    <div class="metric-item">
-                        <div class="metric-value" id="keypad-input" style="word-break: break-all; overflow-wrap: break-word; max-width: 100%;">--</div>
-                        <div class="metric-label">Keypad Input</div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Metrics Card -->
-            <div class="card">
-                <h2>System Metrics</h2>
-                <div class="metrics-grid" id="metrics-grid">
-                    <div class="loading">Loading metrics...</div>
-                </div>
-            </div>
-
-            <!-- Health Checks Card -->
-            <div class="card">
-                <h2>Health Status</h2>
-                <div class="health-checks" id="health-checks">
-                    <div class="loading">Loading health checks...</div>
-                </div>
-            </div>
-
-            <!-- Control Panel -->
-            <div class="card control-panel">
-                <h2>System Control</h2>
-                <div class="control-buttons">
-                    <button class="btn btn-primary" onclick="refreshData()">Refresh Data</button>
-                    <button class="btn btn-success" onclick="startCall()">Start Call</button>
-                    <button class="btn btn-warning" onclick="resetSystem()">Reset System</button>
-                    <button class="btn btn-danger" onclick="emergencyStop()">Emergency Stop</button>
-                </div>
-            </div>
-
-            <!-- Hardware Simulation Panel -->
-            <div class="card control-panel">
-                <h2>Hardware Simulation</h2>
-                
-                <!-- Keypad Simulation -->
-                <div class="simulation-section">
-                    <h3>Keypad</h3>
-                    <div class="keypad-grid">
-                        <button class="keypad-btn" onclick="simulateKeypad('1')">1</button>
-                        <button class="keypad-btn" onclick="simulateKeypad('2')">2</button>
-                        <button class="keypad-btn" onclick="simulateKeypad('3')">3</button>
-                        <button class="keypad-btn" onclick="simulateKeypad('4')">4</button>
-                        <button class="keypad-btn" onclick="simulateKeypad('5')">5</button>
-                        <button class="keypad-btn" onclick="simulateKeypad('6')">6</button>
-                        <button class="keypad-btn" onclick="simulateKeypad('7')">7</button>
-                        <button class="keypad-btn" onclick="simulateKeypad('8')">8</button>
-                        <button class="keypad-btn" onclick="simulateKeypad('9')">9</button>
-                        <button class="keypad-btn" onclick="simulateKeypad('*')">*</button>
-                        <button class="keypad-btn" onclick="simulateKeypad('0')">0</button>
-                        <button class="keypad-btn" onclick="simulateKeypad('#')">#</button>
-                    </div>
-                    <div class="keypad-controls">
-                        <button class="btn btn-warning" onclick="clearKeypad()">Clear</button>
-                        <button class="btn btn-danger" onclick="backspaceKeypad()">Backspace</button>
-                    </div>
-                </div>
-
-                <!-- Coin Reader Simulation -->
-                <div class="simulation-section">
-                    <h3>Coin Reader</h3>
-                    <div class="coin-reader-controls">
-                        <button class="btn btn-success" onclick="simulateCoinInsert(1)">Insert 1¢</button>
-                        <button class="btn btn-success" onclick="simulateCoinInsert(5)">Insert 5¢</button>
-                        <button class="btn btn-success" onclick="simulateCoinInsert(10)">Insert 10¢</button>
-                        <button class="btn btn-success" onclick="simulateCoinInsert(25)">Insert 25¢</button>
-                        <button class="btn btn-warning" onclick="simulateCoinReturn()">Return Coins</button>
-                    </div>
-                </div>
-
-                <!-- Handset Control -->
-                <div class="simulation-section">
-                    <h3>Handset</h3>
-                    <div class="handset-controls">
-                        <button class="btn btn-primary" onclick="simulateHandsetUp()">Handset Up</button>
-                        <button class="btn btn-primary" onclick="simulateHandsetDown()">Handset Down</button>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Plugin Management Panel -->
-            <div class="card control-panel">
-                <h2>Plugin Management</h2>
-                
-                <div class="plugin-section">
-                    <h3>Available Plugins</h3>
-                    <div class="plugin-grid" id="plugin-grid">
-                        <div class="loading">Loading plugins...</div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Configuration Panel -->
-            <div class="card config-panel">
-                <h2>System Configuration</h2>
-                <div class="config-section">
-                    <h3>Hardware Configuration</h3>
-                    <div class="config-grid" id="hardware-config">
-                        <div class="loading">Loading configuration...</div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Logs Panel -->
-            <div class="card logs-panel">
-                <h2>System Logs</h2>
-                <div id="logs-container">
-                    <div class="loading">Loading logs...</div>
-                </div>
-            </div>
-        </div>
+<!-- ======================= FACEPLATE ======================= -->
+<header class="faceplate">
+  <div class="brand">
+    <div class="mark">
+      <span class="diamond">◆</span>
+      <h1>MILLEN<b>NIUM</b></h1>
     </div>
+    <div class="sub">Nortel · Payphone Control Unit</div>
+  </div>
 
-    <div class="refresh-indicator" id="refresh-indicator">
-        Auto-refresh: ON
+  <div class="spacer"></div>
+
+  <div class="leds">
+    <div class="led-unit"><span class="led" id="led-sys"></span><span>SYS</span></div>
+    <div class="led-unit"><span class="led" id="led-sip"></span><span>SIP</span></div>
+    <div class="led-unit"><span class="led" id="led-line"></span><span>LINE</span></div>
+  </div>
+
+  <div class="readout-strip">
+    <div class="ro"><span class="k">Uptime</span><span class="v" id="ro-uptime">--</span></div>
+    <div class="ro"><span class="k">Local Time</span><span class="v" id="ro-clock">--:--:--</span></div>
+    <div class="ro"><span class="k">Last Sync</span><span class="v" id="ro-sync">--</span></div>
+  </div>
+</header>
+
+<!-- ========================= RACK ========================= -->
+<main class="rack">
+
+  <!-- STATE + VFD (hero) -->
+  <section class="panel col-8">
+    <div class="phead"><span class="bar"></span><h2>Line State</h2><span class="tag">MOD-01</span></div>
+    <div class="state-line">
+      <div class="state-big s-idle" id="state-big">IDLE</div>
+      <div class="state-tag" id="state-desc">— standby —</div>
     </div>
-
-    <div class="notification-container" id="notification-container">
+    <div class="vfd">
+      <div class="vfd-lbl">VFD · 2×20 Character Display</div>
+      <div class="vfd-row" id="vfd1">&nbsp;</div>
+      <div class="vfd-row" id="vfd2">&nbsp;</div>
     </div>
+    <div class="readouts">
+      <div class="ru"><div class="rl">Coin Balance</div><div class="rv coin" id="ro-coins">0¢</div></div>
+      <div class="ru"><div class="rl">Keypad Buffer</div><div class="rv buf" id="ro-buf">—</div></div>
+    </div>
+  </section>
 
-    <script>
-        let refreshInterval;
-        let lastUpdateTime = Date.now();
-        let isUpdating = false;
+  <!-- SYSTEM CONTROL -->
+  <section class="panel col-4">
+    <div class="phead"><span class="bar"></span><h2>Control</h2><span class="tag">CMD</span></div>
+    <div class="btns">
+      <button class="btn primary" data-act="refresh">Refresh</button>
+      <button class="btn good" data-act="start_call">Start Call</button>
+      <button class="btn warn" data-act="reset_system">Reset</button>
+      <button class="btn bad" data-act="emergency_stop">E-Stop</button>
+    </div>
+    <div class="psub">Handset</div>
+    <div class="btns">
+      <button class="btn" data-act="handset_up">Lift</button>
+      <button class="btn" data-act="handset_down">Hang Up</button>
+    </div>
+  </section>
 
-        // State mapping with better formatting
-        const stateNames = {
-            0: 'Invalid',
-            1: 'Idle (Handset Down)',
-            2: 'Idle (Handset Up)', 
-            3: 'Incoming Call',
-            4: 'Call Active'
-        };
+  <!-- METRICS -->
+  <section class="panel col-4">
+    <div class="phead"><span class="bar"></span><h2>Metrics</h2><span class="tag">TLM</span></div>
+    <div class="rows" id="metrics"><div class="muted">loading…</div></div>
+  </section>
 
-        const stateDescriptions = {
-            0: 'System in invalid state',
-            1: 'System idle with handset down',
-            2: 'System idle with handset up', 
-            3: 'Incoming call detected',
-            4: 'Call is currently active'
-        };
+  <!-- HEALTH -->
+  <section class="panel col-4">
+    <div class="phead"><span class="bar"></span><h2>Health</h2><span class="tag">DIAG</span></div>
+    <div class="rows" id="health"><div class="muted">loading…</div></div>
+  </section>
 
-        const stateClasses = {
-            0: 'state-idle',
-            1: 'state-idle',
-            2: 'state-idle',
-            3: 'state-call-incoming',
-            4: 'state-call-active'
-        };
+  <!-- HARDWARE SIM -->
+  <section class="panel col-4">
+    <div class="phead"><span class="bar"></span><h2>Hardware Sim</h2><span class="tag">I/O</span></div>
+    <div class="keypad" id="keypad"></div>
+    <div class="btns">
+      <button class="btn warn" data-act="keypad_clear">Clear</button>
+      <button class="btn" data-act="keypad_backspace">⌫ Back</button>
+    </div>
+    <div class="psub">Coin Validator</div>
+    <div class="btns">
+      <button class="btn good" data-coin="1">1¢</button>
+      <button class="btn good" data-coin="5">5¢</button>
+      <button class="btn good" data-coin="10">10¢</button>
+      <button class="btn good" data-coin="25">25¢</button>
+      <button class="btn warn" data-act="coin_return">Return</button>
+    </div>
+  </section>
 
-        // Initialize the portal
-        document.addEventListener('DOMContentLoaded', function() {
-            refreshData();
-            startAutoRefresh();
-        });
+  <!-- PLUGINS -->
+  <section class="panel col-4">
+    <div class="phead"><span class="bar"></span><h2>Experiences</h2><span class="tag">APP</span></div>
+    <div class="plugins" id="plugins"><div class="muted">loading…</div></div>
+  </section>
 
-        // Audio-aware auto-refresh: slower during calls to reduce CPU usage
-        function startAutoRefresh() {
-            function refreshWithDelay() {
-                refreshData().catch(error => {
-                    // Handle rate limiting gracefully
-                    if (error.message && error.message.includes('429')) {
-                        console.log('Rate limited, slowing down refresh');
-                        // Slow down significantly if rate limited
-                        refreshInterval = setTimeout(refreshWithDelay, 10000);
-                        return;
-                    }
-                });
-                
-                // Use a consistent refresh rate for now (1 second)
-                const delay = 1000; // 1 second refresh rate
-                refreshInterval = setTimeout(refreshWithDelay, delay);
-            }
-            refreshWithDelay();
-        }
+  <!-- CONFIG -->
+  <section class="panel col-8">
+    <div class="phead"><span class="bar"></span><h2>Configuration</h2><span class="tag">CFG</span></div>
+    <div class="rows" id="config" style="columns:2;column-gap:34px"><div class="muted">loading…</div></div>
+  </section>
 
-        function stopAutoRefresh() {
-            if (refreshInterval) {
-                clearTimeout(refreshInterval);
-                refreshInterval = null;
-            }
-        }
+  <!-- LOGS -->
+  <section class="panel col-12">
+    <div class="phead"><span class="bar"></span><h2>System Log</h2><span class="tag">JRNL · INFO</span></div>
+    <div class="logbox" id="logs"><div class="muted">loading…</div></div>
+  </section>
 
-        // Main data refresh function
-        async function refreshData() {
-            try {
-                await Promise.all([
-                    updateSystemStatus(),
-                    updateSystemState(),
-                    updateMetrics(),
-                    updateHealthChecks(),
-                    updateConfiguration(),
-                    updateLogs(),
-                    updatePlugins()
-                ]);
-                
-                updateLastUpdateTime();
-            } catch (error) {
-                console.error('Error refreshing data:', error);
-                showError('Failed to refresh data: ' + error.message);
-            }
-        }
+</main>
 
-        // Update system status
-        async function updateSystemStatus() {
-            try {
-                const response = await fetch('/api/status');
-                const data = await response.json();
-                
-                document.getElementById('system-status').className = 'status-indicator status-healthy';
-            } catch (error) {
-                document.getElementById('system-status').className = 'status-indicator status-critical';
-            }
-        }
+<div class="toasts" id="toasts"></div>
+<div class="refresh" id="refresh"><span class="led on" id="refresh-led"></span><span id="refresh-txt">Auto-Sync · On</span></div>
 
-        // Update system state
-        async function updateSystemState() {
-            try {
-                const response = await fetch('/api/state');
-                const data = await response.json();
-                
-                const stateElement = document.getElementById('current-state');
-                const stateName = stateNames[data.current_state] || 'Unknown';
-                const stateClass = stateClasses[data.current_state] || 'state-idle';
-                const stateDescription = stateDescriptions[data.current_state] || 'Unknown state';
-                
-                stateElement.textContent = stateName;
-                stateElement.className = `state-display ${stateClass}`;
-                stateElement.title = stateDescription;
-                
-                document.getElementById('inserted-cents').textContent = data.inserted_cents;
-                document.getElementById('keypad-input').textContent = data.keypad_buffer || '--';
-            } catch (error) {
-                console.error('Error updating system state:', error);
-            }
-        }
+<script>
+/* ===================== state tables ===================== */
+const STATE_NAME={0:'INVALID',1:'IDLE · DOWN',2:'IDLE · UP',3:'INCOMING',4:'CALL ACTIVE'};
+const STATE_DESC={0:'invalid state',1:'on-hook · standby',2:'off-hook · dial tone',3:'ringing — incoming call',4:'call in progress'};
+const STATE_CLS={0:'s-invalid',1:'s-idle',2:'s-idle',3:'s-incoming',4:'s-active'};
+const KEYS=[['1',''],['2','ABC'],['3','DEF'],['4','GHI'],['5','JKL'],['6','MNO'],
+           ['7','PQRS'],['8','TUV'],['9','WXYZ'],['*','·'],['0','OPER'],['#','·']];
 
-        // Update metrics
-        async function updateMetrics() {
-            try {
-                const response = await fetch('/api/metrics');
-                const data = await response.json();
-                
-                const metricsGrid = document.getElementById('metrics-grid');
-                metricsGrid.innerHTML = '';
-                
-                // Display counters
-                for (const [name, value] of Object.entries(data.counters)) {
-                    const metricItem = createMetricItem(name, value);
-                    metricsGrid.appendChild(metricItem);
-                }
-                
-                // Display gauges
-                for (const [name, value] of Object.entries(data.gauges)) {
-                    const metricItem = createMetricItem(name, value);
-                    metricsGrid.appendChild(metricItem);
-                }
-                
-                if (metricsGrid.children.length === 0) {
-                    metricsGrid.innerHTML = '<div class="loading">No metrics available</div>';
-                }
-            } catch (error) {
-                document.getElementById('metrics-grid').innerHTML = '<div class="error">Failed to load metrics</div>';
-            }
-        }
+let timer=null, autoOn=true;
 
-        function createMetricItem(name, value) {
-            const item = document.createElement('div');
-            item.className = 'metric-item';
-            
-            // Special handling for current_state to show human-readable name
-            let displayValue = value;
-            let displayName = name.replace(/_/g, ' ');
-            
-            if (name === 'current_state') {
-                displayValue = stateNames[value] || 'Unknown';
-                displayName = 'Current State';
-            }
-            
-            item.innerHTML = `
-                <div class="metric-value">${displayValue}</div>
-                <div class="metric-label">${displayName}</div>
-            `;
-            return item;
-        }
+/* ===================== helpers ===================== */
+const $=id=>document.getElementById(id);
+async function jget(u){const r=await fetch(u);if(!r.ok)throw new Error(r.status);return r.json();}
+async function ctl(action,extra){
+  const r=await fetch('/api/control',{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify(Object.assign({action},extra||{}))});
+  return r.json();
+}
+function setLed(el,cls){el.className='led'+(cls?' '+cls:'');}
+function pad20(s){s=(s||'').toString().slice(0,20);return s+' '.repeat(20-s.length);}
+function fmtUptime(s){s=Math.floor(s);const h=Math.floor(s/3600),m=Math.floor(s%3600/60);
+  return h>0?`${h}h ${m}m`:`${m}m ${s%60}s`;}
+function humanize(k){return k.replace(/_/g,' ');}
 
-        // Update health checks
-        async function updateHealthChecks() {
-            try {
-                const response = await fetch('/api/health');
-                const data = await response.json();
-                
-                const healthContainer = document.getElementById('health-checks');
-                healthContainer.innerHTML = '';
-                
-                for (const [name, check] of Object.entries(data.checks)) {
-                    const healthItem = document.createElement('div');
-                    healthItem.className = `health-item ${check.status.toLowerCase()}`;
-                    healthItem.innerHTML = `
-                        <div>
-                            <strong>${name.replace(/_/g, ' ')}</strong>
-                            <div style="font-size: 0.9em; color: #7f8c8d;">${check.message}</div>
-                        </div>
-                        <div class="status-indicator status-${check.status.toLowerCase()}"></div>
-                    `;
-                    healthContainer.appendChild(healthItem);
-                }
-                
-                // Update overall status indicator
-                const overallStatus = document.getElementById('system-status');
-                overallStatus.className = `status-indicator status-${data.overall_status.toLowerCase()}`;
-                
-            } catch (error) {
-                document.getElementById('health-checks').innerHTML = '<div class="error">Failed to load health checks</div>';
-            }
-        }
+/* ===================== build keypad ===================== */
+(function(){
+  const kp=$('keypad');
+  KEYS.forEach(([d,l])=>{
+    const b=document.createElement('button');
+    b.className='key';b.dataset.key=d;
+    b.innerHTML=`<span class="d">${d}</span><span class="l">${l}</span>`;
+    kp.appendChild(b);
+  });
+})();
 
-        // Update configuration
-        async function updateConfiguration() {
-            try {
-                const response = await fetch('/api/config');
-                const data = await response.json();
-                
-                // Hardware Configuration
-                const hardwareConfig = document.getElementById('hardware-config');
-                hardwareConfig.innerHTML = `
-                    <div class="config-item">
-                        <div class="config-label">Display Device</div>
-                        <div class="config-value">${data.hardware.display_device}</div>
-                    </div>
-                    <div class="config-item">
-                        <div class="config-label">Baud Rate</div>
-                        <div class="config-value">${data.hardware.baud_rate}</div>
-                    </div>
-                    <div class="config-item">
-                        <div class="config-label">Call Cost (cents)</div>
-                        <div class="config-value">${data.call.cost_cents}</div>
-                    </div>
-                    <div class="config-item">
-                        <div class="config-label">Call Timeout (seconds)</div>
-                        <div class="config-value">${data.call.timeout_seconds}</div>
-                    </div>
-                    <div class="config-item">
-                        <div class="config-label">Update Interval (ms)</div>
-                        <div class="config-value">${data.system.update_interval_ms || 'Not configured'}</div>
-                    </div>
-                    <div class="config-item">
-                        <div class="config-label">Max Retries</div>
-                        <div class="config-value">${data.system.max_retries || 'Not configured'}</div>
-                    </div>
-                    <div class="config-item">
-                        <div class="config-label">Log Level</div>
-                        <div class="config-value">${data.logging.level}</div>
-                    </div>
-                    <div class="config-item">
-                        <div class="config-label">Log File</div>
-                        <div class="config-value">${data.logging.file || 'Not configured'}</div>
-                    </div>
-                    <div class="config-item">
-                        <div class="config-label">Log to File</div>
-                        <div class="config-value">${data.logging.to_file ? 'Yes' : 'No'}</div>
-                    </div>
-                    <div class="config-item">
-                        <div class="config-label">Metrics Server Enabled</div>
-                        <div class="config-value">${data.metrics_server.enabled ? 'Yes' : 'No'}</div>
-                    </div>
-                    <div class="config-item">
-                        <div class="config-label">Metrics Server Port</div>
-                        <div class="config-value">${data.metrics_server.port || 'Not configured'}</div>
-                    </div>
-                    <div class="config-item">
-                        <div class="config-label">Web Server Enabled</div>
-                        <div class="config-value">${data.web_server.enabled ? 'Yes' : 'No'}</div>
-                    </div>
-                    <div class="config-item">
-                        <div class="config-label">Web Server Port</div>
-                        <div class="config-value">${data.web_server.port || 'Not configured'}</div>
-                    </div>
-                `;
-                
-            } catch (error) {
-                document.getElementById('sip-config').innerHTML = '<div class="error">Failed to load configuration</div>';
-                document.getElementById('hardware-config').innerHTML = '<div class="error">Failed to load configuration</div>';
-            }
-        }
+/* ===================== updates ===================== */
+async function updState(){
+  try{
+    const d=await jget('/api/state');
+    const big=$('state-big');
+    big.textContent=STATE_NAME[d.current_state]||'UNKNOWN';
+    big.className='state-big '+(STATE_CLS[d.current_state]||'s-idle');
+    $('state-desc').textContent='— '+(STATE_DESC[d.current_state]||'unknown')+' —';
+    // VFD
+    $('vfd1').textContent=pad20(d.line1);
+    $('vfd2').innerHTML=pad20(d.line2).replace(/ +$/,m=>'<span class="cur">▏</span>'+m.slice(1));
+    // readouts
+    $('ro-coins').textContent=(d.inserted_cents||0)+'¢';
+    $('ro-buf').textContent=d.keypad_buffer&&d.keypad_buffer.length?d.keypad_buffer:'—';
+    // LEDs
+    setLed($('led-sip'),d.sip_registered?'on':'bad');
+    setLed($('led-line'),d.current_state===4?'on pulse':d.current_state===3?'warn pulse':'on');
+  }catch(e){setLed($('led-sip'),'bad');}
+}
+async function updStatus(){
+  try{await jget('/api/status');setLed($('led-sys'),'on');}
+  catch(e){setLed($('led-sys'),'bad');}
+}
+async function updMetrics(){
+  try{
+    const d=await jget('/api/metrics');
+    const out=[];
+    const add=(k,v)=>{
+      let val=v,name=humanize(k);
+      if(k==='current_state'){val=STATE_NAME[v]||v;}
+      else if(k==='daemon_uptime_seconds'){val=fmtUptime(v);$('ro-uptime').textContent=val;}
+      else if(typeof v==='number'&&!Number.isInteger(v))val=v.toFixed(2);
+      out.push(`<div class="row"><span class="rk">${name}</span><span class="dots"></span><span class="rval hl">${val}</span></div>`);
+    };
+    for(const[k,v]of Object.entries(d.counters||{}))add(k,v);
+    for(const[k,v]of Object.entries(d.gauges||{}))add(k,v);
+    $('metrics').innerHTML=out.length?out.join(''):'<div class="muted">no metrics</div>';
+  }catch(e){$('metrics').innerHTML='<div class="err">metrics offline</div>';}
+}
+async function updHealth(){
+  try{
+    const d=await jget('/api/health');
+    const out=[];
+    for(const[name,c]of Object.entries(d.checks||{})){
+      const s=(c.status||'').toLowerCase();
+      const led=(s==='healthy'||s==='ok'||s==='pass')?'on':(s==='warning'||s==='warn')?'warn':'bad';
+      out.push(`<div class="row health"><div><div class="hl-name">${humanize(name)}</div><div class="hl-msg">${c.message||''}</div></div><span class="led ${led}"></span></div>`);
+    }
+    $('health').innerHTML=out.length?out.join(''):'<div class="muted">no checks</div>';
+    const o=(d.overall_status||'').toLowerCase();
+    setLed($('led-sys'),(o==='healthy'||o==='ok')?'on':(o==='warning'||o==='warn')?'warn':'bad');
+  }catch(e){$('health').innerHTML='<div class="err">diagnostics offline</div>';}
+}
+async function updConfig(){
+  try{
+    const d=await jget('/api/config');
+    const r=(k,v)=>`<div class="row"><span class="rk">${k}</span><span class="dots"></span><span class="rval">${v??'—'}</span></div>`;
+    $('config').innerHTML=[
+      r('Display Device',(d.hardware?.display_device||'').split('/').pop()),
+      r('Baud Rate',d.hardware?.baud_rate),
+      r('Call Cost',d.call?.cost_cents+'¢'),
+      r('Call Timeout',d.call?.timeout_seconds+'s'),
+      r('Tick Interval',(d.system?.update_interval_ms||'—')+'ms'),
+      r('Max Retries',d.system?.max_retries),
+      r('Log Level',d.logging?.level),
+      r('Log To File',d.logging?.to_file?'yes':'no'),
+      r('Metrics Server',(d.metrics_server?.enabled?'on :':'off :')+(d.metrics_server?.port||'—')),
+      r('Web Server',(d.web_server?.enabled?'on :':'off :')+(d.web_server?.port||'—')),
+    ].join('');
+  }catch(e){$('config').innerHTML='<div class="err">config offline</div>';}
+}
+async function updLogs(){
+  try{
+    const d=await jget('/api/logs?level=INFO&max_entries=40');
+    if(d.logs&&d.logs.length){
+      $('logs').innerHTML=d.logs.map(l=>{
+        const t=new Date(l.timestamp*1000).toLocaleTimeString();
+        return `<div class="logline l-${(l.level||'').toLowerCase()}"><span class="lt">${t}</span><span class="lv">${l.level}</span><span class="lm">${l.message}</span></div>`;
+      }).join('');
+    }else $('logs').innerHTML='<div class="muted">no recent log entries</div>';
+  }catch(e){$('logs').innerHTML='<div class="err">journal offline</div>';}
+}
+async function updPlugins(){
+  try{
+    const d=await jget('/api/plugins');
+    if(d.plugins&&d.plugins.length){
+      $('plugins').innerHTML=d.plugins.map(p=>`
+        <div class="plugin ${p.active?'active':''}">
+          <div class="pn">${p.name}<span class="pstat" style="margin-left:auto">${p.active?'Active':'Idle'}</span></div>
+          <div class="pd">${p.description||''}</div>
+          <button class="btn ${p.active?'primary':''}" data-plugin="${encodeURIComponent(p.name)}" ${p.active?'disabled':''}>${p.active?'● Running':'Activate'}</button>
+        </div>`).join('');
+    }else $('plugins').innerHTML='<div class="muted">no plugins</div>';
+  }catch(e){$('plugins').innerHTML='<div class="err">registry offline</div>';}
+}
 
-        // Update logs
-        async function updateLogs() {
-            try {
-                const response = await fetch('/api/logs?level=INFO&max_entries=15');
-                const data = await response.json();
-                
-                const logsContainer = document.getElementById('logs-container');
-                logsContainer.innerHTML = '';
-                
-                if (data.logs && data.logs.length > 0) {
-                    data.logs.forEach(log => {
-                        const logEntry = document.createElement('div');
-                        logEntry.className = `log-entry log-${log.level.toLowerCase()}`;
-                        logEntry.innerHTML = `
-                            <strong>[${new Date(log.timestamp * 1000).toLocaleTimeString()}]</strong>
-                            <span style="margin: 0 10px; font-weight: bold;">${log.level}</span>
-                            ${log.message}
-                        `;
-                        logsContainer.appendChild(logEntry);
-                    });
-                } else {
-                    logsContainer.innerHTML = '<div class="loading">No recent logs available</div>';
-                }
-                
-            } catch (error) {
-                document.getElementById('logs-container').innerHTML = '<div class="error">Failed to load logs</div>';
-            }
-        }
+async function refreshData(){
+  await Promise.all([updStatus(),updState(),updMetrics(),updHealth(),updConfig(),updLogs(),updPlugins()]);
+  $('ro-sync').textContent=new Date().toLocaleTimeString();
+}
 
-        // Update plugins
-        async function updatePlugins() {
-            try {
-                const response = await fetch('/api/plugins');
-                const data = await response.json();
-                
-                const pluginGrid = document.getElementById('plugin-grid');
-                pluginGrid.innerHTML = '';
-                
-                if (data.plugins && data.plugins.length > 0) {
-                    data.plugins.forEach(plugin => {
-                        const pluginCard = document.createElement('div');
-                        pluginCard.className = `plugin-card ${plugin.active ? 'active' : ''}`;
-                        pluginCard.innerHTML = `
-                            <div class="plugin-name">${plugin.name}</div>
-                            <div class="plugin-description">${plugin.description}</div>
-                            <div class="plugin-status ${plugin.active ? 'active' : 'inactive'}">
-                                ${plugin.active ? 'Active' : 'Inactive'}
-                            </div>
-                            <button class="btn ${plugin.active ? 'btn-success' : 'btn-primary'}" 
-                                    onclick="activatePlugin('${plugin.name}')" 
-                                    style="margin-top: 10px; width: 100%;">
-                                ${plugin.active ? 'Currently Active' : 'Activate'}
-                            </button>
-                        `;
-                        pluginGrid.appendChild(pluginCard);
-                    });
-                } else {
-                    pluginGrid.innerHTML = '<div class="loading">No plugins available</div>';
-                }
-                
-            } catch (error) {
-                document.getElementById('plugin-grid').innerHTML = '<div class="error">Failed to load plugins</div>';
-            }
-        }
+/* ===================== auto-sync loop ===================== */
+function loop(){
+  refreshData().catch(e=>{
+    if((''+e.message).includes('429')){timer=setTimeout(loop,10000);return;}
+  });
+  timer=setTimeout(loop,1000);
+}
+function startLoop(){autoOn=true;$('refresh-txt').textContent='Auto-Sync · On';setLed($('refresh-led'),'on');loop();}
+function stopLoop(){autoOn=false;clearTimeout(timer);timer=null;$('refresh-txt').textContent='Auto-Sync · Off';setLed($('refresh-led'),'bad');}
 
-        // Activate a plugin
-        async function activatePlugin(pluginName) {
-            try {
-                const response = await fetch('/api/control', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ action: 'activate_plugin', plugin: pluginName })
-                });
-                
-                const result = await response.json();
-                if (result.success) {
-                    showMessage(`Plugin "${pluginName}" activated successfully!`, 'success');
-                    // Immediately update the UI for better responsiveness
-                    updatePlugins();
-                } else {
-                    showMessage(`Failed to activate plugin "${pluginName}": ${result.message || 'Unknown error'}`, 'error');
-                }
-            } catch (error) {
-                showMessage(`Failed to activate plugin "${pluginName}": ${error.message}`, 'error');
-            }
-        }
+/* ===================== toasts ===================== */
+function toast(msg,type='success'){
+  const t=document.createElement('div');t.className='toast '+type;t.textContent=msg;
+  $('toasts').appendChild(t);
+  setTimeout(()=>{t.style.transition='opacity .3s,transform .3s';t.style.opacity='0';t.style.transform='translateX(24px)';
+    setTimeout(()=>t.remove(),300);},3600);
+}
 
-        // Hardware simulation functions
-        async function simulateKeypad(key) {
-            const button = event.target;
-            const originalText = button.textContent;
-            
-            try {
-                // Show loading state
-                button.textContent = '...';
-                button.disabled = true;
-                
-                const response = await fetch('/api/control', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ action: 'keypad_press', key: key })
-                });
-                const result = await response.json();
-                if (result.success) {
-                    showMessage(`Keypad: ${key} pressed`, 'success');
-                    // Immediately update the UI for better responsiveness
-                    updateSystemState();
-                    updateMetrics();
-                } else {
-                    showMessage('Keypad press ignored - handset must be up', 'warning');
-                }
-            } catch (error) {
-                showMessage('Failed to simulate keypad press: ' + error.message, 'error');
-            } finally {
-                // Restore button state
-                button.textContent = originalText;
-                button.disabled = false;
-            }
-        }
+/* ===================== event wiring ===================== */
+// generic data-act controls
+document.addEventListener('click',async ev=>{
+  const ab=ev.target.closest('[data-act]');
+  if(ab){
+    const a=ab.dataset.act;
+    if(a==='refresh'){refreshData();toast('Telemetry refreshed');return;}
+    if(a==='reset_system'&&!confirm('Reset the system?'))return;
+    if(a==='emergency_stop'&&!confirm('EMERGENCY STOP — halt all operations?'))return;
+    try{const res=await ctl(a);
+      toast(res.success?(ab.textContent.trim()+' ✓'):(res.message||'Ignored — handset must be up'),res.success?'success':'warning');
+    }catch(e){toast('Command failed: '+e.message,'error');}
+    updState();updMetrics();return;
+  }
+  // keypad keys
+  const k=ev.target.closest('.key');
+  if(k){
+    k.disabled=true;
+    try{const res=await ctl('keypad_press',{key:k.dataset.key});
+      toast(res.success?`Key ${k.dataset.key}`:'Ignored — handset must be up',res.success?'success':'warning');
+    }catch(e){toast('Keypad failed: '+e.message,'error');}
+    finally{k.disabled=false;}
+    updState();updMetrics();return;
+  }
+  // coins
+  const cb=ev.target.closest('[data-coin]');
+  if(cb){
+    cb.disabled=true;const c=+cb.dataset.coin;
+    try{const res=await ctl('coin_insert',{cents:c});
+      toast(res.success?`Inserted ${c}¢`:'Ignored — handset must be up',res.success?'success':'warning');
+    }catch(e){toast('Coin failed: '+e.message,'error');}
+    finally{cb.disabled=false;}
+    updState();updMetrics();return;
+  }
+  // plugin activate
+  const pb=ev.target.closest('[data-plugin]');
+  if(pb){
+    const name=decodeURIComponent(pb.dataset.plugin);
+    try{const res=await ctl('activate_plugin',{plugin:name});
+      toast(res.success?`Loaded “${name}”`:(res.message||'Failed'),res.success?'success':'error');
+      if(res.success)updPlugins();
+    }catch(e){toast('Activate failed: '+e.message,'error');}
+    return;
+  }
+});
+$('refresh').addEventListener('click',()=>autoOn?stopLoop():startLoop());
 
-        async function clearKeypad() {
-            try {
-                const response = await fetch('/api/control', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ action: 'keypad_clear' })
-                });
-                const result = await response.json();
-                if (result.success) {
-                    showMessage('Keypad cleared', 'success');
-                    // Immediately update the UI for better responsiveness
-                    updateSystemState();
-                    updateMetrics();
-                } else {
-                    showMessage('Keypad clear ignored - handset must be up', 'warning');
-                }
-            } catch (error) {
-                showMessage('Failed to clear keypad: ' + error.message, 'error');
-            }
-        }
+/* clock */
+setInterval(()=>{$('ro-clock').textContent=new Date().toLocaleTimeString();},1000);
 
-        async function backspaceKeypad() {
-            try {
-                const response = await fetch('/api/control', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ action: 'keypad_backspace' })
-                });
-                const result = await response.json();
-                if (result.success) {
-                    showMessage('Keypad backspace', 'success');
-                    // Immediately update the UI for better responsiveness
-                    updateSystemState();
-                    updateMetrics();
-                } else {
-                    showMessage('Backspace ignored - handset must be up or buffer empty', 'warning');
-                }
-            } catch (error) {
-                showMessage('Failed to simulate backspace: ' + error.message, 'error');
-            }
-        }
-
-        async function simulateCoinInsert(cents) {
-            const button = event.target;
-            const originalText = button.textContent;
-            
-            try {
-                // Show loading state
-                button.textContent = '...';
-                button.disabled = true;
-                
-                const response = await fetch('/api/control', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ action: 'coin_insert', cents: cents })
-                });
-                const result = await response.json();
-                if (result.success) {
-                    showMessage(`Coin inserted: ${cents}¢`, 'success');
-                    // Immediately update the UI for better responsiveness
-                    updateSystemState();
-                    updateMetrics();
-                } else {
-                    showMessage('Coin insert ignored - handset must be up', 'warning');
-                }
-            } catch (error) {
-                showMessage('Failed to simulate coin insert: ' + error.message, 'error');
-            } finally {
-                // Restore button state
-                button.textContent = originalText;
-                button.disabled = false;
-            }
-        }
-
-        async function simulateCoinReturn() {
-            try {
-                const response = await fetch('/api/control', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ action: 'coin_return' })
-                });
-                const result = await response.json();
-                if (result.success) {
-                    showMessage('Coins returned', 'success');
-                    // Immediately update the UI for better responsiveness
-                    updateSystemState();
-                    updateMetrics();
-                } else {
-                    showMessage(result.message || 'Failed to return coins', 'error');
-                }
-            } catch (error) {
-                showMessage('Failed to simulate coin return: ' + error.message, 'error');
-            }
-        }
-
-        async function simulateHandsetUp() {
-            try {
-                const response = await fetch('/api/control', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ action: 'handset_up' })
-                });
-                const result = await response.json();
-                if (result.success) {
-                    showMessage('Handset lifted', 'success');
-                    // Immediately update the UI for better responsiveness
-                    updateSystemState();
-                    updateMetrics();
-                } else {
-                    showMessage('Failed to simulate handset up: ' + (result.message || 'Unknown error'), 'error');
-                }
-            } catch (error) {
-                showMessage('Failed to simulate handset up: ' + error.message, 'error');
-            }
-        }
-
-        async function simulateHandsetDown() {
-            try {
-                const response = await fetch('/api/control', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ action: 'handset_down' })
-                });
-                const result = await response.json();
-                if (result.success) {
-                    showMessage('Handset placed down', 'success');
-                    // Immediately update the UI for better responsiveness
-                    updateSystemState();
-                    updateMetrics();
-                } else {
-                    showMessage('Failed to simulate handset down: ' + (result.message || 'Unknown error'), 'error');
-                }
-            } catch (error) {
-                showMessage('Failed to simulate handset down: ' + error.message, 'error');
-            }
-        }
-
-        // Control functions
-        async function startCall() {
-            try {
-                const response = await fetch('/api/control', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ action: 'start_call' })
-                });
-                const result = await response.json();
-                if (result.success) {
-                    showMessage('Call started successfully', 'success');
-                    // Immediately update the UI for better responsiveness
-                    updateSystemState();
-                    updateMetrics();
-                } else {
-                    showMessage('Failed to start call: ' + (result.message || 'Unknown error'), 'error');
-                }
-            } catch (error) {
-                showMessage('Failed to start call: ' + error.message, 'error');
-            }
-        }
-
-        async function resetSystem() {
-            if (confirm('Are you sure you want to reset the system?')) {
-                try {
-                    const response = await fetch('/api/control', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ action: 'reset_system' })
-                    });
-                    const result = await response.json();
-                    if (result.success) {
-                        showMessage('System reset initiated', 'success');
-                        // Immediately update the UI for better responsiveness
-                        updateSystemState();
-                        updateMetrics();
-                    } else {
-                        showMessage('Failed to reset system: ' + (result.message || 'Unknown error'), 'error');
-                    }
-                } catch (error) {
-                    showMessage('Failed to reset system: ' + error.message, 'error');
-                }
-            }
-        }
-
-        async function emergencyStop() {
-            if (confirm('EMERGENCY STOP: This will immediately halt all system operations. Continue?')) {
-                try {
-                    const response = await fetch('/api/control', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ action: 'emergency_stop' })
-                    });
-                    const result = await response.json();
-                    if (result.success) {
-                        showMessage('Emergency stop activated', 'warning');
-                        // Immediately update the UI for better responsiveness
-                        updateSystemState();
-                        updateMetrics();
-                    } else {
-                        showMessage('Failed to activate emergency stop: ' + (result.message || 'Unknown error'), 'error');
-                    }
-                } catch (error) {
-                    showMessage('Failed to activate emergency stop: ' + error.message, 'error');
-                }
-            }
-        }
-
-        // Utility functions
-        function formatUptime(seconds) {
-            const hours = Math.floor(seconds / 3600);
-            const minutes = Math.floor((seconds % 3600) / 60);
-            const secs = seconds % 60;
-            return `${hours}h ${minutes}m ${secs}s`;
-        }
-
-        function updateLastUpdateTime() {
-            lastUpdateTime = Date.now();
-            document.getElementById('last-update').textContent = new Date().toLocaleTimeString();
-        }
-
-        function showMessage(message, type) {
-            const container = document.getElementById('notification-container');
-            const messageDiv = document.createElement('div');
-            messageDiv.className = `notification ${type}`;
-            messageDiv.textContent = message;
-            
-            container.appendChild(messageDiv);
-            
-            setTimeout(() => {
-                if (container.contains(messageDiv)) {
-                    container.removeChild(messageDiv);
-                }
-            }, 4000);
-        }
-
-        function showError(message) {
-            showMessage(message, 'error');
-        }
-
-        // Toggle auto-refresh
-        document.getElementById('refresh-indicator').addEventListener('click', function() {
-            if (refreshInterval) {
-                stopAutoRefresh();
-                this.textContent = 'Auto-refresh: OFF';
-                this.style.background = 'rgba(231, 76, 60, 0.1)';
-            } else {
-                startAutoRefresh();
-                this.textContent = 'Auto-refresh: ON';
-                this.style.background = 'rgba(255, 255, 255, 0.9)';
-            }
-        });
-    </script>
+/* boot */
+document.addEventListener('DOMContentLoaded',()=>{startLoop();});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Replaces the generic AI-slop dashboard (purple `#667eea→#764ba2` gradient + glassmorphism) with a distinctive design that fits the hardware: **a powered-on piece of telecom equipment**.

## Design
- **Faceplate header** with live status LEDs (SYS / SIP / LINE) driven by real health/registration/call state, etched wordmark, faux screw-heads.
- **The VFD display, finally shown** — the phone's real 2×20 vacuum-fluorescent display (`line1`/`line2` from `/api/state`, which the old UI never displayed) rendered with phosphor glow, scanlines, and a blinking cursor.
- **Phosphor-cyan + amber palette** on dark equipment panels (coins in amber, live data in VFD cyan, critical in red).
- **Tactile payphone keypad** with real letter sublabels (2=ABC, 7=PQRS…).
- Monospace readout tables (metrics/health/config/logs), custom scrollbar, color-coded log levels.
- Atmosphere: film-grain + drifting scanlines + vignette, staggered power-on reveal.
- Type: **Chakra Petch** (display) + **Share Tech Mono** (readouts).

## Functionality — 100% preserved
All 7 `/api/*` data endpoints and all 11 `POST /api/control` actions (keypad, clear/backspace, coins 1–25¢, return, handset up/down, plugin activate, start-call/reset/e-stop) plus the auto-sync toggle. A contrast pass keeps dim text legible on the dark theme.

## Deploy
Served from `/usr/local/share/millennium/web_portal.html` via the file route in `daemon.c` — copy the file and refresh; no daemon rebuild. Verified live on the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)