### PR TITLE
test: portable simulated time — scenario tests run instantly off Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ pcb/*.lck
 pcb/erc_report.txt
 pcb/drc_report.txt
 # PCB build artifacts
+pcb/__pycache__/
 pcb/gerbers_export/
 pcb/jlcpcb/
 pcb/*-backups/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,8 @@ Single-process C daemon. Key files:
 | `health_monitor.c` | Background checks: serial connection, SIP registration |
 | `config.c` | `key=value` config file parser with environment variable fallback |
 | `state_persistence.c` | Save/restore coin balance and active plugin across restarts |
-| `simulator.c` | Test harness: stubs hardware, wraps `time()` for scenario tests |
+| `clock_source.c` | Clock seam (`mclock_now()`): real `time()` in production, an advanceable clock under the simulator. Plugins read it via `sdk_now()` |
+| `simulator.c` | Test harness: stubs hardware, drives the `clock_source` clock so scenario tests advance time instantly on any platform (no real sleeping, no Linux-only `--wrap` trick) |
 | `tests/unit_tests.c` | Unit tests (config, state transitions, emergency detection, plugin registry) |
 
 ### State Machine

--- a/host/Makefile
+++ b/host/Makefile
@@ -20,7 +20,10 @@ config.o: config.c config.h
 	gcc config.c -o config.o -c $(CFLAGS)
 
 # C object files
-daemon_state.o: daemon_state.c daemon_state.h
+clock_source.o: clock_source.c clock_source.h
+	gcc clock_source.c -o clock_source.o -c $(CFLAGS)
+
+daemon_state.o: daemon_state.c daemon_state.h clock_source.h
 	gcc daemon_state.c -o daemon_state.o -c $(CFLAGS)
 
 logger.o: logger.c logger.h
@@ -59,7 +62,7 @@ state_persistence.o: state_persistence.c state_persistence.h daemon_state.h logg
 display_manager.o: display_manager.c display_manager.h millennium_sdk.h
 	gcc display_manager.c -o display_manager.o -c $(CFLAGS)
 
-plugin_sdk.o: plugin_sdk.c plugin_sdk.h plugins.h display_manager.h audio_tones.h millennium_sdk.h logger.h daemon_state.h
+plugin_sdk.o: plugin_sdk.c plugin_sdk.h plugins.h display_manager.h audio_tones.h millennium_sdk.h clock_source.h logger.h daemon_state.h
 	gcc plugin_sdk.c -o plugin_sdk.o -c $(CFLAGS)
 
 version.o: version.c version.h
@@ -78,13 +81,13 @@ daemon.o: daemon.c millennium_sdk.h events.h event_processor.h config.h logger.h
 plugins.o: plugins.c plugins.h
 	gcc plugins.c -o plugins.o -c $(CFLAGS)
 
-plugins/classic_phone.o: plugins/classic_phone.c plugins.h audio_tones.h config.h
+plugins/classic_phone.o: plugins/classic_phone.c plugins.h plugin_sdk.h audio_tones.h config.h
 	gcc plugins/classic_phone.c -o plugins/classic_phone.o -c $(CFLAGS)
 
-plugins/fortune_teller.o: plugins/fortune_teller.c plugins.h
+plugins/fortune_teller.o: plugins/fortune_teller.c plugins.h plugin_sdk.h
 	gcc plugins/fortune_teller.c -o plugins/fortune_teller.o -c $(CFLAGS)
 
-plugins/jukebox.o: plugins/jukebox.c plugins.h
+plugins/jukebox.o: plugins/jukebox.c plugins.h plugin_sdk.h
 	gcc plugins/jukebox.c -o plugins/jukebox.o -c $(CFLAGS)
 
 plugins/number_guess.o: plugins/number_guess.c plugins.h plugin_sdk.h config.h
@@ -99,21 +102,19 @@ plugins/dial_a_joke.o: plugins/dial_a_joke.c plugins.h plugin_sdk.h config.h
 plugins/trivia.o: plugins/trivia.c plugins.h plugin_sdk.h config.h
 	gcc plugins/trivia.c -o plugins/trivia.o -c $(CFLAGS)
 
-daemon: daemon.o daemon_state.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o
-	gcc daemon.o daemon_state.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o -o daemon $(LDFLAGS) -lm
+daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o
+	gcc daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o -o daemon $(LDFLAGS) -lm
 
 # Simulator object file
 simulator.o: simulator.c millennium_sdk.h events.h config.h daemon_state.h logger.h metrics.h plugins.h
 	gcc simulator.c -o simulator.o -c $(CFLAGS)
 
 # Simulator objects — no baresip, no web server, no daemon.o
-SIM_OBJS = simulator.o daemon_state.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o
+SIM_OBJS = simulator.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o
 
-# On Linux, wrap time() for simulated time; elsewhere use real time
+# Simulated time is portable: the simulator installs a clock source
+# (clock_source.h) that the daemon/plugins read through, so no -Wl,--wrap hack.
 SIM_LDFLAGS = -lpthread
-ifeq ($(shell uname -s),Linux)
-SIM_LDFLAGS += -Wl,--wrap=time
-endif
 
 simulator: $(SIM_OBJS)
 	gcc $(SIM_OBJS) -o simulator $(SIM_LDFLAGS)
@@ -121,7 +122,7 @@ simulator: $(SIM_OBJS)
 all: daemon
 
 # Unit test binary
-UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o updater.o
+UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o updater.o
 
 tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h millennium_sdk.h updater.h
 	gcc tests/unit_tests.c -o tests/unit_tests.o -c $(CFLAGS) -I.
@@ -159,7 +160,7 @@ test: simulator unit_tests
 # ALSA paths in audio_tones.c, plus web_server/websocket/health_monitor — is
 # never compiled by `make test`. This target catches type/syntax errors in that
 # code on any Linux box with libasound2-dev (e.g. CI), short of a full link.
-COMPILE_CHECK_OBJS = daemon.o daemon_state.o millennium_sdk.o events.o \
+COMPILE_CHECK_OBJS = daemon.o daemon_state.o clock_source.o millennium_sdk.o events.o \
 	event_processor.o config.o logger.o health_monitor.o metrics.o \
 	metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o \
 	plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o \

--- a/host/PLUGIN_AUTHORING.md
+++ b/host/PLUGIN_AUTHORING.md
@@ -95,9 +95,12 @@ void register_hello_plugin(void) {
 - **Receiver state.** Gate behaviour on `sdk_receiver_is_up()`; show a
   "Lift receiver" splash when it's down (every built-in does this).
 - **Non-blocking delays.** Never `sleep()`. Record a deadline
-  (`time(NULL) + n`) and check it in `handle_tick()` — see the celebration
-  delay in `number_guess.c` or the playback pacing in `simon.c`. (`time()` has
-  1-second resolution.)
+  (`sdk_now() + n`) and check it in `handle_tick()` — see the celebration
+  delay in `number_guess.c` or the playback pacing in `simon.c`. Always read
+  the clock with `sdk_now()` (or age a timestamp with `sdk_elapsed(t)`), never
+  `time(NULL)` directly: `sdk_now()` honors the scenario simulator's
+  advanceable clock, so `wait` advances time instantly instead of really
+  sleeping. (Resolution is 1 second.)
 - **Config.** Read per-plugin settings from `daemon.conf` with
   `config_get_int/string/bool(config_get_instance(), "your.key", default)`.
   Exposing a "forced" value (e.g. `guess.secret`) makes scenario tests
@@ -128,10 +131,10 @@ them directly.
 
 ## Reference
 
-See [`plugin_sdk.h`](plugin_sdk.h) for the full API: display
-(`sdk_display`, `sdk_displayf`), audio (`sdk_beep`, `sdk_coin_chime`,
-`sdk_dial_tone`, …), calls (`sdk_call`, `sdk_answer`, `sdk_hangup`,
-`sdk_send_dtmf`), state (`sdk_state`, `sdk_receiver_is_up`, `sdk_keypad`),
-balance (`sdk_balance`, `sdk_spend_balance`, …), logging (`sdk_log`,
-`sdk_logf`), and randomness (`sdk_rand_below`, `sdk_rand_range`,
+See [`plugin_sdk.h`](plugin_sdk.h) for the full API: time (`sdk_now`,
+`sdk_elapsed`), display (`sdk_display`, `sdk_displayf`), audio (`sdk_beep`,
+`sdk_coin_chime`, `sdk_dial_tone`, …), calls (`sdk_call`, `sdk_answer`,
+`sdk_hangup`, `sdk_send_dtmf`), state (`sdk_state`, `sdk_receiver_is_up`,
+`sdk_keypad`), balance (`sdk_balance`, `sdk_spend_balance`, …), logging
+(`sdk_log`, `sdk_logf`), and randomness (`sdk_rand_below`, `sdk_rand_range`,
 `sdk_rand_choice`).

--- a/host/clock_source.c
+++ b/host/clock_source.c
@@ -1,0 +1,13 @@
+#include "clock_source.h"
+
+/* NULL in production: mclock_now() falls through to the real time(NULL). The
+ * simulator installs a source returning its advanceable clock. */
+static time_t (*g_clock_source)(void) = 0;
+
+time_t mclock_now(void) {
+    return g_clock_source ? g_clock_source() : time(NULL);
+}
+
+void mclock_set_source(time_t (*source)(void)) {
+    g_clock_source = source;
+}

--- a/host/clock_source.h
+++ b/host/clock_source.h
@@ -1,0 +1,29 @@
+#ifndef CLOCK_SOURCE_H
+#define CLOCK_SOURCE_H
+
+#include <time.h>
+
+/*
+ * Clock seam — the single function all daemon/plugin timing reads through.
+ *
+ * The daemon's timing logic (idle timeouts, "reveal the answer in 2s", coin
+ * return windows, …) used to call time(NULL) directly. That made simulated
+ * time depend on a Linux-only -Wl,--wrap=time linker trick: on the Mac (the
+ * primary dev box) the wrap doesn't apply, so the scenario simulator's `wait`
+ * had to fall back to a real nanosleep — making `make test` actually sleep.
+ *
+ * Routing every timing read through mclock_now() removes that platform split.
+ * In production no source is installed, so mclock_now() == time(NULL). The
+ * simulator installs a source that returns its advanceable clock, so `wait`
+ * advances time instantly on every platform.
+ */
+
+/* Current wall-clock time in seconds, honoring an installed source (see
+ * mclock_set_source). With no source installed this is exactly time(NULL). */
+time_t mclock_now(void);
+
+/* Install (or, with NULL, clear) the clock source. The simulator points this
+ * at its advanceable clock; the live daemon leaves it NULL. */
+void mclock_set_source(time_t (*source)(void));
+
+#endif /* CLOCK_SOURCE_H */

--- a/host/daemon_state.c
+++ b/host/daemon_state.c
@@ -1,4 +1,5 @@
 #include "daemon_state.h"
+#include "clock_source.h"
 #include <string.h>
 #include <time.h>
 #include <ctype.h>
@@ -9,7 +10,7 @@ void daemon_state_init(daemon_state_data_t* state) {
     state->current_state = DAEMON_STATE_IDLE_DOWN;
     memset(state->keypad_buffer, 0, sizeof(state->keypad_buffer));
     state->inserted_cents = 0;
-    state->last_activity = time(NULL);
+    state->last_activity = mclock_now();
 }
 
 void daemon_state_reset(daemon_state_data_t* state) {
@@ -18,12 +19,12 @@ void daemon_state_reset(daemon_state_data_t* state) {
     state->current_state = DAEMON_STATE_IDLE_DOWN;
     daemon_state_clear_keypad(state);
     state->inserted_cents = 0;
-    state->last_activity = time(NULL);
+    state->last_activity = mclock_now();
 }
 
 void daemon_state_update_activity(daemon_state_data_t* state) {
     if (!state) return;
-    state->last_activity = time(NULL);
+    state->last_activity = mclock_now();
 }
 
 const char* daemon_state_to_string(daemon_state_t state) {

--- a/host/plugin_sdk.c
+++ b/host/plugin_sdk.c
@@ -10,11 +10,21 @@
 #include "display_manager.h"
 #include "audio_tones.h"
 #include "millennium_sdk.h"
+#include "clock_source.h"
 #include "logger.h"
 
 /* Globals owned by the daemon / simulator / test harness. */
 extern daemon_state_data_t *daemon_state;
 extern millennium_client_t *client;
+
+/* ── Time ────────────────────────────────────────────────────────────── */
+
+time_t sdk_now(void) { return mclock_now(); }
+
+int sdk_elapsed(time_t past) {
+    time_t now = mclock_now();
+    return now > past ? (int)(now - past) : 0;
+}
 
 /* ── Display ─────────────────────────────────────────────────────────── */
 

--- a/host/plugin_sdk.h
+++ b/host/plugin_sdk.h
@@ -35,7 +35,21 @@
  *   }
  */
 
+#include <time.h>
 #include "daemon_state.h"
+
+/* ── Time ────────────────────────────────────────────────────────────────
+ * Always read the clock through these instead of time(NULL). They honor the
+ * scenario simulator's advanceable clock, so a plugin's timing logic (e.g.
+ * "reveal the answer 2 seconds later") behaves identically on the Pi and in
+ * the instant, no-sleep scenario tests. */
+
+/* Current time in seconds, like time(NULL) but simulator-aware. */
+time_t sdk_now(void);
+
+/* Whole seconds elapsed since `past` (clamped to >= 0). Equivalent to
+ * sdk_now() - past, the idiom plugins use to age timestamps. */
+int sdk_elapsed(time_t past);
 
 /* ── Display ─────────────────────────────────────────────────────────────
  * The VFD is two lines of 20 chars. Lines longer than 20 chars auto-scroll.

--- a/host/plugins/classic_phone.c
+++ b/host/plugins/classic_phone.c
@@ -7,6 +7,7 @@
 #include "../plugins.h"
 #include "../logger.h"
 #include "../millennium_sdk.h"
+#include "../plugin_sdk.h"
 #include "../config.h"
 #include "../metrics.h"
 #include "../display_manager.h"
@@ -58,7 +59,7 @@ static int classic_phone_handle_coin(int coin_value, const char *coin_code) {
     if (coin_value > 0 && daemon_state && daemon_state->current_state == DAEMON_STATE_IDLE_UP) {
         audio_tones_play_coin_tone();
         classic_phone_data.inserted_cents += coin_value;
-        classic_phone_data.last_activity = time(NULL);
+        classic_phone_data.last_activity = sdk_now();
 
         classic_phone_update_display();
         classic_phone_check_and_call();
@@ -85,7 +86,7 @@ static int classic_phone_handle_keypad(char key) {
         classic_phone_data.keypad_length < 10) {
         audio_tones_play_dtmf(key);
         classic_phone_add_key(key);
-        classic_phone_data.last_activity = time(NULL);
+        classic_phone_data.last_activity = sdk_now();
         classic_phone_update_display();
         classic_phone_check_and_call();
     }
@@ -97,13 +98,13 @@ static int classic_phone_handle_hook(int hook_up, int hook_down) {
         if (classic_phone_data.is_in_call) {
             logger_info_with_category("ClassicPhone", "Handset lifted during incoming call");
             audio_tones_stop();
-            classic_phone_data.call_start_time = time(NULL);
+            classic_phone_data.call_start_time = sdk_now();
             classic_phone_update_display();
         } else {
             /* Start new call session — play dial tone */
             classic_phone_data.inserted_cents = 0;
             classic_phone_data.keypad_length = 0;
-            classic_phone_data.last_activity = time(NULL);
+            classic_phone_data.last_activity = sdk_now();
             audio_tones_play_dial_tone();
             classic_phone_update_display();
         }
@@ -133,14 +134,14 @@ static int classic_phone_handle_call_state(int call_state) {
     if (call_state == EVENT_CALL_STATE_INCOMING) {
         audio_tones_stop();
         classic_phone_data.is_in_call = 1;
-        classic_phone_data.call_start_time = time(NULL);
+        classic_phone_data.call_start_time = sdk_now();
         classic_phone_update_display();
         logger_info_with_category("ClassicPhone", "Incoming call received");
     } else if (call_state == EVENT_CALL_STATE_ACTIVE) {
         audio_tones_stop();
         classic_phone_data.is_dialing = 0;  /* Call connected - no longer dialing */
         classic_phone_data.is_in_call = 1;
-        classic_phone_data.call_start_time = time(NULL);
+        classic_phone_data.call_start_time = sdk_now();
         classic_phone_update_display();
         logger_info_with_category("ClassicPhone", "Call established");
     } else if (call_state == EVENT_CALL_STATE_INVALID) {
@@ -183,7 +184,7 @@ static int classic_phone_handle_card(const char *card_number) {
         classic_phone_data.is_card_call = 1;
         strncpy(classic_phone_data.card_number, card_number, sizeof(classic_phone_data.card_number) - 1);
         classic_phone_data.card_number[sizeof(classic_phone_data.card_number) - 1] = '\0';
-        classic_phone_data.last_activity = time(NULL);
+        classic_phone_data.last_activity = sdk_now();
         display_manager_set_text("Card accepted", "Dial number");
         logger_infof_with_category("ClassicPhone", "Free calling card accepted: %.4s...", card_number);
         return 1;
@@ -207,7 +208,7 @@ static void classic_phone_on_activation(void) {
     classic_phone_data.keypad_length = 0;
     classic_phone_data.is_dialing = 0;
     classic_phone_data.is_in_call = 0;
-    classic_phone_data.last_activity = time(NULL);
+    classic_phone_data.last_activity = sdk_now();
     classic_phone_update_display();
 }
 
@@ -408,13 +409,13 @@ static void classic_phone_tick(void) {
     if (!classic_phone_data.is_in_call && !classic_phone_data.is_dialing &&
         daemon_state && daemon_state->current_state == DAEMON_STATE_IDLE_UP &&
         classic_phone_data.idle_timeout_seconds > 0) {
-        int idle_secs = (int)(time(NULL) - classic_phone_data.last_activity);
+        int idle_secs = (int)(sdk_now() - classic_phone_data.last_activity);
         if (idle_secs >= classic_phone_data.idle_timeout_seconds) {
             logger_info_with_category("ClassicPhone", "Idle timeout — resetting");
             audio_tones_stop();
             classic_phone_data.keypad_length = 0;
             classic_phone_data.inserted_cents = 0;
-            classic_phone_data.last_activity = time(NULL);
+            classic_phone_data.last_activity = sdk_now();
             classic_phone_update_display();
         }
     }
@@ -433,7 +434,7 @@ static void classic_phone_tick(void) {
     }
 
     remaining = classic_phone_data.call_timeout_seconds
-              - (int)(time(NULL) - classic_phone_data.call_start_time);
+              - (int)(sdk_now() - classic_phone_data.call_start_time);
 
     if (remaining <= 0) {
         logger_info_with_category("ClassicPhone",
@@ -466,7 +467,7 @@ void register_classic_phone_plugin(void) {
     classic_phone_data.is_in_call = 0;
     classic_phone_data.call_timeout_seconds = config_get_call_timeout_seconds(config_get_instance());
     classic_phone_data.idle_timeout_seconds = config_get_idle_timeout_seconds(config_get_instance());
-    classic_phone_data.last_activity = time(NULL);
+    classic_phone_data.last_activity = sdk_now();
     
     plugins_register("Classic Phone",
                     "Traditional pay phone functionality with VoIP calling",

--- a/host/plugins/dial_a_joke.c
+++ b/host/plugins/dial_a_joke.c
@@ -74,7 +74,7 @@ static void dj_tell(void) {
     sdk_display(jokes[dj.current].setup, "...");
     sdk_logf(JOKE_CAT, "Telling joke %d", dj.current);
     dj.phase = DJ_SETUP;
-    dj.reveal_at = time(NULL) + 2;
+    dj.reveal_at = sdk_now() + 2;
 }
 
 /* ── Plugin callbacks ────────────────────────────────────────────────── */
@@ -101,7 +101,7 @@ static void dj_handle_activation(void) {
 }
 
 static void dj_handle_tick(void) {
-    if (dj.phase == DJ_SETUP && time(NULL) >= dj.reveal_at) {
+    if (dj.phase == DJ_SETUP && sdk_now() >= dj.reveal_at) {
         sdk_display(jokes[dj.current].punch, "Press key: more");
         dj.phase = DJ_IDLE;
     }

--- a/host/plugins/fortune_teller.c
+++ b/host/plugins/fortune_teller.c
@@ -6,6 +6,7 @@
 #include "../plugins.h"
 #include "../logger.h"
 #include "../millennium_sdk.h"
+#include "../plugin_sdk.h"
 #include "../display_manager.h"
 
 /* Delay states: non-blocking fortune flow (#114) */
@@ -86,7 +87,7 @@ static const char* fortune_teller_get_random_fortune(int category);
 static int fortune_teller_handle_coin(int coin_value, const char *coin_code) {
     if (coin_value > 0) {
         fortune_teller_data.inserted_cents += coin_value;
-        fortune_teller_data.last_activity = time(NULL);
+        fortune_teller_data.last_activity = sdk_now();
         
         if (fortune_teller_data.inserted_cents >= fortune_teller_data.fortune_cost_cents) {
             fortune_teller_data.is_ready = 1;
@@ -122,7 +123,7 @@ static int fortune_teller_handle_hook(int hook_up, int hook_down) {
         fortune_teller_data.inserted_cents = 0;
         fortune_teller_data.fortune_type = 0;
         fortune_teller_data.is_ready = 0;
-        fortune_teller_data.last_activity = time(NULL);
+        fortune_teller_data.last_activity = sdk_now();
         fortune_teller_show_welcome();
     } else if (hook_down) {
         /* Return coins if handset down without fortune */
@@ -148,7 +149,7 @@ static void fortune_teller_on_activation(void) {
     fortune_teller_data.fortune_type = 0;
     fortune_teller_data.is_ready = 0;
     fortune_teller_data.delay_state = FT_STATE_IDLE;
-    fortune_teller_data.last_activity = time(NULL);
+    fortune_teller_data.last_activity = sdk_now();
     fortune_teller_show_welcome();
 }
 
@@ -182,11 +183,11 @@ static void fortune_teller_show_reading(void) {
 static void fortune_teller_give_fortune(void) {
     fortune_teller_show_reading();
     fortune_teller_data.delay_state = FT_STATE_READING;
-    fortune_teller_data.delay_until = time(NULL) + 2;
+    fortune_teller_data.delay_until = sdk_now() + 2;
 }
 
 static void fortune_teller_tick(void) {
-    time_t now = time(NULL);
+    time_t now = sdk_now();
     if (fortune_teller_data.delay_state == FT_STATE_READING && now >= fortune_teller_data.delay_until) {
         const char* fortune = fortune_teller_get_random_fortune(fortune_teller_data.fortune_type);
         const char* category = fortune_categories[fortune_teller_data.fortune_type];
@@ -234,7 +235,7 @@ void register_fortune_teller_plugin(void) {
     fortune_teller_data.fortune_cost_cents = 25; /* 25 cents per fortune */
     fortune_teller_data.fortune_type = 0;
     fortune_teller_data.is_ready = 0;
-    fortune_teller_data.last_activity = time(NULL);
+    fortune_teller_data.last_activity = sdk_now();
     
     /* Seed random number generator */
     srand(time(NULL));

--- a/host/plugins/jukebox.c
+++ b/host/plugins/jukebox.c
@@ -8,6 +8,7 @@
 #include "../plugins.h"
 #include "../logger.h"
 #include "../millennium_sdk.h"
+#include "../plugin_sdk.h"
 #include "../display_manager.h"
 #include "../audio_tones.h"
 
@@ -84,7 +85,7 @@ static void jukebox_check_playback(void);
 static int jukebox_handle_coin(int coin_value, const char *coin_code) {
     if (coin_value > 0) {
         jukebox_data.inserted_cents += coin_value;
-        jukebox_data.last_activity = time(NULL);
+        jukebox_data.last_activity = sdk_now();
         
         if (jukebox_data.inserted_cents >= jukebox_data.song_cost_cents) {
             jukebox_show_menu();
@@ -131,7 +132,7 @@ static int jukebox_handle_hook(int hook_up, int hook_down) {
         jukebox_data.inserted_cents = 0;
         jukebox_data.selected_song = -1;
         jukebox_data.is_playing = 0;
-        jukebox_data.last_activity = time(NULL);
+        jukebox_data.last_activity = sdk_now();
         jukebox_show_welcome();
     } else if (hook_down) {
         /* Stop playback and return coins */
@@ -160,7 +161,7 @@ static void jukebox_on_activation(void) {
     jukebox_data.inserted_cents = 0;
     jukebox_data.selected_song = -1;
     jukebox_data.is_playing = 0;
-    jukebox_data.last_activity = time(NULL);
+    jukebox_data.last_activity = sdk_now();
     jukebox_data.play_start_time = 0;
     jukebox_data.play_duration_seconds = 0;
     jukebox_data.stop_audio = 0;
@@ -208,7 +209,7 @@ static void jukebox_play_song(int song_number) {
 
     jukebox_data.selected_song = song_number;
     jukebox_data.is_playing = 1;
-    jukebox_data.play_start_time = time(NULL);
+    jukebox_data.play_start_time = sdk_now();
     jukebox_data.play_duration_seconds = songs[song_number].duration_seconds;
 
     jukebox_show_playing();
@@ -254,7 +255,7 @@ static void jukebox_stop_song(void) {
 #pragma GCC diagnostic ignored "-Wunused-function"
 static void jukebox_check_playback(void) {
     if (jukebox_data.is_playing) {
-        time_t now = time(NULL);
+        time_t now = sdk_now();
         if (now - jukebox_data.play_start_time >= jukebox_data.play_duration_seconds) {
             /* Song finished */
             jukebox_stop_song();
@@ -458,7 +459,7 @@ void register_jukebox_plugin(void) {
     jukebox_data.song_cost_cents = 25; /* 25 cents per song */
     jukebox_data.selected_song = -1;
     jukebox_data.is_playing = 0;
-    jukebox_data.last_activity = time(NULL);
+    jukebox_data.last_activity = sdk_now();
     jukebox_data.play_start_time = 0;
     jukebox_data.play_duration_seconds = 0;
 #if HAVE_ALSA

--- a/host/plugins/number_guess.c
+++ b/host/plugins/number_guess.c
@@ -121,7 +121,7 @@ static void ng_submit(void) {
         sdk_display("Correct!", l2);
         sdk_logf(GUESS_CAT, "Solved in %d guesses", ng.guesses);
         ng.phase = NG_PLAY_WON;
-        ng.reset_at = time(NULL) + 3;
+        ng.reset_at = sdk_now() + 3;
     } else if (cmp < 0) {
         snprintf(l2, sizeof(l2), "Higher (try %d)", ng.guesses);
         sdk_display("Too low!", l2);
@@ -183,7 +183,7 @@ static void ng_handle_activation(void) {
 }
 
 static void ng_handle_tick(void) {
-    if (ng.phase == NG_PLAY_WON && time(NULL) >= ng.reset_at) {
+    if (ng.phase == NG_PLAY_WON && sdk_now() >= ng.reset_at) {
         ng_reset();
     }
 }

--- a/host/plugins/simon.c
+++ b/host/plugins/simon.c
@@ -22,7 +22,7 @@
 
 #define SIMON_CAT "Simon"
 #define SIMON_MAX 16        /* longest sequence we track */
-#define SIMON_NOTE_SECS 1   /* playback pace (time() has 1s resolution) */
+#define SIMON_NOTE_SECS 1   /* playback pace (sdk_now() has 1s resolution) */
 
 #define S_IDLE  0   /* waiting for a key to start */
 #define S_SHOW  1   /* playing back the sequence */
@@ -64,7 +64,7 @@ static void simon_begin(void) {
     sm.round = 0;
     sm.show_idx = 0;
     sm.phase = S_SHOW;
-    sm.next_at = time(NULL); /* reveal first note on the next tick */
+    sm.next_at = sdk_now(); /* reveal first note on the next tick */
     sdk_log(SIMON_CAT, "Game started");
 }
 
@@ -76,7 +76,7 @@ static void simon_next_round(void) {
     }
     sm.show_idx = 0;
     sm.phase = S_SHOW;
-    sm.next_at = time(NULL);
+    sm.next_at = sdk_now();
 }
 
 static void simon_enter_input(void) {
@@ -91,7 +91,7 @@ static void simon_game_over(void) {
     sdk_display("Game Over", l2);
     sdk_logf(SIMON_CAT, "Game over, score %d", sm.round);
     sm.phase = S_OVER;
-    sm.next_at = time(NULL) + 3;
+    sm.next_at = sdk_now() + 3;
 }
 
 /* ── Plugin callbacks ────────────────────────────────────────────────── */
@@ -132,7 +132,7 @@ static void simon_handle_activation(void) {
 }
 
 static void simon_handle_tick(void) {
-    time_t now = time(NULL);
+    time_t now = sdk_now();
 
     if (sm.phase == S_SHOW) {
         if (now < sm.next_at) return;

--- a/host/plugins/trivia.c
+++ b/host/plugins/trivia.c
@@ -84,7 +84,7 @@ static void tq_finish(void) {
     sdk_display("Quiz complete!", l2);
     sdk_logf(TRIVIA_CAT, "Quiz complete, score %d/%d", tq.score, TRIVIA_ROUND);
     tq.phase = TQ_DONE;
-    tq.next_at = time(NULL) + 3;
+    tq.next_at = sdk_now() + 3;
 }
 
 static void tq_answer(int said_true) {
@@ -100,7 +100,7 @@ static void tq_answer(int said_true) {
     tq.asked++;
     tq.idx = (tq.idx + 1) % NUM_Q;
     tq.phase = TQ_FEEDBACK;
-    tq.next_at = time(NULL) + 2;
+    tq.next_at = sdk_now() + 2;
 }
 
 /* ── Plugin callbacks ────────────────────────────────────────────────── */
@@ -128,13 +128,13 @@ static void tq_handle_activation(void) {
 }
 
 static void tq_handle_tick(void) {
-    if (tq.phase == TQ_FEEDBACK && time(NULL) >= tq.next_at) {
+    if (tq.phase == TQ_FEEDBACK && sdk_now() >= tq.next_at) {
         if (tq.asked >= TRIVIA_ROUND) {
             tq_finish();
         } else {
             tq_ask();
         }
-    } else if (tq.phase == TQ_DONE && time(NULL) >= tq.next_at) {
+    } else if (tq.phase == TQ_DONE && sdk_now() >= tq.next_at) {
         tq.phase = TQ_IDLE;
         tq_show_idle();
     }

--- a/host/simulator.c
+++ b/host/simulator.c
@@ -13,6 +13,7 @@ extern daemon_state_data_t *daemon_state;
 #include "state_persistence.h"
 #include "display_manager.h"
 #include "audio_tones.h"
+#include "clock_source.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -20,26 +21,21 @@ extern daemon_state_data_t *daemon_state;
 #include <time.h>
 #include <pthread.h>
 
-/* ── Simulated time ────────────────────────────────────────────────── */
+/* ── Simulated time ──────────────────────────────────────────────────
+ * The daemon and plugins read the clock through mclock_now() (clock_source.h).
+ * We install sim_clock_now() as that source so `wait` can advance time
+ * instantly on every platform — no real sleeping, and no Linux-only
+ * -Wl,--wrap=time linker trick. */
 
 static time_t sim_clock;
-static int    sim_clock_initialized = 0;
 
-#ifdef __linux__
-extern time_t __real_time(time_t *tloc);
-
-time_t __wrap_time(time_t *tloc) {
-    if (sim_clock_initialized) {
-        if (tloc) *tloc = sim_clock;
-        return sim_clock;
-    }
-    return __real_time(tloc);
+static time_t sim_clock_now(void) {
+    return sim_clock;
 }
-#endif
 
 static void sim_time_init(void) {
     sim_clock = time(NULL);
-    sim_clock_initialized = 1;
+    mclock_set_source(sim_clock_now);
 }
 
 static void sim_time_advance(int seconds) {
@@ -584,12 +580,7 @@ static int run_scenario(const char *path) {
             int i;
             fprintf(stderr, "  advancing %d seconds...\n", secs);
             for (i = 0; i < secs; i++) {
-#ifdef __linux__
                 sim_time_advance(1);
-#else
-                { struct timespec ts = {1, 0}; nanosleep(&ts, NULL); }
-                sim_time_advance(1);
-#endif
                 plugins_tick();
                 display_manager_tick();
                 sim_drain_events();

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -8,6 +8,7 @@
 #include "../millennium_sdk.h"
 #include "../updater.h"
 #include "../plugin_sdk.h"
+#include "../clock_source.h"
 #include <stdlib.h>
 
 /* ── Stubs for linker (plugins.c references these) ──────────────── */
@@ -706,6 +707,32 @@ static void test_sdk_state(void) {
     TEST_ASSERT_EQ_STR(sdk_keypad(), "");
 }
 
+/* ── Clock seam tests ──────────────────────────────────────────── */
+
+static time_t g_fake_clock = 0;
+static time_t fake_clock_source(void) { return g_fake_clock; }
+
+static void test_clock_default_is_real_time(void) {
+    /* With no source installed, mclock_now() tracks the real clock. */
+    mclock_set_source(NULL);
+    TEST_ASSERT(mclock_now() > 0);
+    TEST_ASSERT(mclock_now() >= time(NULL) - 2);
+}
+
+static void test_clock_source_override(void) {
+    g_fake_clock = 1000;
+    mclock_set_source(fake_clock_source);
+    TEST_ASSERT_EQ_INT((int)mclock_now(), 1000);
+    TEST_ASSERT_EQ_INT((int)sdk_now(), 1000); /* SDK reads through the seam */
+
+    g_fake_clock = 1042;                       /* advancing is instant */
+    TEST_ASSERT_EQ_INT((int)sdk_now(), 1042);
+    TEST_ASSERT_EQ_INT(sdk_elapsed(1000), 42); /* whole seconds since */
+    TEST_ASSERT_EQ_INT(sdk_elapsed(2000), 0);  /* future clamps to 0 */
+
+    mclock_set_source(NULL);                    /* restore for later tests */
+}
+
 /* ── Emergency number tests ────────────────────────────────────── */
 
 static void test_free_number_911(void) {
@@ -878,6 +905,10 @@ int main(void) {
     TEST_SUITE_RUN(test_sdk_rand_choice);
     TEST_SUITE_RUN(test_sdk_balance);
     TEST_SUITE_RUN(test_sdk_state);
+
+    TEST_SUITE_BEGIN("Clock Seam");
+    TEST_SUITE_RUN(test_clock_default_is_real_time);
+    TEST_SUITE_RUN(test_clock_source_override);
 
     TEST_SUITE_BEGIN("Emergency Numbers");
     TEST_SUITE_RUN(test_free_number_911);


### PR DESCRIPTION
## Problem

The scenario simulator freezes the clock for tests by intercepting `time()` with a **Linux-only** `-Wl,--wrap=time` linker trick. On macOS — the primary development machine per `CLAUDE.md` — the wrap doesn't apply, so `wait <seconds>` fell back to a **real `nanosleep`**.

The result: `make test` genuinely slept on the dev box. There are **84 simulated seconds** of `wait` across the scenarios, so the suite spent ~84s sleeping (the trivia scenario alone took **6s**).

## Fix

Route all daemon/plugin timing through one explicit clock seam instead of the linker hack:

- **`clock_source.{c,h}`** — `mclock_now()` returns the real `time()` in production, or an installed source under test; `mclock_set_source()` installs one.
- **`plugin_sdk`** — new `sdk_now()` / `sdk_elapsed()`, the documented way for plugins to read the clock. All 7 built-in plugins and `daemon_state.c` migrate off direct `time(NULL)` (the RNG seed in `fortune_teller` stays real time).
- **`simulator.c`** — installs an advanceable clock source on *every* platform; `wait` advances it instantly with no sleeping. The `__wrap_time` machinery and the `--wrap=time` Makefile flag are gone.
- **Tests** — a new "Clock Seam" unit suite covers default-is-real-time and override behavior through both `mclock_now` and `sdk_now`/`sdk_elapsed`.
- **Docs** — `PLUGIN_AUTHORING.md` and `CLAUDE.md` updated.

Production behavior is unchanged: with no source installed, `mclock_now()` is exactly `time(NULL)`.

## Results

| | Before (macOS) | After |
|---|---|---|
| Scenario suite | ~84s (real sleeping) | **0.006s** |
| Trivia scenario | 6.0s | **0.002s** |
| Full `make test` (clean build + all tests) | — | **~2.8s** |

Unit tests: **57 passed, 0 failed** (was 55 + the 2 new seam tests). All scenarios pass.

## Test plan

- [x] `make clean && make test` — all scenarios pass, unit tests 57/57
- [x] Timed scenario suite: 0.006s (was ~84s of sleep on macOS)
- [x] No stray `time(NULL)` timing left in plugins (only the intentional `srand` seed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)