### PR TITLE
build: unify on C89 + enforce -Werror; fix /api/logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,8 +155,7 @@ Pure ALSA (`libasound`), no PipeWire. Left channel → ringer (TDA2822M ch A), r
 
 ## Coding Conventions
 
-- **C89** for all files except `simulator.c`, `jukebox.c`, `audio_tones.c` (C99 needed for mixed declarations)
-- `-Wall -Wextra` on all targets; no separate linter configured
+- **C89** across the whole codebase, compiled with `-std=gnu89` (the C89 language plus the GNU extensions the ALSA/PJSIP system headers require, e.g. `inline`; strict `-std=c89` can't parse those headers). `-Wall -Wextra -Wdeclaration-after-statement` on all targets keeps the source free of C99-style mixed declarations; no separate linter configured
 - No external dependencies beyond ALSA, pthread, PJSIP (libpjproject), and libc
 - No C++ in the active daemon targets (`.cpp` files in `host/` are legacy/unused)
 

--- a/host/Makefile
+++ b/host/Makefile
@@ -3,9 +3,12 @@ CXXFLAGS=-g -O3 -std=c++17 -Wall -Wextra
 # .pc Libs.private, so we need --static to pull them into the link.
 LDFLAGS=-lpthread -latomic -lasound `pkg-config --libs --static libpjproject`
 
-# C flags for C files
-CFLAGS=-g -O3 -Wall -Wextra -std=c89
-C99_CFLAGS=-g -O3 -Wall -Wextra -std=c99
+# C flags for C files. The codebase targets C89. We use -std=gnu89 (the C89
+# language plus the GNU extensions that the ALSA and PJSIP system headers rely
+# on, e.g. `inline`) because strict -std=c89 fails to parse those headers.
+# -Wdeclaration-after-statement keeps OUR OWN code free of C99-style mixed
+# declarations, so the source stays C89-conformant.
+CFLAGS=-g -O3 -Wall -Wextra -std=gnu89 -Wdeclaration-after-statement -Werror
 
 # Build version info
 GIT_HASH := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -24,13 +27,13 @@ logger.o: logger.c logger.h
 	gcc logger.c -o logger.o -c $(CFLAGS)
 
 health_monitor.o: health_monitor.c health_monitor.h logger.h
-	gcc health_monitor.c -o health_monitor.o -c $(CFLAGS) -lpthread
+	gcc health_monitor.c -o health_monitor.o -c $(CFLAGS)
 
 metrics.o: metrics.c metrics.h
 	gcc metrics.c -o metrics.o -c $(CFLAGS)
 
 metrics_server.o: metrics_server.c metrics_server.h metrics.h logger.h
-	gcc metrics_server.c -o metrics_server.o -c $(CFLAGS) -lpthread
+	gcc metrics_server.c -o metrics_server.o -c $(CFLAGS)
 
 websocket.o: websocket.c websocket.h
 	gcc websocket.c -o websocket.o -c $(CFLAGS)
@@ -39,7 +42,7 @@ web_server.o: web_server.c web_server.h websocket.h config.h logger.h metrics.h 
 	gcc web_server.c -o web_server.o -c $(CFLAGS)
 
 pjsip_interface.o: pjsip_interface.c pjsip_interface.h logger.h
-	gcc pjsip_interface.c -o pjsip_interface.o -c $(C99_CFLAGS) `pkg-config --cflags libpjproject`
+	gcc pjsip_interface.c -o pjsip_interface.o -c $(CFLAGS) `pkg-config --cflags libpjproject`
 
 events.o: events.c events.h
 	gcc events.c -o events.o -c $(CFLAGS)
@@ -63,7 +66,7 @@ version.o: version.c version.h
 	gcc version.c -o version.o -c $(CFLAGS) $(VERSION_CFLAGS)
 
 audio_tones.o: audio_tones.c audio_tones.h logger.h
-	gcc audio_tones.c -o audio_tones.o -c $(C99_CFLAGS) -lm
+	gcc audio_tones.c -o audio_tones.o -c $(CFLAGS)
 
 updater.o: updater.c updater.h version.h logger.h
 	gcc updater.c -o updater.o -c $(CFLAGS)
@@ -82,7 +85,7 @@ plugins/fortune_teller.o: plugins/fortune_teller.c plugins.h
 	gcc plugins/fortune_teller.c -o plugins/fortune_teller.o -c $(CFLAGS)
 
 plugins/jukebox.o: plugins/jukebox.c plugins.h
-	gcc plugins/jukebox.c -o plugins/jukebox.o -c $(C99_CFLAGS) -lpthread
+	gcc plugins/jukebox.c -o plugins/jukebox.o -c $(CFLAGS)
 
 plugins/number_guess.o: plugins/number_guess.c plugins.h plugin_sdk.h config.h
 	gcc plugins/number_guess.c -o plugins/number_guess.o -c $(CFLAGS)
@@ -99,9 +102,9 @@ plugins/trivia.o: plugins/trivia.c plugins.h plugin_sdk.h config.h
 daemon: daemon.o daemon_state.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o
 	gcc daemon.o daemon_state.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o -o daemon $(LDFLAGS) -lm
 
-# Simulator object file (uses C99 for mixed declarations)
+# Simulator object file
 simulator.o: simulator.c millennium_sdk.h events.h config.h daemon_state.h logger.h metrics.h plugins.h
-	gcc simulator.c -o simulator.o -c $(C99_CFLAGS)
+	gcc simulator.c -o simulator.o -c $(CFLAGS)
 
 # Simulator objects — no baresip, no web server, no daemon.o
 SIM_OBJS = simulator.o daemon_state.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o
@@ -121,7 +124,7 @@ all: daemon
 UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o updater.o
 
 tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h millennium_sdk.h updater.h
-	gcc tests/unit_tests.c -o tests/unit_tests.o -c $(C99_CFLAGS) -I.
+	gcc tests/unit_tests.c -o tests/unit_tests.o -c $(CFLAGS) -I.
 
 # Unit tests don't use time wrapping; link ALSA on Linux for jukebox
 UNIT_LDFLAGS = -lpthread
@@ -138,7 +141,7 @@ unit_tests: $(UNIT_TEST_OBJS)
 # compiles and runs. Not part of `make test` (which must run anywhere).
 pjsip-smoke: tests/pjsip_smoke.c pjsip_interface.c pjsip_interface.h logger.o
 	gcc tests/pjsip_smoke.c pjsip_interface.c logger.o -o pjsip_smoke \
-		$(C99_CFLAGS) `pkg-config --cflags libpjproject` \
+		$(CFLAGS) `pkg-config --cflags libpjproject` \
 		`pkg-config --libs --static libpjproject` -lpthread -lm
 
 # Run all scenario tests via the simulator

--- a/host/audio_tones.c
+++ b/host/audio_tones.c
@@ -68,8 +68,6 @@ static int dtmf_freqs(char key, double *f1, double *f2) {
 
 static void *tone_thread_func(void *arg) {
     tone_spec_t spec = *(tone_spec_t *)arg;
-    free(arg);
-
     snd_pcm_t *pcm = NULL;
     int err;
     int16_t buf[SAMPLE_RATE / 10]; /* 100 ms buffer */
@@ -77,6 +75,8 @@ static void *tone_thread_func(void *arg) {
     unsigned long sample_idx = 0;
     int elapsed_ms = 0;
     int cadence_pos = 0; /* ms into current on/off cycle */
+
+    free(arg);
 
     err = snd_pcm_open(&pcm, spec.device ? spec.device : "default",
                        SND_PCM_STREAM_PLAYBACK, 0);
@@ -103,6 +103,7 @@ static void *tone_thread_func(void *arg) {
     while (!tone_stop_flag) {
         int i;
         int silent = 0;
+        snd_pcm_sframes_t frames;
 
         /* Check cadence: are we in the off period? */
         if (spec.on_ms > 0 && spec.off_ms > 0) {
@@ -123,7 +124,7 @@ static void *tone_thread_func(void *arg) {
             sample_idx++;
         }
 
-        snd_pcm_sframes_t frames = snd_pcm_writei(pcm, buf, buf_frames);
+        frames = snd_pcm_writei(pcm, buf, buf_frames);
         if (frames < 0) {
             frames = snd_pcm_recover(pcm, (int)frames, 0);
             if (frames < 0) break;

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -165,23 +165,25 @@ void generate_display_bytes(char *output, size_t output_size) {
 
 /* Helper function to safely copy strings with bounds checking */
 static void safe_strcpy(char *dest, const char *src, size_t dest_size) {
+    size_t n;
     if (!dest || dest_size == 0) return;
-    
-    if (src) {
-        strncpy(dest, src, dest_size - 1);
-    } else {
+    if (!src) {
         dest[0] = '\0';
+        return;
     }
-    dest[dest_size - 1] = '\0';
+    n = strlen(src);
+    if (n >= dest_size) n = dest_size - 1;
+    memcpy(dest, src, n);
+    dest[n] = '\0';
 }
 
 /* Helper function to update display - consolidates repetitive code */
 static void update_display(void) {
+    char display_bytes[100];
     if (!client || !daemon_state) {
         return;
     }
-    
-    char display_bytes[100];
+
     generate_display_bytes(display_bytes, sizeof(display_bytes));
     millennium_client_set_display(client, display_bytes);
 }
@@ -275,20 +277,21 @@ static void daemon_broadcast_state(const char *event_type) {
 }
 
 void handle_coin_event(coin_event_t *coin_event) {
+    char *coin_code_str;
+    int coin_value = 0;
     if (!coin_event) {
         logger_error_with_category("Coin", "Received null coin event");
         return;
     }
     VALIDATE_BASICS();
-    
-    char *coin_code_str = coin_event_get_coin_code(coin_event);
+
+    coin_code_str = coin_event_get_coin_code(coin_event);
     if (!coin_code_str) {
         logger_error_with_category("Coin", "Failed to get coin code");
         return;
     }
-    
-    int coin_value = 0;
-    
+
+
     if (strcmp(coin_code_str, "COIN_6") == 0) {
         coin_value = 5;
     } else if (strcmp(coin_code_str, "COIN_7") == 0) {
@@ -328,17 +331,20 @@ void handle_coin_event(coin_event_t *coin_event) {
 
 void handle_call_state_event(call_state_event_t *call_state_event) {
     int need_hangup_sync = 0;
-    
+    int is_incoming;
+    int phone_down;
+    int phone_up;
+
     if (!call_state_event) {
         logger_error_with_category("Call", "Received null call state event");
         return;
     }
     VALIDATE_BASICS();
-    
+
     pthread_mutex_lock(&daemon_state_mutex);
-    int is_incoming = (call_state_event_get_state(call_state_event) == EVENT_CALL_STATE_INCOMING);
-    int phone_down = (daemon_state->current_state == DAEMON_STATE_IDLE_DOWN);
-    int phone_up = (daemon_state->current_state == DAEMON_STATE_IDLE_UP);
+    is_incoming = (call_state_event_get_state(call_state_event) == EVENT_CALL_STATE_INCOMING);
+    phone_down = (daemon_state->current_state == DAEMON_STATE_IDLE_DOWN);
+    phone_up = (daemon_state->current_state == DAEMON_STATE_IDLE_UP);
     
     /* #92: Accept incoming when handset down (ring) or up (e.g. interrupt dialing) */
     if (is_incoming && (phone_down || phone_up)) {
@@ -412,15 +418,19 @@ void handle_call_state_event(call_state_event_t *call_state_event) {
 }
 
 void handle_hook_event(hook_state_change_event_t *hook_event) {
+    int hook_up;
+    int hook_down;
+    int resulting_state;
+
     if (!hook_event) {
         logger_error_with_category("Hook", "Received null hook event");
         return;
     }
     VALIDATE_BASICS();
-    
+
     pthread_mutex_lock(&daemon_state_mutex);
-    int hook_up = (hook_state_change_event_get_direction(hook_event) == 'U');
-    int hook_down = (hook_state_change_event_get_direction(hook_event) == 'D');
+    hook_up = (hook_state_change_event_get_direction(hook_event) == 'U');
+    hook_down = (hook_state_change_event_get_direction(hook_event) == 'D');
     
     if (hook_up) {
         int call_incoming = (daemon_state->current_state == DAEMON_STATE_CALL_INCOMING);
@@ -462,9 +472,9 @@ void handle_hook_event(hook_state_change_event_t *hook_event) {
         daemon_state->current_state = DAEMON_STATE_IDLE_DOWN;
         daemon_state_update_activity(daemon_state);
     }
-    int resulting_state = (int)daemon_state->current_state;
+    resulting_state = (int)daemon_state->current_state;
     pthread_mutex_unlock(&daemon_state_mutex);
-    
+
     /* Let active plugin handle the hook event */
     plugins_handle_hook(hook_up, hook_down);
     
@@ -486,13 +496,14 @@ void handle_hook_event(hook_state_change_event_t *hook_event) {
 }
 
 void handle_keypad_event(keypad_event_t *keypad_event) {
+    char key;
     if (!keypad_event) {
         logger_error_with_category("Keypad", "Received null keypad event");
         return;
     }
     VALIDATE_BASICS();
-    
-    char key = keypad_event_get_key(keypad_event);
+
+    key = keypad_event_get_key(keypad_event);
 
     /* Digits feed the shared dial buffer (for Classic Phone dialing) only
      * while the phone is ready and the buffer has room. */
@@ -531,6 +542,9 @@ void handle_card_event(card_event_t *card_event) {
 
 /* Implementation of sendControlCommand */
 int send_control_command(const char* action) {
+    char command[MAX_STRING_LEN];
+    char arg[MAX_STRING_LEN];
+    const char *colon_pos;
     if (!daemon_state) {
         logger_error_with_category("Control", "Daemon state is null");
         return 0;
@@ -549,10 +563,8 @@ int send_control_command(const char* action) {
     printf("[CONTROL] Received command: %s\n", action);
     
     /* Parse command and arguments */
-    char command[MAX_STRING_LEN];
-    char arg[MAX_STRING_LEN];
-    const char *colon_pos = strchr(action, ':');
-    
+    colon_pos = strchr(action, ':');
+
     if (colon_pos) {
         size_t cmd_len = colon_pos - action;
         if (cmd_len >= MAX_STRING_LEN) {
@@ -621,6 +633,7 @@ int send_control_command(const char* action) {
         }
         
     } else if (strcmp(command, "keypad_clear") == 0) {
+        int success;
         /* Only allow clear when handset is up (same as physical keypad logic) */
         pthread_mutex_lock(&daemon_state_mutex);
         if (is_phone_ready_for_operation()) {
@@ -628,54 +641,58 @@ int send_control_command(const char* action) {
             daemon_state_update_activity(daemon_state);
             metrics_increment_counter("keypad_clears", 1);
             logger_info_with_category("Control", "Keypad cleared via web portal");
-            
+
             /* Let plugins handle display updates */
         } else {
             logger_warn_with_category("Control", "Keypad clear ignored - handset down");
         }
-        int success = is_phone_ready_for_operation();
+        success = is_phone_ready_for_operation();
         pthread_mutex_unlock(&daemon_state_mutex);
         return success;
         
     } else if (strcmp(command, "keypad_backspace") == 0) {
+        int buffer_not_empty;
+        int success;
         /* Only allow backspace when handset is up and buffer is not empty */
         pthread_mutex_lock(&daemon_state_mutex);
-        int buffer_not_empty = (daemon_state_get_keypad_length(daemon_state) > 0);
-        
+        buffer_not_empty = (daemon_state_get_keypad_length(daemon_state) > 0);
+
         if (is_phone_ready_for_operation() && buffer_not_empty) {
             daemon_state_remove_last_key(daemon_state);
             daemon_state_update_activity(daemon_state);
             metrics_increment_counter("keypad_backspaces", 1);
             logger_info_with_category("Control", "Keypad backspace via web portal");
-            
+
             /* Let plugins handle display updates */
         } else {
             logger_warn_with_category("Control", "Keypad backspace ignored - handset down or buffer empty");
         }
-        int success = (is_phone_ready_for_operation() && buffer_not_empty);
+        success = (is_phone_ready_for_operation() && buffer_not_empty);
         pthread_mutex_unlock(&daemon_state_mutex);
         return success;
         
     } else if (strcmp(command, "coin_insert") == 0) {
+        int cents;
+        uint8_t coin_code;
+        coin_event_t *coin_event;
         /* Extract cents from argument and inject as coin event */
         if (strlen(arg) == 0) {
             logger_warn_with_category("Control", "Coin insert command missing argument");
             return 0;
         }
-        
+
         logger_infof_with_category("Control", "Extracted cents string: '%s'", arg);
         printf("[CONTROL] Extracted cents: '%s'\n", arg);
-        
-        int cents = atoi(arg);
-        
+
+        cents = atoi(arg);
+
         /* Validate coin value */
         if (cents <= 0) {
             logger_warnf_with_category("Control", "Invalid coin value: %d¢", cents);
             return 0;
         }
-        
+
         /* Map cents to coin codes (same as physical coin reader) */
-        uint8_t coin_code;
         switch (cents) {
             case 5:  coin_code = 0x36; break; /* COIN_6 */
             case 10: coin_code = 0x37; break; /* COIN_7 */
@@ -685,7 +702,7 @@ int send_control_command(const char* action) {
                 return 0;
         }
         
-        coin_event_t *coin_event = coin_event_create(coin_code);
+        coin_event = coin_event_create(coin_code);
         if (coin_event) {
             event_processor_process_event(event_processor, (event_t *)coin_event);
             event_destroy((event_t *)coin_event);
@@ -776,19 +793,21 @@ health_status_t check_sip_connection(void) {
 }
 
 health_status_t check_daemon_activity(void) {
+    time_t now;
+    time_t last_activity;
+    time_t time_since_activity;
     if (!daemon_state) {
         return HEALTH_STATUS_CRITICAL;
     }
-    
-    time_t now = time(NULL);
-    time_t last_activity;
-    
+
+    now = time(NULL);
+
     pthread_mutex_lock(&daemon_state_mutex);
     last_activity = daemon_state->last_activity;
     pthread_mutex_unlock(&daemon_state_mutex);
-    
-    time_t time_since_activity = now - last_activity;
-    
+
+    time_since_activity = now - last_activity;
+
     if (time_since_activity > 3600) { /* No activity for more than 1 hour */
         return HEALTH_STATUS_WARNING;
     }
@@ -798,17 +817,21 @@ health_status_t check_daemon_activity(void) {
 
 /* Helper function to update metrics - consolidated from thread */
 static void update_metrics(void) {
+    time_t uptime;
+    double current_state;
+    double inserted_cents;
+    double keypad_size;
     if (!daemon_state) return;
-    
+
     /* Update system metrics */
-    time_t uptime = time(NULL) - daemon_start_time;
+    uptime = time(NULL) - daemon_start_time;
     metrics_set_gauge("daemon_uptime_seconds", (double)uptime);
-    
+
     /* Quick snapshot of state without holding mutex too long */
     pthread_mutex_lock(&daemon_state_mutex);
-    double current_state = (double)daemon_state->current_state;
-    double inserted_cents = (double)daemon_state->inserted_cents;
-    double keypad_size = (double)daemon_state_get_keypad_length(daemon_state);
+    current_state = (double)daemon_state->current_state;
+    inserted_cents = (double)daemon_state->inserted_cents;
+    keypad_size = (double)daemon_state_get_keypad_length(daemon_state);
     pthread_mutex_unlock(&daemon_state_mutex);
     
     /* Update metrics outside of mutex */
@@ -818,6 +841,10 @@ static void update_metrics(void) {
 }
 
 int main(int argc, char *argv[]) {
+    config_data_t* config;
+    /* health_monitor_t* health_monitor = health_monitor_get_instance(); */
+    char config_file[MAX_STRING_LEN];
+
     /* Daemon has no controlling terminal: point stdin at /dev/null so nothing
      * accidentally polls fd 0 (which under systemd can be a non-pollable fd). */
     {
@@ -828,10 +855,8 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    config_data_t* config = config_get_instance();
-    /* health_monitor_t* health_monitor = health_monitor_get_instance(); */
-    char config_file[MAX_STRING_LEN];
-    
+    config = config_get_instance();
+
     /* Record daemon start time for uptime calculation */
     daemon_start_time = time(NULL);
     
@@ -984,16 +1009,17 @@ int main(int argc, char *argv[]) {
     
     /* Main event loop */
     while (1) {
+        event_t *event;
         pthread_mutex_lock(&running_mutex);
         if (!running) {
             pthread_mutex_unlock(&running_mutex);
             break;
         }
         pthread_mutex_unlock(&running_mutex);
-        
+
         millennium_client_update(client);
-        
-        event_t *event = (event_t *)millennium_client_next_event(client);
+
+        event = (event_t *)millennium_client_next_event(client);
         if (event) {
             event_processor_process_event(event_processor, event);
             event_destroy(event);

--- a/host/events.c
+++ b/host/events.c
@@ -7,9 +7,11 @@
 
 /* Helper function to create a string copy */
 static char *strdup_safe(const char *src) {
+    size_t len;
+    char *dst;
     if (!src) return NULL;
-    size_t len = strlen(src);
-    char *dst = malloc(len + 1);
+    len = strlen(src);
+    dst = malloc(len + 1);
     if (dst) {
         memcpy(dst, src, len);
         dst[len] = '\0';

--- a/host/health_monitor.c
+++ b/host/health_monitor.c
@@ -35,15 +35,17 @@ int health_monitor_register_check(const char* name,
                                  health_check_func_t check_function,
                                  time_t interval_seconds) {
     health_monitor_t* monitor = health_monitor_get_instance();
-    
+    int existing_index;
+    int index;
+
     if (!name || !check_function) {
         return 0; /* Invalid parameters */
     }
-    
+
     pthread_mutex_lock(&g_monitor_mutex);
-    
+
     /* Check if already exists */
-    int existing_index = find_check_index(name);
+    existing_index = find_check_index(name);
     if (existing_index >= 0) {
         pthread_mutex_unlock(&g_monitor_mutex);
         return 0; /* Already exists */
@@ -56,7 +58,7 @@ int health_monitor_register_check(const char* name,
     }
     
     /* Add new check */
-    int index = monitor->checks_count;
+    index = monitor->checks_count;
     strncpy(monitor->checks[index].name, name, sizeof(monitor->checks[index].name) - 1);
     monitor->checks[index].name[sizeof(monitor->checks[index].name) - 1] = '\0';
     monitor->checks[index].check_function = check_function;
@@ -75,14 +77,15 @@ int health_monitor_register_check(const char* name,
 
 void health_monitor_unregister_check(const char* name) {
     health_monitor_t* monitor = health_monitor_get_instance();
-    
+    int index;
+
     if (!name) {
         return;
     }
-    
+
     pthread_mutex_lock(&g_monitor_mutex);
-    
-    int index = find_check_index(name);
+
+    index = find_check_index(name);
     if (index >= 0) {
         /* Shift remaining checks down */
         int i;

--- a/host/logger.c
+++ b/host/logger.c
@@ -277,21 +277,23 @@ const char* logger_format_level(log_level_t level) {
 void logger_add_to_memory(const char* formatted_message) {
     logger_data_t* logger = logger_get_instance();
     int index;
-    
+    size_t mlen, mcap;
+
     if (logger == NULL || formatted_message == NULL) {
         return;
     }
-    
+
     /* Use circular buffer */
     index = (logger->memory_logs_start + logger->memory_logs_count) % 1000;
-    
-    /* Safe copy with guaranteed null termination - truncation is intentional */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-truncation"
-    strncpy(logger->memory_logs[index], formatted_message, sizeof(logger->memory_logs[index]) - 1);
-#pragma GCC diagnostic pop
-    logger->memory_logs[index][sizeof(logger->memory_logs[index]) - 1] = '\0';
-    
+
+    /* Copy with intentional truncation, always null-terminated. (memcpy rather
+     * than strncpy so neither gcc -Wstringop-truncation nor clang complains.) */
+    mcap = sizeof(logger->memory_logs[index]) - 1;
+    mlen = strlen(formatted_message);
+    if (mlen > mcap) mlen = mcap;
+    memcpy(logger->memory_logs[index], formatted_message, mlen);
+    logger->memory_logs[index][mlen] = '\0';
+
     if (logger->memory_logs_count < 1000) {
         logger->memory_logs_count++;
     } else {
@@ -303,24 +305,76 @@ void logger_add_to_memory(const char* formatted_message) {
 int logger_get_recent_logs(char logs[][512], int max_entries) {
     logger_data_t* logger = logger_get_instance();
     int i, j, count;
-    
+
     if (logger == NULL || logs == NULL || max_entries <= 0) {
         return 0;
     }
-    
+
     pthread_mutex_lock(&logger_mutex);
-    
+
     count = (max_entries < logger->memory_logs_count) ? max_entries : logger->memory_logs_count;
-    
+
     for (i = 0, j = logger->memory_logs_start; i < count; i++) {
         strncpy(logs[i], logger->memory_logs[j], sizeof(logs[i]) - 1);
         logs[i][sizeof(logs[i]) - 1] = '\0';
         j = (j + 1) % 1000;
     }
-    
+
     pthread_mutex_unlock(&logger_mutex);
-    
+
     return count;
+}
+
+/* Parse the severity out of a stored line: "[timestamp] [LEVEL] ..." */
+static log_level_t logger_parse_line_level(const char* line) {
+    const char* p;
+    if (line == NULL) return LOG_LEVEL_INFO;
+    p = strchr(line, ']');            /* end of [timestamp] */
+    if (p == NULL) return LOG_LEVEL_INFO;
+    p = strchr(p + 1, '[');           /* start of [LEVEL]   */
+    if (p == NULL) return LOG_LEVEL_INFO;
+    p++;
+    if (strncmp(p, "VERBOSE", 7) == 0) return LOG_LEVEL_VERBOSE;
+    if (strncmp(p, "DEBUG", 5) == 0)   return LOG_LEVEL_DEBUG;
+    if (strncmp(p, "INFO", 4) == 0)    return LOG_LEVEL_INFO;
+    if (strncmp(p, "WARN", 4) == 0)    return LOG_LEVEL_WARN;
+    if (strncmp(p, "ERROR", 5) == 0)   return LOG_LEVEL_ERROR;
+    return LOG_LEVEL_INFO;
+}
+
+int logger_get_recent_logs_min_level(char logs[][512], int max_entries, log_level_t min_level) {
+    logger_data_t* logger = logger_get_instance();
+    int n, k, idx, collected, a, b;
+    char tmp[512];
+
+    if (logger == NULL || logs == NULL || max_entries <= 0) {
+        return 0;
+    }
+
+    pthread_mutex_lock(&logger_mutex);
+
+    n = logger->memory_logs_count;
+    collected = 0;
+    /* Walk newest -> oldest across the whole ring, keep up to max_entries
+     * matching the minimum level. */
+    for (k = 1; k <= n && collected < max_entries; k++) {
+        idx = (logger->memory_logs_start + n - k) % 1000;
+        if (logger_parse_line_level(logger->memory_logs[idx]) >= min_level) {
+            strncpy(logs[collected], logger->memory_logs[idx], 511);
+            logs[collected][511] = '\0';
+            collected++;
+        }
+    }
+    /* Collected newest-first; reverse to oldest-first to match the other API. */
+    for (a = 0, b = collected - 1; a < b; a++, b--) {
+        memcpy(tmp, logs[a], 512);
+        memcpy(logs[a], logs[b], 512);
+        memcpy(logs[b], tmp, 512);
+    }
+
+    pthread_mutex_unlock(&logger_mutex);
+
+    return collected;
 }
 
 /* Convenience methods */

--- a/host/logger.h
+++ b/host/logger.h
@@ -85,6 +85,10 @@ const char* logger_level_to_string(log_level_t level);
 
 /* In-memory log storage */
 int logger_get_recent_logs(char logs[][512], int max_entries);
+/* Newest entries whose level is >= min_level, scanning the full ring buffer
+ * (so INFO+ events surface even when DEBUG output floods the recent window).
+ * Returns them oldest-first, like logger_get_recent_logs. */
+int logger_get_recent_logs_min_level(char logs[][512], int max_entries, log_level_t min_level);
 
 /* Internal functions */
 void logger_write_log(log_level_t level, const char* category, const char* message);

--- a/host/metrics.c
+++ b/host/metrics.c
@@ -65,27 +65,30 @@ static int find_histogram_index(const char *name) {
 
 /* Helper function to add a counter */
 static int add_counter(const char *name) {
+    int index;
     if (g_metrics->counter_count >= g_metrics->counter_capacity) {
         size_t new_capacity = g_metrics->counter_capacity * 2;
+        metrics_counter_t *new_counters;
+        char **new_names;
         if (new_capacity == 0) new_capacity = 16;
-        
-        metrics_counter_t *new_counters = realloc(g_metrics->counters, 
+
+        new_counters = realloc(g_metrics->counters,
             new_capacity * sizeof(metrics_counter_t));
         if (!new_counters) return -1;
-        
-        char **new_names = realloc(g_metrics->counter_names, 
+
+        new_names = realloc(g_metrics->counter_names,
             new_capacity * sizeof(char*));
         if (!new_names) {
             free(new_counters);
             return -1;
         }
-        
+
         g_metrics->counters = new_counters;
         g_metrics->counter_names = new_names;
         g_metrics->counter_capacity = new_capacity;
     }
-    
-    int index = (int)g_metrics->counter_count;
+
+    index = (int)g_metrics->counter_count;
     g_metrics->counter_names[index] = my_strdup(name);
     if (!g_metrics->counter_names[index]) return -1;
     
@@ -98,27 +101,30 @@ static int add_counter(const char *name) {
 
 /* Helper function to add a gauge */
 static int add_gauge(const char *name) {
+    int index;
     if (g_metrics->gauge_count >= g_metrics->gauge_capacity) {
         size_t new_capacity = g_metrics->gauge_capacity * 2;
+        metrics_gauge_t *new_gauges;
+        char **new_names;
         if (new_capacity == 0) new_capacity = 16;
-        
-        metrics_gauge_t *new_gauges = realloc(g_metrics->gauges, 
+
+        new_gauges = realloc(g_metrics->gauges,
             new_capacity * sizeof(metrics_gauge_t));
         if (!new_gauges) return -1;
-        
-        char **new_names = realloc(g_metrics->gauge_names, 
+
+        new_names = realloc(g_metrics->gauge_names,
             new_capacity * sizeof(char*));
         if (!new_names) {
             free(new_gauges);
             return -1;
         }
-        
+
         g_metrics->gauges = new_gauges;
         g_metrics->gauge_names = new_names;
         g_metrics->gauge_capacity = new_capacity;
     }
-    
-    int index = (int)g_metrics->gauge_count;
+
+    index = (int)g_metrics->gauge_count;
     g_metrics->gauge_names[index] = my_strdup(name);
     if (!g_metrics->gauge_names[index]) return -1;
     
@@ -131,27 +137,30 @@ static int add_gauge(const char *name) {
 
 /* Helper function to add a histogram */
 static int add_histogram(const char *name) {
+    int index;
     if (g_metrics->histogram_count >= g_metrics->histogram_capacity) {
         size_t new_capacity = g_metrics->histogram_capacity * 2;
+        metrics_histogram_t *new_histograms;
+        char **new_names;
         if (new_capacity == 0) new_capacity = 16;
-        
-        metrics_histogram_t *new_histograms = realloc(g_metrics->histograms, 
+
+        new_histograms = realloc(g_metrics->histograms,
             new_capacity * sizeof(metrics_histogram_t));
         if (!new_histograms) return -1;
-        
-        char **new_names = realloc(g_metrics->histogram_names, 
+
+        new_names = realloc(g_metrics->histogram_names,
             new_capacity * sizeof(char*));
         if (!new_names) {
             free(new_histograms);
             return -1;
         }
-        
+
         g_metrics->histograms = new_histograms;
         g_metrics->histogram_names = new_names;
         g_metrics->histogram_capacity = new_capacity;
     }
-    
-    int index = (int)g_metrics->histogram_count;
+
+    index = (int)g_metrics->histogram_count;
     g_metrics->histogram_names[index] = my_strdup(name);
     if (!g_metrics->histogram_names[index]) return -1;
     
@@ -389,9 +398,10 @@ int metrics_observe_histogram(const char *name, double value) {
     /* Add value to the values array */
     if (hist->values_size >= hist->values_capacity) {
         size_t new_capacity = hist->values_capacity * 2;
+        double *new_values;
         if (new_capacity == 0) new_capacity = 16;
-        
-        double *new_values = realloc(hist->values, new_capacity * sizeof(double));
+
+        new_values = realloc(hist->values, new_capacity * sizeof(double));
         if (!new_values) {
             pthread_mutex_unlock(&metrics_mutex);
             return -1;
@@ -539,8 +549,9 @@ char *metrics_export_prometheus(void) {
     #define GROW_IF_NEEDED() do { \
         if (pos + 512 >= len && len < METRICS_EXPORT_MAX_SIZE) { \
             size_t new_len = len * 2; \
+            char *tmp; \
             if (new_len > METRICS_EXPORT_MAX_SIZE) new_len = METRICS_EXPORT_MAX_SIZE; \
-            char *tmp = realloc(result, new_len); \
+            tmp = realloc(result, new_len); \
             if (tmp) { result = tmp; len = new_len; } \
         } \
     } while (0)

--- a/host/millennium_sdk.c
+++ b/host/millennium_sdk.c
@@ -55,13 +55,15 @@ static void event_queue_push(struct millennium_client *client, void *event) {
 }
 
 static void *event_queue_pop(struct millennium_client *client) {
+    struct event_queue_node *node;
+    void *event;
     if (!client->event_queue_head) {
         return NULL;
     }
-    
-    struct event_queue_node *node = client->event_queue_head;
-    void *event = node->event;
-    
+
+    node = client->event_queue_head;
+    event = node->event;
+
     client->event_queue_head = node->next;
     if (!client->event_queue_head) {
         client->event_queue_tail = NULL;
@@ -86,9 +88,11 @@ static void event_queue_clear(struct millennium_client *client) {
 
 /* String utilities */
 static char *string_duplicate(const char *src) {
+    size_t len;
+    char *dst;
     if (!src) return NULL;
-    size_t len = strlen(src) + 1;
-    char *dst = malloc(len);
+    len = strlen(src) + 1;
+    dst = malloc(len);
     if (dst) {
         strcpy(dst, src);
     }
@@ -106,13 +110,14 @@ static void string_buffer_ensure_capacity(struct millennium_client *client, size
     }
     if (needed >= client->input_buffer_capacity) {
         size_t new_capacity = client->input_buffer_capacity * 2;
+        char *new_buffer;
         if (new_capacity < needed) {
             new_capacity = needed + 1;
         }
         if (new_capacity > MAX_INPUT_BUFFER_SIZE) {
             new_capacity = MAX_INPUT_BUFFER_SIZE;
         }
-        char *new_buffer = realloc(client->input_buffer, new_capacity);
+        new_buffer = realloc(client->input_buffer, new_capacity);
         if (new_buffer) {
             client->input_buffer = new_buffer;
             client->input_buffer_capacity = new_capacity;
@@ -410,13 +415,14 @@ int millennium_client_serial_is_healthy(struct millennium_client *client) {
 }
 
 void millennium_client_check_serial(struct millennium_client *client) {
-    if (!client || client->display_fd == -1) return;
-
 #if SERIAL_WATCHDOG_ENABLED
     struct timespec now;
     long elapsed;
     int backoff;
+#endif
+    if (!client || client->display_fd == -1) return;
 
+#if SERIAL_WATCHDOG_ENABLED
     clock_gettime(CLOCK_MONOTONIC, &now);
     elapsed = now.tv_sec - client->last_serial_activity.tv_sec;
 
@@ -468,6 +474,8 @@ void millennium_client_check_serial(struct millennium_client *client) {
 void millennium_client_update(struct millennium_client *client) {
     char buffer[1024];
     ssize_t bytes_read;
+    struct timespec current_time;
+    long elapsed_ms;
 
     if (client->display_fd == -1) return;
 
@@ -482,10 +490,9 @@ void millennium_client_update(struct millennium_client *client) {
         logger_errorf_with_category("SDK", "Error reading from display_fd: %s", strerror(errno));
     }
 
-    struct timespec current_time;
     clock_gettime(CLOCK_MONOTONIC, &current_time);
-    
-    long elapsed_ms = (current_time.tv_sec - client->last_update_time.tv_sec) * 1000 +
+
+    elapsed_ms = (current_time.tv_sec - client->last_update_time.tv_sec) * 1000 +
                      (current_time.tv_nsec - client->last_update_time.tv_nsec) / 1000000;
     
     if (client->display_dirty && elapsed_ms > 33) {
@@ -501,10 +508,14 @@ void millennium_client_update(struct millennium_client *client) {
 
 void millennium_client_process_event_buffer(struct millennium_client *client) {
     while (client->input_buffer_size > 0) {
-        logger_debug_with_category("SDK", client->input_buffer);
-        
         size_t event_start = 0;
         size_t i;
+        char event_type;
+        char *payload;
+        size_t payload_len;
+        size_t remove_len;
+        logger_debug_with_category("SDK", client->input_buffer);
+
         for (i = 0; i < client->input_buffer_size; i++) {
             char c = client->input_buffer[i];
             if (c == '@' || c == 'K' || c == 'C' || c == 'V' || c == 'A' || 
@@ -519,8 +530,8 @@ void millennium_client_process_event_buffer(struct millennium_client *client) {
             return; /* No event marker found */
         }
 
-        char event_type = client->input_buffer[event_start];
-        char *payload = millennium_client_extract_payload(client, event_type, event_start);
+        event_type = client->input_buffer[event_start];
+        payload = millennium_client_extract_payload(client, event_type, event_start);
         
         logger_debugf_with_category("SDK", "Event type: %c", event_type);
         
@@ -531,8 +542,8 @@ void millennium_client_process_event_buffer(struct millennium_client *client) {
         millennium_client_create_and_queue_event_char(client, event_type, payload);
         
         /* Remove processed data from buffer */
-        size_t payload_len = payload ? strlen(payload) : 0;
-        size_t remove_len = event_start + payload_len + 1;
+        payload_len = payload ? strlen(payload) : 0;
+        remove_len = event_start + payload_len + 1;
         if (remove_len < client->input_buffer_size) {
             memmove(client->input_buffer, client->input_buffer + remove_len, 
                    client->input_buffer_size - remove_len);
@@ -652,17 +663,19 @@ void millennium_client_set_display(struct millennium_client *client, const char 
 }
 
 void millennium_client_write_to_display(struct millennium_client *client, const char *message) {
+    uint8_t cmd_data;
+    size_t total_bytes_written = 0;
+    size_t message_length;
     if (!message) return;
-    
+
     logger_debugf_with_category("SDK", "Writing message to display: %s", message);
 
     /* Step 1: Write the command */
-    uint8_t cmd_data = (uint8_t)strlen(message);
+    cmd_data = (uint8_t)strlen(message);
     millennium_client_write_command(client, 0x02, &cmd_data, 1);
 
     /* Step 2: Write the message in a loop to ensure all bytes are written */
-    size_t total_bytes_written = 0;
-    size_t message_length = strlen(message);
+    message_length = strlen(message);
 
     while (total_bytes_written < message_length) {
         ssize_t bytes_written = write(client->display_fd, message + total_bytes_written,

--- a/host/plugins.c
+++ b/host/plugins.c
@@ -56,6 +56,7 @@ int plugins_register(const char *name, const char *description,
                     card_handler_t card_handler,
                     activation_handler_t activation_handler,
                     tick_handler_t tick_handler) {
+    int i;
     if (plugin_count >= MAX_PLUGINS) {
         logger_error_with_category("Plugins", "Maximum number of plugins reached");
         return -1;
@@ -67,7 +68,6 @@ int plugins_register(const char *name, const char *description,
     }
     
     /* Check if plugin already exists */
-    int i;
     for (i = 0; i < plugin_count; i++) {
         if (strcmp(plugins[i].name, name) == 0) {
             logger_warnf_with_category("Plugins", "Plugin %s already registered", name);
@@ -93,6 +93,7 @@ int plugins_register(const char *name, const char *description,
 }
 
 int plugins_activate(const char *plugin_name) {
+    int i;
     if (!plugin_name) {
         logger_error_with_category("Plugins", "Plugin name required for activation");
         return -1;
@@ -101,7 +102,6 @@ int plugins_activate(const char *plugin_name) {
     pthread_mutex_lock(&plugins_mutex);
     
     /* Find the plugin */
-    int i;
     for (i = 0; i < plugin_count; i++) {
         if (strcmp(plugins[i].name, plugin_name) == 0) {
             active_plugin_index = i;
@@ -123,8 +123,8 @@ int plugins_activate(const char *plugin_name) {
 }
 
 const char* plugins_get_active_name(void) {
-    pthread_mutex_lock(&plugins_mutex);
     const char *name = NULL;
+    pthread_mutex_lock(&plugins_mutex);
     if (active_plugin_index >= 0 && active_plugin_index < plugin_count) {
         name = plugins[active_plugin_index].name;
     }
@@ -133,23 +133,24 @@ const char* plugins_get_active_name(void) {
 }
 
 int plugins_list(char *buffer, size_t buffer_size) {
+    int pos = 0;
+    int i;
     if (!buffer || buffer_size == 0) {
         return -1;
     }
-    
+
     pthread_mutex_lock(&plugins_mutex);
-    
+
     buffer[0] = '\0';
-    int pos = 0;
-    
-    int i;
+
     for (i = 0; i < plugin_count && pos < (int)buffer_size - 1; i++) {
         char temp[256];
+        int len;
         snprintf(temp, sizeof(temp), "%s: %s%s\n",
                 plugins[i].name, plugins[i].description,
                 (i == active_plugin_index) ? " (ACTIVE)" : "");
-        
-        int len = strlen(temp);
+
+        len = strlen(temp);
         if (pos + len < (int)buffer_size - 1) {
             strncpy(buffer + pos, temp, buffer_size - pos - 1);
             buffer[buffer_size - 1] = '\0';

--- a/host/plugins/jukebox.c
+++ b/host/plugins/jukebox.c
@@ -199,24 +199,26 @@ static void jukebox_show_playing(void) {
 }
 
 static void jukebox_play_song(int song_number) {
+    const song_info_t *song;
+    char log_msg[256];
+    const char* wav_file;
     if (song_number < 0 || song_number >= (int)NUM_SONGS) {
         return;
     }
-    
+
     jukebox_data.selected_song = song_number;
     jukebox_data.is_playing = 1;
     jukebox_data.play_start_time = time(NULL);
     jukebox_data.play_duration_seconds = songs[song_number].duration_seconds;
-    
+
     jukebox_show_playing();
-    
-    const song_info_t *song = &songs[song_number];
-    char log_msg[256];
+
+    song = &songs[song_number];
     snprintf(log_msg, sizeof(log_msg), "Playing song: %s by %s", song->title, song->artist);
     logger_info_with_category("Jukebox", log_msg);
-    
+
     /* Play the WAV file using ALSA */
-    const char* wav_file = songs[song_number].audio_file;
+    wav_file = songs[song_number].audio_file;
     if (jukebox_play_wav_file(wav_file) == 0) {
         char log_msg[256];
         snprintf(log_msg, sizeof(log_msg), "Started playing WAV file: %s", wav_file);
@@ -265,7 +267,9 @@ static void jukebox_check_playback(void) {
 #if HAVE_ALSA
 static int jukebox_init_alsa(void) {
     int err;
-    
+    snd_pcm_hw_params_t *hw_params;
+    unsigned int rate;
+
     /* Open PCM device for playback */
     err = snd_pcm_open(&jukebox_data.pcm_handle, "default", SND_PCM_STREAM_PLAYBACK, 0);
     if (err < 0) {
@@ -276,7 +280,6 @@ static int jukebox_init_alsa(void) {
     }
     
     /* Set hardware parameters */
-    snd_pcm_hw_params_t *hw_params;
     hw_params = malloc(snd_pcm_hw_params_sizeof());
     if (!hw_params) {
         logger_error_with_category("Jukebox", "Cannot allocate hardware parameters");
@@ -311,7 +314,7 @@ static int jukebox_init_alsa(void) {
     }
     
     /* Set sample rate */
-    unsigned int rate = 44100;
+    rate = 44100;
     err = snd_pcm_hw_params_set_rate_near(jukebox_data.pcm_handle, hw_params, &rate, 0);
     if (err < 0) {
         logger_error_with_category("Jukebox", "Cannot set sample rate");
@@ -359,6 +362,7 @@ static void jukebox_cleanup_alsa(void) {
 #endif
 
 static int jukebox_play_wav_file(const char* wav_file) {
+    int err;
 #if HAVE_ALSA
     /* Initialize ALSA if not already done */
     if (!jukebox_data.pcm_handle) {
@@ -372,7 +376,7 @@ static int jukebox_play_wav_file(const char* wav_file) {
     jukebox_data.stop_audio = 0;
     
     /* Create audio thread */
-    int err = pthread_create(&jukebox_data.audio_thread, NULL, jukebox_audio_thread, (void*)wav_file);
+    err = pthread_create(&jukebox_data.audio_thread, NULL, jukebox_audio_thread, (void*)wav_file);
     if (err != 0) {
         logger_error_with_category("Jukebox", "Failed to create audio thread");
         return -1;

--- a/host/plugins/number_guess.c
+++ b/host/plugins/number_guess.c
@@ -106,7 +106,7 @@ int number_guess_compare(int secret, int guess) {
 
 static void ng_submit(void) {
     int guess, cmp;
-    char l2[21];
+    char l2[32];   /* room for "Higher (try %d)" with a worst-case int */
 
     if (ng.entry_len == 0) return; /* nothing entered */
     guess = atoi(ng.entry);

--- a/host/updater.c
+++ b/host/updater.c
@@ -82,8 +82,9 @@ static int do_check(void) {
 }
 
 static void *check_thread_func(void *arg) {
+    int rc;
     (void)arg;
-    int rc = do_check();
+    rc = do_check();
     pthread_mutex_lock(&check_mutex);
     check_state = 2;  /* checked */
     if (rc != 0) latest_version[0] = '\0';
@@ -162,8 +163,9 @@ const char *updater_get_apply_status(void) {
 
 /* #118: Run apply in background; returns immediately. */
 static void *apply_thread_func(void *arg) {
+    int rc;
     (void)arg;
-    int rc = updater_apply(apply_source_dir);
+    rc = updater_apply(apply_source_dir);
     if (rc != 0) {
         pthread_mutex_lock(&apply_mutex);
         apply_state = 0;
@@ -213,13 +215,10 @@ int updater_is_applying(void) {
 
 static int run_command(const char *cmd) {
     int rc;
-    char log_msg[512];
-    snprintf(log_msg, sizeof(log_msg), "Running: %s", cmd);
-    logger_info_with_category("Updater", log_msg);
+    logger_infof_with_category("Updater", "Running: %s", cmd);
     rc = system(cmd);
     if (rc != 0) {
-        snprintf(log_msg, sizeof(log_msg), "Command failed (exit %d): %s", rc, cmd);
-        logger_warn_with_category("Updater", log_msg);
+        logger_warnf_with_category("Updater", "Command failed (exit %d): %s", rc, cmd);
     }
     return rc;
 }

--- a/host/web_server.c
+++ b/host/web_server.c
@@ -42,9 +42,9 @@ void* web_server_thread_func(void* arg);
 
 /* String utility functions */
 void web_server_strcpy_safe(char* dest, const char* src, size_t dest_size) {
-    if (!dest || !src || dest_size == 0) return;
-    
     size_t i;
+    if (!dest || !src || dest_size == 0) return;
+
     for (i = 0; i < dest_size - 1 && src[i] != '\0'; i++) {
         dest[i] = src[i];
     }
@@ -52,12 +52,13 @@ void web_server_strcpy_safe(char* dest, const char* src, size_t dest_size) {
 }
 
 void web_server_strcat_safe(char* dest, const char* src, size_t dest_size) {
-    if (!dest || !src || dest_size == 0) return;
-    
-    size_t dest_len = web_server_strlen_safe(dest);
-    if (dest_len >= dest_size - 1) return;
-    
+    size_t dest_len;
     size_t i;
+    if (!dest || !src || dest_size == 0) return;
+
+    dest_len = web_server_strlen_safe(dest);
+    if (dest_len >= dest_size - 1) return;
+
     for (i = 0; i < dest_size - dest_len - 1 && src[i] != '\0'; i++) {
         dest[dest_len + i] = src[i];
     }
@@ -122,9 +123,10 @@ int web_server_strcasecmp(const char* s1, const char* s2) {
 
 /* WebServer creation and destruction */
 struct web_server* web_server_create(int port) {
+    int i;
     struct web_server* server = (struct web_server*)web_server_malloc(sizeof(struct web_server));
     if (!server) return NULL;
-    
+
     memset(server, 0, sizeof(struct web_server));
     server->port = port;
     server->running = 0;
@@ -137,7 +139,6 @@ struct web_server* web_server_create(int port) {
     server->rate_limit_count = 0;
     
     /* Initialize static route flags */
-    int i;
     for (i = 0; i < 16; i++) {
         server->static_is_file[i] = 0;
     }
@@ -230,10 +231,11 @@ int web_server_get_port(const struct web_server* server) {
 
 /* Route management */
 void web_server_add_route(struct web_server* server, const char* method, const char* path, route_handler_t handler) {
+    int idx;
     if (!server || !method || !path || !handler) return;
     if (server->route_count >= 32) return; /* Max routes reached */
-    
-    int idx = server->route_count;
+
+    idx = server->route_count;
     web_server_strcpy_safe(server->route_methods[idx], method, sizeof(server->route_methods[idx]));
     web_server_strcpy_safe(server->route_paths[idx], path, sizeof(server->route_paths[idx]));
     server->route_handlers[idx] = handler;
@@ -241,10 +243,11 @@ void web_server_add_route(struct web_server* server, const char* method, const c
 }
 
 void web_server_add_static_route(struct web_server* server, const char* path, const char* content, const char* content_type) {
+    int idx;
     if (!server || !path || !content || !content_type) return;
     if (server->static_count >= 16) return; /* Max static routes reached */
-    
-    int idx = server->static_count;
+
+    idx = server->static_count;
     web_server_strcpy_safe(server->static_paths[idx], path, sizeof(server->static_paths[idx]));
     web_server_strcpy_safe(server->static_contents[idx], content, sizeof(server->static_contents[idx]));
     web_server_strcpy_safe(server->static_content_types[idx], content_type, sizeof(server->static_content_types[idx]));
@@ -253,10 +256,11 @@ void web_server_add_static_route(struct web_server* server, const char* path, co
 }
 
 void web_server_add_file_route(struct web_server* server, const char* path, const char* file_path, const char* content_type) {
+    int idx;
     if (!server || !path || !file_path || !content_type) return;
     if (server->static_count >= 16) return; /* Max static routes reached */
-    
-    int idx = server->static_count;
+
+    idx = server->static_count;
     web_server_strcpy_safe(server->static_paths[idx], path, sizeof(server->static_paths[idx]));
     web_server_strcpy_safe(server->static_file_paths[idx], file_path, sizeof(server->static_file_paths[idx]));
     web_server_strcpy_safe(server->static_content_types[idx], content_type, sizeof(server->static_content_types[idx]));
@@ -267,79 +271,93 @@ void web_server_add_file_route(struct web_server* server, const char* path, cons
 /* HTTP parsing functions */
 struct http_request web_server_parse_request(const char* raw_request) {
     struct http_request request;
-    memset(&request, 0, sizeof(request));
-    
-    if (!raw_request) return request;
-    
-    /* Parse request line */
-    const char* line_start = raw_request;
-    const char* line_end = strchr(line_start, '\n');
-    if (!line_end) return request;
-    
-    /* Extract method and path */
+    const char* line_start;
+    const char* line_end;
     char request_line[512];
-    size_t line_len = line_end - line_start;
+    size_t line_len;
+    char* cr_pos;
+    char* query_pos;
+    const char* header_start;
+    memset(&request, 0, sizeof(request));
+
+    if (!raw_request) return request;
+
+    /* Parse request line */
+    line_start = raw_request;
+    line_end = strchr(line_start, '\n');
+    if (!line_end) return request;
+
+    /* Extract method and path */
+    line_len = line_end - line_start;
     if (line_len >= sizeof(request_line)) line_len = sizeof(request_line) - 1;
-    
+
     memcpy(request_line, line_start, line_len);
     request_line[line_len] = '\0';
-    
+
     /* Remove \r if present */
-    char* cr_pos = strchr(request_line, '\r');
+    cr_pos = strchr(request_line, '\r');
     if (cr_pos) *cr_pos = '\0';
-    
+
     /* Parse method and path */
     if (sscanf(request_line, "%15s %255s", request.method, request.path) != 2) {
         return request;
     }
-    
+
     /* Remove query parameters from path */
-    char* query_pos = strchr(request.path, '?');
+    query_pos = strchr(request.path, '?');
     if (query_pos) {
         *query_pos = '\0';
         web_server_parse_query_string(query_pos + 1, &request);
     }
-    
+
     /* Parse headers */
-    const char* header_start = line_end + 1;
+    header_start = line_end + 1;
     while (header_start && *header_start != '\0') {
-        const char* header_end = strchr(header_start, '\n');
+        const char* header_end;
+        char header_line[512];
+        size_t header_len;
+        char* cr_pos;
+        char* colon_pos;
+        header_end = strchr(header_start, '\n');
         if (!header_end) break;
-        
+
         /* Check for end of headers (empty line) */
         if (header_end == header_start + 1) {
             break;
         }
-        
-        char header_line[512];
-        size_t header_len = header_end - header_start;
+
+        header_len = header_end - header_start;
         if (header_len >= sizeof(header_line)) header_len = sizeof(header_line) - 1;
-        
+
         memcpy(header_line, header_start, header_len);
         header_line[header_len] = '\0';
-        
+
         /* Remove \r if present */
-        char* cr_pos = strchr(header_line, '\r');
+        cr_pos = strchr(header_line, '\r');
         if (cr_pos) *cr_pos = '\0';
-        
+
         /* Parse header key:value */
-        char* colon_pos = strchr(header_line, ':');
+        colon_pos = strchr(header_line, ':');
         if (colon_pos && request.header_count < 32) {
+            char* key;
+            char* value;
+            char* key_end;
+            char* value_end;
             *colon_pos = '\0';
-            char* key = header_line;
-            char* value = colon_pos + 1;
-            
+            key = header_line;
+            value = colon_pos + 1;
+
             /* Trim whitespace */
             while (*key == ' ' || *key == '\t') key++;
             while (*value == ' ' || *value == '\t') value++;
-            
-            char* key_end = key + strlen(key) - 1;
+
+            key_end = key + strlen(key) - 1;
             while (key_end > key && (*key_end == ' ' || *key_end == '\t' || *key_end == '\r')) {
                 *key_end = '\0';
                 key_end--;
             }
-            
-            char* value_end = value + strlen(value) - 1;
+
+            value_end = value + strlen(value) - 1;
             while (value_end > value && (*value_end == ' ' || *value_end == '\t' || *value_end == '\r')) {
                 *value_end = '\0';
                 value_end--;
@@ -365,29 +383,35 @@ struct http_request web_server_parse_request(const char* raw_request) {
 }
 
 void web_server_parse_query_string(const char* query, struct http_request* request) {
+    const char* start;
     if (!query || !request) return;
-    
-    const char* start = query;
+
+    start = query;
     while (*start && request->query_count < 16) {
-        const char* end = strchr(start, '&');
-        if (!end) end = start + strlen(start);
-        
+        const char* end;
         char pair[256];
-        size_t pair_len = end - start;
+        size_t pair_len;
+        char* eq_pos;
+        end = strchr(start, '&');
+        if (!end) end = start + strlen(start);
+
+        pair_len = end - start;
         if (pair_len >= sizeof(pair)) pair_len = sizeof(pair) - 1;
-        
+
         memcpy(pair, start, pair_len);
         pair[pair_len] = '\0';
-        
-        char* eq_pos = strchr(pair, '=');
+
+        eq_pos = strchr(pair, '=');
         if (eq_pos) {
-            *eq_pos = '\0';
-            char* key = pair;
-            char* value = eq_pos + 1;
-            
-            /* URL decode */
+            char* key;
+            char* value;
             char decoded_key[64];
             char decoded_value[256];
+            *eq_pos = '\0';
+            key = pair;
+            value = eq_pos + 1;
+
+            /* URL decode */
             web_server_url_decode(key, decoded_key, sizeof(decoded_key));
             web_server_url_decode(value, decoded_value, sizeof(decoded_value));
             
@@ -402,9 +426,10 @@ void web_server_parse_query_string(const char* query, struct http_request* reque
 }
 
 char* web_server_url_decode(const char* str, char* result, size_t result_size) {
+    size_t i, j;
     if (!str || !result || result_size == 0) return NULL;
-    
-    size_t i, j = 0;
+
+    j = 0;
     for (i = 0; str[i] != '\0' && j < result_size - 1; i++) {
         if (str[i] == '%' && i + 2 < strlen(str)) {
             char hex[3] = {str[i+1], str[i+2], '\0'};
@@ -427,19 +452,22 @@ char* web_server_url_decode(const char* str, char* result, size_t result_size) {
 
 /* Socket initialization */
 void web_server_init_socket(struct web_server* server) {
+    int opt;
+    struct sockaddr_in address;
+    int flags;
+    char start_msg[256];
     if (!server) return;
-    
+
     server->server_fd = socket(AF_INET, SOCK_STREAM, 0);
     if (server->server_fd < 0) {
         logger_error_with_category("WebServer", "Failed to create socket");
         return;
     }
-    
+
     /* Set socket options for reuse */
-    int opt = 1;
+    opt = 1;
     setsockopt(server->server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-    
-    struct sockaddr_in address;
+
     address.sin_family = AF_INET;
     address.sin_addr.s_addr = INADDR_ANY;
     address.sin_port = htons(server->port);
@@ -461,10 +489,9 @@ void web_server_init_socket(struct web_server* server) {
     }
     
     /* Set socket to non-blocking */
-    int flags = fcntl(server->server_fd, F_GETFL, 0);
+    flags = fcntl(server->server_fd, F_GETFL, 0);
     fcntl(server->server_fd, F_SETFL, flags | O_NONBLOCK);
-    
-    char start_msg[256];
+
     snprintf(start_msg, sizeof(start_msg), "Web server started on port %d", server->port);
     logger_info_with_category("WebServer", start_msg);
 }
@@ -478,7 +505,7 @@ void* web_server_thread_func(void* arg) {
     while (!server->should_stop) {
         struct sockaddr_in client_addr;
         socklen_t client_len = sizeof(client_addr);
-        
+        struct timeval tv;
         int client_fd = accept(server->server_fd, (struct sockaddr*)&client_addr, &client_len);
         
         if (client_fd >= 0) {
@@ -493,7 +520,6 @@ void* web_server_thread_func(void* arg) {
         
         /* Small sleep to prevent busy waiting */
         /* Use select() for C89-compatible microsecond sleep */
-        struct timeval tv;
         tv.tv_sec = 0;
         tv.tv_usec = 1000; /* 1ms */
         select(0, NULL, NULL, NULL, &tv);
@@ -503,17 +529,19 @@ void* web_server_thread_func(void* arg) {
 }
 
 void web_server_handle_client(struct web_server* server, int client_fd) {
+    char buffer[4096] = {0};
+    ssize_t bytes_read;
     if (!server) {
         close(client_fd);
         return;
     }
-    
-    char buffer[4096] = {0};
-    ssize_t bytes_read = read(client_fd, buffer, sizeof(buffer) - 1);
-    
+
+    bytes_read = read(client_fd, buffer, sizeof(buffer) - 1);
+
     if (bytes_read > 0) {
         struct http_request parsed_request = web_server_parse_request(buffer);
-        
+        struct http_response response;
+
         /* Get client IP for rate limiting */
         struct sockaddr_in client_addr;
         socklen_t client_len = sizeof(client_addr);
@@ -522,8 +550,8 @@ void web_server_handle_client(struct web_server* server, int client_fd) {
         } else {
             web_server_strcpy_safe(parsed_request.client_ip, "unknown", sizeof(parsed_request.client_ip));
         }
-        
-        struct http_response response = web_server_process_request(server, &parsed_request);
+
+        response = web_server_process_request(server, &parsed_request);
         
         if (response.status_code == 101) {
             /* WebSocket upgrade — send handshake then keep fd open */
@@ -559,6 +587,7 @@ void web_server_handle_client(struct web_server* server, int client_fd) {
 /* Request processing */
 struct http_response web_server_process_request(struct web_server* server, const struct http_request* request) {
     struct http_response response;
+    int i;
     memset(&response, 0, sizeof(response));
     response.status_code = 200;
     
@@ -611,17 +640,17 @@ struct http_response web_server_process_request(struct web_server* server, const
     }
     
     /* Check static routes first */
-    int i;
     for (i = 0; i < server->static_count; i++) {
         if (strcmp(server->static_paths[i], request->path) == 0) {
             if (server->static_is_file[i]) {
                 /* File route - create streaming response */
+                FILE* file;
                 response.is_streaming = 1;
                 web_server_strcpy_safe(response.file_path, server->static_file_paths[i], sizeof(response.file_path));
                 web_server_strcpy_safe(response.content_type, server->static_content_types[i], sizeof(response.content_type));
-                
+
                 /* Get file size for Content-Length header */
-                FILE* file = fopen(response.file_path, "rb");
+                file = fopen(response.file_path, "rb");
                 if (file) {
                     fseek(file, 0, SEEK_END);
                     response.content_length = ftell(file);
@@ -652,11 +681,10 @@ struct http_response web_server_process_request(struct web_server* server, const
 }
 
 int web_server_is_websocket_upgrade(const struct http_request* request) {
-    if (!request) return 0;
-    
     int i;
     int has_upgrade = 0, has_connection = 0;
-    
+    if (!request) return 0;
+
     for (i = 0; i < request->header_count; i++) {
         if (web_server_strcasecmp(request->header_keys[i], "Upgrade") == 0) {
             if (web_server_strcasecmp(request->header_values[i], "websocket") == 0) {
@@ -674,21 +702,28 @@ int web_server_is_websocket_upgrade(const struct http_request* request) {
 
 /* Response serialization */
 char* web_server_serialize_response(const struct http_response* response) {
+    size_t total_size;
+    char* result;
+    char* ptr;
+    size_t remaining;
+    const char* status_text = "OK";
+    int written;
+    int i;
+    size_t body_len;
     if (!response) return NULL;
-    
+
     /* Calculate total size needed */
-    size_t total_size = 1024; /* Base size for status line and headers */
+    total_size = 1024; /* Base size for status line and headers */
     total_size += strlen(response->body);
     total_size += response->header_count * 128; /* Space for headers */
-    
-    char* result = (char*)web_server_malloc(total_size);
+
+    result = (char*)web_server_malloc(total_size);
     if (!result) return NULL;
-    
-    char* ptr = result;
-    size_t remaining = total_size;
-    
+
+    ptr = result;
+    remaining = total_size;
+
     /* Status line */
-    const char* status_text = "OK";
     switch (response->status_code) {
         case 200: status_text = "OK"; break;
         case 404: status_text = "Not Found"; break;
@@ -698,14 +733,13 @@ char* web_server_serialize_response(const struct http_response* response) {
         default: status_text = "Unknown"; break;
     }
     
-    int written = snprintf(ptr, remaining, "HTTP/1.1 %d %s\r\n", response->status_code, status_text);
+    written = snprintf(ptr, remaining, "HTTP/1.1 %d %s\r\n", response->status_code, status_text);
     if (written > 0 && (size_t)written < remaining) {
         ptr += written;
         remaining -= written;
     }
-    
+
     /* Headers */
-    int i;
     for (i = 0; i < response->header_count; i++) {
         written = snprintf(ptr, remaining, "%s: %s\r\n", 
                           response->header_keys[i], response->header_values[i]);
@@ -739,7 +773,7 @@ char* web_server_serialize_response(const struct http_response* response) {
     }
     
     /* Body */
-    size_t body_len = strlen(response->body);
+    body_len = strlen(response->body);
     if (body_len < remaining) {
         memcpy(ptr, response->body, body_len);
         ptr += body_len;
@@ -770,13 +804,14 @@ void web_server_setup_api_routes(struct web_server* server) {
 
 /* Default handlers */
 struct http_response web_server_handle_not_found(const struct http_request* request) {
-    (void)request; /* Suppress unused parameter warning */
     struct http_response response;
+    const char* html;
+    (void)request; /* Suppress unused parameter warning */
     memset(&response, 0, sizeof(response));
     response.status_code = 404;
     web_server_strcpy_safe(response.content_type, "text/html", sizeof(response.content_type));
-    
-    const char* html = 
+
+    html =
         "<!DOCTYPE html>\n"
         "<html>\n"
         "<head>\n"
@@ -798,18 +833,21 @@ struct http_response web_server_handle_not_found(const struct http_request* requ
 }
 
 struct http_response web_server_handle_api_status(const struct http_request* request) {
-    (void)request; /* Suppress unused parameter warning */
     struct http_response response;
+    time_t now;
+    time_t start_time;
+    time_t uptime_seconds;
+    char json[512];
+    (void)request; /* Suppress unused parameter warning */
     memset(&response, 0, sizeof(response));
     response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
-    
+
     /* Calculate actual uptime */
-    time_t now = time(NULL);
-    time_t start_time = get_daemon_start_time();
-    time_t uptime_seconds = now - start_time;
-    
-    char json[512];
+    now = time(NULL);
+    start_time = get_daemon_start_time();
+    uptime_seconds = now - start_time;
+
     snprintf(json, sizeof(json),
         "{"
         "\"status\":\"running\","
@@ -823,14 +861,15 @@ struct http_response web_server_handle_api_status(const struct http_request* req
 }
 
 struct http_response web_server_handle_api_metrics(const struct http_request* request) {
-    (void)request; /* Suppress unused parameter warning */
     struct http_response response;
+    char *json_data;
+    (void)request; /* Suppress unused parameter warning */
     memset(&response, 0, sizeof(response));
     response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
-    
+
     /* Use C89 metrics API - simplified version */
-    char *json_data = metrics_export_json();
+    json_data = metrics_export_json();
     if (json_data) {
         web_server_strcpy_safe(response.body, json_data, sizeof(response.body));
         free(json_data);
@@ -841,32 +880,37 @@ struct http_response web_server_handle_api_metrics(const struct http_request* re
 }
 
 struct http_response web_server_handle_api_health(const struct http_request* request) {
-    (void)request; /* Suppress unused parameter warning */
     struct http_response response;
+    health_status_t overall_status;
+    health_check_t checks[32];
+    int checks_count;
+    char escaped_overall[32];
+    char json[2048];
+    char* ptr;
+    size_t remaining;
+    int written;
+    int i;
+    int first = 1;
+    (void)request; /* Suppress unused parameter warning */
     memset(&response, 0, sizeof(response));
     response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
-    
-    health_status_t overall_status = health_monitor_get_overall_status();
-    health_check_t checks[32];
-    int checks_count = health_monitor_get_all_checks(checks, 32);
-    
-    char escaped_overall[32];
+
+    overall_status = health_monitor_get_overall_status();
+    checks_count = health_monitor_get_all_checks(checks, 32);
+
     web_server_json_escape(health_monitor_status_to_string(overall_status),
                           escaped_overall, sizeof(escaped_overall));
-    char json[2048];
-    char* ptr = json;
-    size_t remaining = sizeof(json);
-    
-    int written = snprintf(ptr, remaining, "{\"overall_status\":\"%s\",\"checks\":{", 
+    ptr = json;
+    remaining = sizeof(json);
+
+    written = snprintf(ptr, remaining, "{\"overall_status\":\"%s\",\"checks\":{",
                           escaped_overall);
     if (written > 0 && (size_t)written < remaining) {
         ptr += written;
         remaining -= written;
     }
-    
-    int i;
-    int first = 1;
+
     for (i = 0; i < checks_count && remaining > 200; i++) {
         char escaped_name[64];
         char escaped_status[32];
@@ -903,25 +947,26 @@ struct http_response web_server_handle_api_health(const struct http_request* req
 }
 
 struct http_response web_server_handle_api_config(const struct http_request* request) {
-    (void)request; /* Suppress unused parameter warning */
     struct http_response response;
+    config_data_t* config;
+    char escaped_device[128];
+    char escaped_level[32];
+    char escaped_file[256];
+    char json[2048];
+    (void)request; /* Suppress unused parameter warning */
     memset(&response, 0, sizeof(response));
     response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
-    
-    config_data_t* config = config_get_instance();
+
+    config = config_get_instance();
     if (!config) {
         web_server_strcpy_safe(response.body, "{\"error\":\"Config not available\"}", sizeof(response.body));
         return response;
     }
-    
-    char escaped_device[128];
-    char escaped_level[32];
-    char escaped_file[256];
+
     web_server_json_escape(config_get_display_device(config), escaped_device, sizeof(escaped_device));
     web_server_json_escape(config_get_log_level(config), escaped_level, sizeof(escaped_level));
     web_server_json_escape(config_get_log_file(config), escaped_file, sizeof(escaped_file));
-    char json[2048];
     snprintf(json, sizeof(json),
         "{"
         "\"hardware\":{"
@@ -969,20 +1014,21 @@ struct http_response web_server_handle_api_config(const struct http_request* req
 }
 
 struct http_response web_server_handle_api_state(const struct http_request* request) {
-    (void)request; /* Suppress unused parameter warning */
     struct http_response response;
+    char json[1024];
+    struct daemon_state_info state_info;
+    char line1[64], line2[64];
+    char escaped_line1[128], escaped_line2[128];
+    char escaped_keypad[128];
+    char escaped_error[256];
+    (void)request; /* Suppress unused parameter warning */
     memset(&response, 0, sizeof(response));
     response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
-    
-    char json[1024];
-    struct daemon_state_info state_info = get_daemon_state_info();
-    char line1[64], line2[64];
-    char escaped_line1[128], escaped_line2[128];
+
+    state_info = get_daemon_state_info();
 
     /* Escape strings for JSON (prevent injection from keypad_buffer, sip_last_error) */
-    char escaped_keypad[128];
-    char escaped_error[256];
     web_server_json_escape(state_info.keypad_buffer, escaped_keypad, sizeof(escaped_keypad));
     web_server_json_escape(state_info.sip_last_error, escaped_error, sizeof(escaped_error));
 
@@ -1016,18 +1062,24 @@ struct http_response web_server_handle_api_state(const struct http_request* requ
 
 struct http_response web_server_handle_api_control(const struct http_request* request) {
     struct http_response response;
-    memset(&response, 0, sizeof(response));
-    response.status_code = 200;
-    web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
-    
     char json[1024];
     char action[64] = "unknown";
     char key[16] = "";
     char plugin[64] = "";
     int cents = 0;
-    
+    char* action_pos;
+    char* key_pos;
+    char* plugin_pos;
+    int success = 0;
+    char message[256] = "Unknown action";
+    char escaped_action[128];
+    char escaped_message[512];
+    memset(&response, 0, sizeof(response));
+    response.status_code = 200;
+    web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
+
     /* Parse action from JSON body */
-    char* action_pos = strstr(request->body, "\"action\":\"");
+    action_pos = strstr(request->body, "\"action\":\"");
     if (action_pos) {
         char* start = action_pos + 10; /* Length of "action":" */
         char* end = strchr(start, '"');
@@ -1041,7 +1093,7 @@ struct http_response web_server_handle_api_control(const struct http_request* re
     }
     
     /* Parse key for keypad actions (supports "key" or "arg") */
-    char* key_pos = strstr(request->body, "\"key\":\"");
+    key_pos = strstr(request->body, "\"key\":\"");
     if (key_pos) {
         char* start = key_pos + 7; /* Length of "key":" */
         char* end = strchr(start, '"');
@@ -1092,7 +1144,7 @@ struct http_response web_server_handle_api_control(const struct http_request* re
     }
     
     /* Parse plugin for plugin actions */
-    char* plugin_pos = strstr(request->body, "\"plugin\":\"");
+    plugin_pos = strstr(request->body, "\"plugin\":\"");
     if (plugin_pos) {
         char* start = plugin_pos + 10; /* Length of "plugin":" */
         char* end = strchr(start, '"');
@@ -1106,9 +1158,6 @@ struct http_response web_server_handle_api_control(const struct http_request* re
     }
     
     /* Handle different actions */
-    int success = 0;
-    char message[256] = "Unknown action";
-    
     if (strcmp(action, "start_call") == 0) {
         success = send_control_command("start_call");
         snprintf(message, sizeof(message), "%s", success ? "Call initiation requested" : "Failed to initiate call");
@@ -1161,8 +1210,6 @@ struct http_response web_server_handle_api_control(const struct http_request* re
     }
     
     /* Escape for JSON to prevent injection when action/message contain " or \ */
-    char escaped_action[128];
-    char escaped_message[512];
     web_server_json_escape(action, escaped_action, sizeof(escaped_action));
     web_server_json_escape(message, escaped_message, sizeof(escaped_message));
     
@@ -1182,22 +1229,31 @@ struct http_response web_server_handle_api_control(const struct http_request* re
 
 struct http_response web_server_handle_api_logs(const struct http_request* request) {
     struct http_response response;
+    char level[16] = "INFO";
+    int i;
+    int max_entries = 20;
+    char json[8192];
+    char* ptr = json;
+    size_t remaining = sizeof(json);
+    int written;
+    log_level_t min_level = LOG_LEVEL_INFO;
+    char log_buffer[50][512];
+    int log_count;
+    int first = 1;
+    int total_count = 0;
     memset(&response, 0, sizeof(response));
     response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
-    
+
     /* Get log level parameter */
-    char level[16] = "INFO";
-    int i;
     for (i = 0; i < request->query_count; i++) {
         if (strcmp(request->query_keys[i], "level") == 0) {
             web_server_strcpy_safe(level, request->query_values[i], sizeof(level));
             break;
         }
     }
-    
+
     /* Get max entries parameter (default to 20, max 50) */
-    int max_entries = 20;
     for (i = 0; i < request->query_count; i++) {
         if (strcmp(request->query_keys[i], "max_entries") == 0) {
             max_entries = atoi(request->query_values[i]);
@@ -1206,25 +1262,32 @@ struct http_response web_server_handle_api_logs(const struct http_request* reque
             break;
         }
     }
-    
-    char json[8192];
-    char* ptr = json;
-    size_t remaining = sizeof(json);
-    
-    int written = snprintf(ptr, remaining, "{\"logs\":[");
+
+    written = snprintf(ptr, remaining, "{\"logs\":[");
     if (written > 0 && (size_t)written < remaining) {
         ptr += written;
         remaining -= written;
     }
-    
-    /* Get logs from memory */
-    char log_buffer[50][512];
-    int log_count = logger_get_recent_logs(log_buffer, max_entries);
-    
-    int first = 1;
-    int total_count = 0;
+
+    /* Map requested level name -> minimum severity. This is a THRESHOLD, not an
+     * exact match, so an INFO view still surfaces WARN/ERROR. */
+    if (strcmp(level, "ALL") == 0 || strcmp(level, "VERBOSE") == 0) min_level = LOG_LEVEL_VERBOSE;
+    else if (strcmp(level, "DEBUG") == 0) min_level = LOG_LEVEL_DEBUG;
+    else if (strcmp(level, "INFO") == 0) min_level = LOG_LEVEL_INFO;
+    else if (strcmp(level, "WARN") == 0 || strcmp(level, "WARNING") == 0) min_level = LOG_LEVEL_WARN;
+    else if (strcmp(level, "ERROR") == 0) min_level = LOG_LEVEL_ERROR;
+
+    /* Get logs from memory, level-filtered across the whole ring buffer so
+     * INFO+ events appear even when DEBUG output dominates the recent window. */
+    log_count = logger_get_recent_logs_min_level(log_buffer, max_entries, min_level);
+
     /* Process logs in reverse order (newest first) */
     for (i = log_count - 1; i >= 0 && remaining > 200; i--) {
+        char escaped_message[512];
+        time_t log_timestamp;
+        char log_level[16] = "INFO"; /* Default level */
+        char* timestamp_start;
+        char escaped_level[32];
         if (!first) {
             written = snprintf(ptr, remaining, ",");
             if (written > 0 && (size_t)written < remaining) {
@@ -1234,11 +1297,14 @@ struct http_response web_server_handle_api_logs(const struct http_request* reque
         }
         
         /* JSON-escape log message: ", \, and control chars (#112) */
-        char escaped_message[512];
         {
             char *src = log_buffer[i];
             char *dst = escaped_message;
             size_t dst_remaining = sizeof(escaped_message) - 1;
+            /* Skip the "[timestamp] [LEVEL] " prefix so the message field holds
+             * just "[category] text" (the client renders its own time + level). */
+            { char *b1 = strchr(src, ']');
+              if (b1) { char *b2 = strchr(b1 + 1, ']'); if (b2 && b2[1] == ' ') src = b2 + 2; } }
             while (*src && dst_remaining > 2) {
                 if (*src == '"' || *src == '\\') {
                     *dst++ = '\\';
@@ -1263,17 +1329,17 @@ struct http_response web_server_handle_api_logs(const struct http_request* reque
         }
         
         /* Extract timestamp and level from the log message */
-        time_t log_timestamp = time(NULL); /* Default to current time */
-        char log_level[16] = "INFO"; /* Default level */
-        
+        log_timestamp = time(NULL); /* Default to current time */
+
         /* Try to parse timestamp from log message format: [YYYY-MM-DD HH:MM:SS.mmm] [LEVEL] [CATEGORY] message */
-        char* timestamp_start = strstr(log_buffer[i], "[");
+        timestamp_start = strstr(log_buffer[i], "[");
         if (timestamp_start) {
             char* timestamp_end = strstr(timestamp_start + 1, "]");
             if (timestamp_end) {
                 /* Parse the timestamp - format: YYYY-MM-DD HH:MM:SS.mmm */
                 int year, month, day, hour, min, sec, msec;
-                if (sscanf(timestamp_start + 1, "%d-%d-%d %d:%d:%d.%d", 
+                char* level_start;
+                if (sscanf(timestamp_start + 1, "%d-%d-%d %d:%d:%d.%d",
                           &year, &month, &day, &hour, &min, &sec, &msec) == 7) {
                     /* Convert to time_t (approximate) */
                     struct tm tm_time = {0};
@@ -1287,7 +1353,7 @@ struct http_response web_server_handle_api_logs(const struct http_request* reque
                 }
                 
                 /* Try to parse log level from the next [LEVEL] section */
-                char* level_start = strstr(timestamp_end + 1, "[");
+                level_start = strstr(timestamp_end + 1, "[");
                 if (level_start) {
                     char* level_end = strstr(level_start + 1, "]");
                     if (level_end) {
@@ -1301,33 +1367,9 @@ struct http_response web_server_handle_api_logs(const struct http_request* reque
             }
         }
         
-        /* Filter by level if specified */
-        if (strcmp(level, "ALL") != 0) {
-            /* Convert both to uppercase for comparison */
-            char upper_level[16];
-            char upper_log_level[16];
-            int j;
-            
-            /* Convert requested level to uppercase */
-            for (j = 0; level[j] != '\0' && j < (int)(sizeof(upper_level) - 1); j++) {
-                upper_level[j] = toupper(level[j]);
-            }
-            upper_level[j] = '\0';
-            
-            /* Convert log level to uppercase */
-            for (j = 0; log_level[j] != '\0' && j < (int)(sizeof(upper_log_level) - 1); j++) {
-                upper_log_level[j] = toupper(log_level[j]);
-            }
-            upper_log_level[j] = '\0';
-            
-            /* Skip if level doesn't match */
-            if (strcmp(upper_level, upper_log_level) != 0) {
-                continue;
-            }
-        }
-        
+        /* Level filtering already applied by logger_get_recent_logs_min_level. */
+
         /* Escape log_level for JSON (parsed from log, could have special chars) */
-        char escaped_level[32];
         web_server_json_escape(log_level, escaped_level, sizeof(escaped_level));
         written = snprintf(ptr, remaining,
             "{\"timestamp\":%ld,\"level\":\"%s\",\"message\":\"%s\"}",
@@ -1352,13 +1394,12 @@ struct http_response web_server_handle_api_logs(const struct http_request* reque
 }
 
 struct http_response web_server_handle_api_plugins(const struct http_request* request) {
-    (void)request; /* Suppress unused parameter warning */
     struct http_response response;
+    char json[2048];
+    (void)request; /* Suppress unused parameter warning */
     memset(&response, 0, sizeof(response));
     response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
-    
-    char json[2048];
 
     /* Enumerate the registry dynamically so newly added plugins appear in the
      * dashboard automatically (no hard-coded list to keep in sync). */
@@ -1372,9 +1413,9 @@ struct http_response web_server_handle_api_plugins(const struct http_request* re
 }
 
 struct http_response web_server_handle_api_version(const struct http_request* request) {
-    (void)request;
     struct http_response response;
     char json[512];
+    (void)request;
     memset(&response, 0, sizeof(response));
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
     response.status_code = 200;
@@ -1386,10 +1427,10 @@ struct http_response web_server_handle_api_version(const struct http_request* re
 }
 
 struct http_response web_server_handle_api_check_update(const struct http_request* request) {
-    (void)request;
     struct http_response response;
     char json[512];
     const char *latest;
+    (void)request;
     memset(&response, 0, sizeof(response));
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
     response.status_code = 200;
@@ -1411,11 +1452,11 @@ struct http_response web_server_handle_api_check_update(const struct http_reques
 }
 
 struct http_response web_server_handle_api_update(const struct http_request* request) {
-    (void)request;
     struct http_response response;
     char json[512];
     const char *source_dir;
     int rc;
+    (void)request;
     memset(&response, 0, sizeof(response));
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
 
@@ -1439,8 +1480,8 @@ struct http_response web_server_handle_api_update(const struct http_request* req
 }
 
 struct http_response web_server_handle_dashboard(const struct http_request* request) {
-    (void)request;
     struct http_response response;
+    (void)request;
     memset(&response, 0, sizeof(response));
     response.status_code = 200;
     web_server_strcpy_safe(response.content_type, "text/html", sizeof(response.content_type));
@@ -1618,14 +1659,16 @@ int web_server_is_audio_active(void) {
 }
 
 int web_server_check_rate_limit(struct web_server* server, const char* client_ip, const char* endpoint) {
-    if (!server || !client_ip || !endpoint) return 1;
-    
-    time_t now = time(NULL);
+    time_t now;
     char key[128];
-    snprintf(key, sizeof(key), "%s:%s", client_ip, endpoint);
-    
-    /* Clean up old entries (older than 60 seconds) */
     int i;
+    int found_idx = -1;
+    if (!server || !client_ip || !endpoint) return 1;
+
+    now = time(NULL);
+    snprintf(key, sizeof(key), "%s:%s", client_ip, endpoint);
+
+    /* Clean up old entries (older than 60 seconds) */
     for (i = 0; i < server->rate_limit_count; i++) {
         if (now - server->rate_limit_infos[i].last_request > 60) {
             /* Remove this entry by shifting remaining entries */
@@ -1641,7 +1684,6 @@ int web_server_check_rate_limit(struct web_server* server, const char* client_ip
     }
     
     /* Find existing entry or create new one */
-    int found_idx = -1;
     for (i = 0; i < server->rate_limit_count; i++) {
         if (strcmp(server->rate_limit_keys[i], key) == 0) {
             found_idx = i;
@@ -1653,8 +1695,8 @@ int web_server_check_rate_limit(struct web_server* server, const char* client_ip
         /* Create new entry */
         if (server->rate_limit_count < 64) {
             found_idx = server->rate_limit_count;
-            strncpy(server->rate_limit_keys[found_idx], key, sizeof(server->rate_limit_keys[found_idx]) - 1);
-            server->rate_limit_keys[found_idx][sizeof(server->rate_limit_keys[found_idx]) - 1] = '\0';
+            web_server_strcpy_safe(server->rate_limit_keys[found_idx], key,
+                                   sizeof(server->rate_limit_keys[found_idx]));
             server->rate_limit_infos[found_idx].request_count = 0;
             server->rate_limit_count++;
         } else {
@@ -1671,6 +1713,7 @@ int web_server_check_rate_limit(struct web_server* server, const char* client_ip
 
 struct http_response web_server_create_rate_limit_response(void) {
     struct http_response response;
+    const char* json;
     memset(&response, 0, sizeof(response));
     response.status_code = 429; /* Too Many Requests */
     
@@ -1680,7 +1723,7 @@ struct http_response web_server_create_rate_limit_response(void) {
     
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
     
-    const char* json = 
+    json =
         "{"
         "\"error\": \"Rate limit exceeded\","
         "\"message\": \"Too many requests. Please slow down, especially during calls.\","
@@ -1720,15 +1763,21 @@ void web_server_broadcast_to_websockets(struct web_server* server, const char* m
 
 /* Streaming response implementation */
 int web_server_send_streaming_response(int client_fd, const struct http_response* response) {
-    if (!response || !response->is_streaming) return -1;
-    
-    /* Send HTTP headers first */
     char headers[1024];
     char* ptr = headers;
     size_t remaining = sizeof(headers);
-    
+    int written;
+    int i;
+    FILE* file;
+    char buffer[8192];  /* 8KB buffer for efficient reading */
+    size_t bytes_read;
+    int total_sent = 0;
+    if (!response || !response->is_streaming) return -1;
+
+    /* Send HTTP headers first */
+
     /* Status line */
-    int written = snprintf(ptr, remaining, "HTTP/1.1 %d OK\r\n", response->status_code);
+    written = snprintf(ptr, remaining, "HTTP/1.1 %d OK\r\n", response->status_code);
     if (written > 0 && (size_t)written < remaining) {
         ptr += written;
         remaining -= written;
@@ -1749,7 +1798,6 @@ int web_server_send_streaming_response(int client_fd, const struct http_response
     }
     
     /* Additional headers */
-    int i;
     for (i = 0; i < response->header_count; i++) {
         written = snprintf(ptr, remaining, "%s: %s\r\n", 
                           response->header_keys[i], response->header_values[i]);
@@ -1772,15 +1820,11 @@ int web_server_send_streaming_response(int client_fd, const struct http_response
     }
     
     /* Open and send file content */
-    FILE* file = fopen(response->file_path, "rb");
+    file = fopen(response->file_path, "rb");
     if (!file) {
         return -1;
     }
-    
-    char buffer[8192];  /* 8KB buffer for efficient reading */
-    size_t bytes_read;
-    int total_sent = 0;
-    
+
     while ((bytes_read = fread(buffer, 1, sizeof(buffer), file)) > 0) {
         ssize_t sent = send(client_fd, buffer, bytes_read, 0);
         if (sent < 0) {

--- a/host/websocket.c
+++ b/host/websocket.c
@@ -121,7 +121,7 @@ static void base64_encode(const uint8_t *in, size_t in_len, char *out, size_t ou
 
 int ws_compute_accept_key(const char *client_key, char *out, size_t out_size) {
     char concat[128];
-    uint8_t digest[20];
+    uint8_t digest[20] = {0};
 
     if (!client_key || !out || out_size < 29) return -1;
 


### PR DESCRIPTION
Three related backend/build changes (bundled because they touch overlapping files and `-Werror` only stays green with all the warning fixes present).

## 1. Unify on C89
The codebase had a `-std=c89` / `-std=c99` split. The "C99" files actually needed it for **ALSA/PJSIP system headers** (which use `inline`), not their own code. Now everything compiles with **`-std=gnu89`** (C89 language + the GNU extensions those headers require; strict `-std=c89` can't parse them), and **`-Wdeclaration-after-statement`** keeps our source free of C99-style mixed declarations. ~90 declaration sites were hoisted to block tops.

## 2. Treat all warnings as errors (`-Werror`)
Resolved every warning on **both** compilers (clang for the Mac test build, gcc for the Pi daemon):

| Warning | Fix |
|---------|-----|
| `-Wmaybe-uninitialized` (websocket SHA1 digest) | zero-initialise `digest[20]` |
| `-Wstringop-truncation` (logger, `safe_strcpy`, rate-limit key) | `strncpy` → `memcpy` / existing safe helper |
| `-Wformat-truncation` (updater, number_guess) | use `logger_*f` variants; widen line buffer |
| clang unused-arg (`-lpthread`/`-lm` on `-c` lines) | move to link lines only |

## 3. Fix `/api/logs` (returned empty)
Under `logging.level=DEBUG` the endpoint returned `{logs:[],total:0}` because the filter was **exact-match** and the recent ring buffer was flooded with DEBUG. Added `logger_get_recent_logs_min_level` (scans the full ring for the newest entries **≥** a severity), made the handler a **threshold** (an INFO view now also shows WARN/ERROR), and stripped the redundant `[timestamp] [LEVEL]` prefix from the message field.

## Testing
- `make test` passes.
- **Warning-clean `-Werror` build on both Mac (clang) and Pi (gcc).**
- Daemon deployed and verified: `active`, `NRestarts=0`, SIP-registered, `/api/logs?level=INFO` returns entries.

CLAUDE.md updated to describe the single C89/gnu89 standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)