### PR TITLE
plugins: make event dispatch thread-safe

### DIFF
--- a/host/plugins.c
+++ b/host/plugins.c
@@ -259,61 +259,70 @@ int plugins_to_json(char *buffer, size_t buffer_size) {
     return (int)pos;
 }
 
-int plugins_handle_coin(int coin_value, const char *coin_code) {
+/* Capture the active plugin's table entry under the registry mutex.
+ *
+ * Dispatch happens on the daemon event thread while activation
+ * (plugins_activate) can run concurrently on the web-server thread, so
+ * reading active_plugin_index without the lock is a data race. We snapshot
+ * the pointer here under the lock and let the caller invoke the handler
+ * *outside* the lock: the plugins[] table is a fixed static array whose
+ * entries are never moved or unregistered, so the returned pointer stays
+ * valid, and dispatching unlocked avoids holding the mutex across a plugin
+ * callback (which may re-enter the registry and would otherwise deadlock).
+ * Returns NULL when no plugin is active. */
+static plugin_t *plugins_snapshot_active(void) {
+    plugin_t *active = NULL;
+    pthread_mutex_lock(&plugins_mutex);
     if (active_plugin_index >= 0 && active_plugin_index < plugin_count) {
-        plugin_t *active_plugin = &plugins[active_plugin_index];
-        if (active_plugin->handle_coin) {
-            return active_plugin->handle_coin(coin_value, coin_code);
-        }
+        active = &plugins[active_plugin_index];
+    }
+    pthread_mutex_unlock(&plugins_mutex);
+    return active;
+}
+
+int plugins_handle_coin(int coin_value, const char *coin_code) {
+    plugin_t *active = plugins_snapshot_active();
+    if (active && active->handle_coin) {
+        return active->handle_coin(coin_value, coin_code);
     }
     return -1; /* No active plugin or handler */
 }
 
 int plugins_handle_keypad(char key) {
-    if (active_plugin_index >= 0 && active_plugin_index < plugin_count) {
-        plugin_t *active_plugin = &plugins[active_plugin_index];
-        if (active_plugin->handle_keypad) {
-            return active_plugin->handle_keypad(key);
-        }
+    plugin_t *active = plugins_snapshot_active();
+    if (active && active->handle_keypad) {
+        return active->handle_keypad(key);
     }
     return -1; /* No active plugin or handler */
 }
 
 int plugins_handle_hook(int hook_up, int hook_down) {
-    if (active_plugin_index >= 0 && active_plugin_index < plugin_count) {
-        plugin_t *active_plugin = &plugins[active_plugin_index];
-        if (active_plugin->handle_hook) {
-            return active_plugin->handle_hook(hook_up, hook_down);
-        }
+    plugin_t *active = plugins_snapshot_active();
+    if (active && active->handle_hook) {
+        return active->handle_hook(hook_up, hook_down);
     }
     return -1; /* No active plugin or handler */
 }
 
 int plugins_handle_call_state(int call_state) {
-    if (active_plugin_index >= 0 && active_plugin_index < plugin_count) {
-        plugin_t *active_plugin = &plugins[active_plugin_index];
-        if (active_plugin->handle_call_state) {
-            return active_plugin->handle_call_state(call_state);
-        }
+    plugin_t *active = plugins_snapshot_active();
+    if (active && active->handle_call_state) {
+        return active->handle_call_state(call_state);
     }
     return -1; /* No active plugin or handler */
 }
 
 int plugins_handle_card(const char *card_number) {
-    if (active_plugin_index >= 0 && active_plugin_index < plugin_count) {
-        plugin_t *active_plugin = &plugins[active_plugin_index];
-        if (active_plugin->handle_card) {
-            return active_plugin->handle_card(card_number);
-        }
+    plugin_t *active = plugins_snapshot_active();
+    if (active && active->handle_card) {
+        return active->handle_card(card_number);
     }
     return -1;
 }
 
 void plugins_tick(void) {
-    if (active_plugin_index >= 0 && active_plugin_index < plugin_count) {
-        plugin_t *active_plugin = &plugins[active_plugin_index];
-        if (active_plugin->handle_tick) {
-            active_plugin->handle_tick();
-        }
+    plugin_t *active = plugins_snapshot_active();
+    if (active && active->handle_tick) {
+        active->handle_tick();
     }
 }

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -405,6 +405,121 @@ static void test_plugins_duplicate_register(void) {
     plugins_cleanup();
 }
 
+/* ── Plugin dispatch (plugins_handle_*) ─────────────────────────────── */
+
+/* Counting handlers that record their last argument so we can verify the
+ * active plugin actually receives each event and its return value is
+ * propagated back to the caller. */
+static int g_disp_coin_calls, g_disp_coin_value;
+static int g_disp_key_calls; static char g_disp_key_char;
+static int g_disp_hook_calls, g_disp_hook_up, g_disp_hook_down;
+static int g_disp_call_calls, g_disp_call_state;
+static int g_disp_card_calls; static char g_disp_card_last[32];
+static int g_disp_tick_calls;
+
+static int disp_coin_handler(int v, const char *c) {
+    (void)c; g_disp_coin_calls++; g_disp_coin_value = v; return 42;
+}
+static int disp_key_handler(char k) {
+    g_disp_key_calls++; g_disp_key_char = k; return 0;
+}
+static int disp_hook_handler(int u, int d) {
+    g_disp_hook_calls++; g_disp_hook_up = u; g_disp_hook_down = d; return 0;
+}
+static int disp_call_handler(int s) {
+    g_disp_call_calls++; g_disp_call_state = s; return 0;
+}
+static int disp_card_handler(const char *n) {
+    g_disp_card_calls++;
+    strncpy(g_disp_card_last, n ? n : "", sizeof(g_disp_card_last) - 1);
+    g_disp_card_last[sizeof(g_disp_card_last) - 1] = '\0';
+    return 0;
+}
+static void disp_tick_handler(void) { g_disp_tick_calls++; }
+
+static void test_plugins_dispatch_to_active(void) {
+    daemon_state_data_t ds;
+    daemon_state_init(&ds);
+    daemon_state = &ds;
+    client = millennium_client_create();
+
+    plugins_init();
+    g_disp_coin_calls = g_disp_key_calls = g_disp_hook_calls = 0;
+    g_disp_call_calls = g_disp_card_calls = g_disp_tick_calls = 0;
+
+    TEST_ASSERT_EQ_INT(plugins_register("Dispatch Test", "Counts events",
+        disp_coin_handler, disp_key_handler, disp_hook_handler,
+        disp_call_handler, disp_card_handler, NULL, disp_tick_handler), 0);
+    TEST_ASSERT_EQ_INT(plugins_activate("Dispatch Test"), 0);
+
+    /* Each dispatch reaches the active plugin and propagates its return. */
+    TEST_ASSERT_EQ_INT(plugins_handle_coin(25, "COIN_8"), 42);
+    TEST_ASSERT_EQ_INT(g_disp_coin_calls, 1);
+    TEST_ASSERT_EQ_INT(g_disp_coin_value, 25);
+
+    plugins_handle_keypad('7');
+    TEST_ASSERT_EQ_INT(g_disp_key_calls, 1);
+    TEST_ASSERT_EQ_INT((int)g_disp_key_char, (int)'7');
+
+    plugins_handle_hook(1, 0);
+    TEST_ASSERT_EQ_INT(g_disp_hook_calls, 1);
+    TEST_ASSERT_EQ_INT(g_disp_hook_up, 1);
+    TEST_ASSERT_EQ_INT(g_disp_hook_down, 0);
+
+    plugins_handle_call_state(3);
+    TEST_ASSERT_EQ_INT(g_disp_call_calls, 1);
+    TEST_ASSERT_EQ_INT(g_disp_call_state, 3);
+
+    plugins_handle_card("4111111111111111");
+    TEST_ASSERT_EQ_INT(g_disp_card_calls, 1);
+    TEST_ASSERT_EQ_STR(g_disp_card_last, "4111111111111111");
+
+    plugins_tick();
+    TEST_ASSERT_EQ_INT(g_disp_tick_calls, 1);
+
+    millennium_client_destroy(client);
+    client = NULL;
+    daemon_state = NULL;
+    plugins_cleanup();
+}
+
+static void test_plugins_dispatch_no_active(void) {
+    /* With no plugin active, dispatch is a safe no-op returning -1 and never
+     * touches a stale handler. */
+    plugins_cleanup();
+    TEST_ASSERT_EQ_INT(plugins_handle_coin(5, "COIN_1"), -1);
+    TEST_ASSERT_EQ_INT(plugins_handle_keypad('1'), -1);
+    TEST_ASSERT_EQ_INT(plugins_handle_hook(0, 1), -1);
+    TEST_ASSERT_EQ_INT(plugins_handle_call_state(0), -1);
+    TEST_ASSERT_EQ_INT(plugins_handle_card("0"), -1);
+    plugins_tick(); /* must not crash */
+}
+
+static void test_plugins_dispatch_missing_handler(void) {
+    /* A plugin that registers NULL for a handler returns -1 for that event
+     * rather than dereferencing a NULL function pointer. */
+    daemon_state_data_t ds;
+    daemon_state_init(&ds);
+    daemon_state = &ds;
+    client = millennium_client_create();
+
+    plugins_init();
+
+    TEST_ASSERT_EQ_INT(plugins_register("No Handlers", "All NULL",
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL), 0);
+    TEST_ASSERT_EQ_INT(plugins_activate("No Handlers"), 0);
+
+    TEST_ASSERT_EQ_INT(plugins_handle_coin(25, "COIN_8"), -1);
+    TEST_ASSERT_EQ_INT(plugins_handle_keypad('7'), -1);
+    TEST_ASSERT_EQ_INT(plugins_handle_card("0"), -1);
+    plugins_tick(); /* NULL tick handler must not crash */
+
+    millennium_client_destroy(client);
+    client = NULL;
+    daemon_state = NULL;
+    plugins_cleanup();
+}
+
 /* ── Plugin registry / dynamic enumeration ─────────────────────────── */
 
 /* Pure comparison exported by plugins/number_guess.c */
@@ -749,6 +864,9 @@ int main(void) {
     TEST_SUITE_RUN(test_plugins_register_custom);
     TEST_SUITE_RUN(test_plugins_list);
     TEST_SUITE_RUN(test_plugins_duplicate_register);
+    TEST_SUITE_RUN(test_plugins_dispatch_to_active);
+    TEST_SUITE_RUN(test_plugins_dispatch_no_active);
+    TEST_SUITE_RUN(test_plugins_dispatch_missing_handler);
     TEST_SUITE_RUN(test_plugins_builtins_registered);
     TEST_SUITE_RUN(test_plugins_get_info);
     TEST_SUITE_RUN(test_plugins_to_json);


### PR DESCRIPTION
## Problem

The active plugin can be switched at runtime via `POST /api/control` (`activate_plugin:<name>`), which runs `plugins_activate()` on the **web-server thread** and writes `active_plugin_index` under `plugins_mutex`. But the six dispatch functions — `plugins_handle_coin/keypad/hook/call_state/card` and `plugins_tick`, called from the **daemon event thread** — read `active_plugin_index` and dereferenced `plugins[active_plugin_index]` **without** taking the lock.

That's a genuine data race on `active_plugin_index` between two real, concurrently-running threads. Every other accessor in `plugins.c` (`plugins_get_active_name`, `plugins_list`, `plugins_to_json`, …) already locks; these six were the inconsistency.

## Fix

Add `plugins_snapshot_active()`, which captures the active plugin's table entry under the mutex, and have each dispatch function invoke the handler **outside** the lock. This is safe and deadlock-free because:

- `plugins[]` is a fixed static array whose entries are never moved or unregistered, so the snapshot pointer stays valid for the handler call.
- Dispatching unlocked avoids holding the mutex across a plugin callback, which could re-enter the registry and deadlock on the non-recursive mutex.

## Tests

The dispatch path (`plugins_handle_*`) was previously **never tested** — only `plugins_activate` was. Added three unit tests:

- `test_plugins_dispatch_to_active` — each event reaches the active plugin with correct args, and the handler's return value propagates.
- `test_plugins_dispatch_no_active` — dispatch with no active plugin is a safe no-op returning `-1`.
- `test_plugins_dispatch_missing_handler` — a plugin registering `NULL` handlers returns `-1` instead of dereferencing a NULL function pointer.

## Verification

Clean build under `-Wall -Wextra -Wdeclaration-after-statement -Werror`; `make test` (unit + scenario) green — **55/55 unit tests pass** (up from 52), all scenarios pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)