### PR TITLE
logger: async file writer so a slow disk can't stall the daemon (#123)

### DIFF
--- a/host/daemon.c
+++ b/host/daemon.c
@@ -1134,6 +1134,10 @@ int main(int argc, char *argv[]) {
     }
     
     logger_info_with_category("Daemon", "Daemon shutdown complete");
-    
+
+    /* Drain the async log queue and stop the writer thread so the final
+     * lines reach disk before we exit (issue #123). */
+    logger_shutdown();
+
     return 0;
 }

--- a/host/logger.c
+++ b/host/logger.c
@@ -10,7 +10,203 @@
 
 /* Global logger instance */
 logger_data_t* g_logger = NULL;
+
+/* logger_mutex guards the in-memory ring buffer + console output (fast, never
+ * blocks on disk). logger_file_mutex guards the actual file stream and the
+ * rotation bookkeeping, and is only ever held by the async writer thread (and
+ * by the set_* config calls at startup) — so disk latency never blocks a
+ * producer. See the async writer block below. */
 static pthread_mutex_t logger_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t logger_file_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+/* Forward declarations for the async writer machinery (defined below). */
+static void logger_check_rotation(logger_data_t* logger);
+static void logger_emit_to_file(const char* line);
+static void logger_writer_start(void);
+static void logger_enqueue(const char* line);
+
+/* ── Asynchronous file writer (issue #123) ───────────────────────────────
+ * Previously logger_write_log held logger_mutex across fprintf() + fflush(),
+ * so a slow log target (NFS, full disk, busy spindle) stalled EVERY thread
+ * that logged: main loop, web server, health monitor, PJSIP callbacks. One
+ * slow write cascaded into event-processing delay and serial backlog.
+ *
+ * Now a producer only formats its line, appends it to the in-memory ring +
+ * console under logger_mutex, then drops the line into this bounded queue and
+ * returns. A dedicated writer thread drains the queue to disk under
+ * logger_file_mutex. Disk latency is absorbed by the queue, never by a
+ * producer. If the writer can't keep up the queue fills, the newest lines are
+ * dropped and counted, and the writer emits a single notice line — memory is
+ * bounded and the system never stalls. */
+#define LOG_QUEUE_CAP 1024
+#define LOG_LINE_MAX  512
+
+static struct {
+    char lines[LOG_QUEUE_CAP][LOG_LINE_MAX];
+    int head;                  /* index of the next line to write */
+    int count;                 /* lines queued but not yet on disk */
+    unsigned long dropped;     /* lines discarded on overflow since last notice */
+    int started;               /* writer thread is running */
+    int shutting_down;         /* drain-and-exit requested */
+    pthread_t thread;
+    pthread_mutex_t lock;
+    pthread_cond_t not_empty;  /* a line was queued, or shutdown requested */
+    pthread_cond_t drained;    /* queue emptied (count reached 0) */
+} log_queue = {
+    {{0}}, 0, 0, 0, 0, 0, 0,
+    PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, PTHREAD_COND_INITIALIZER
+};
+
+/* Write one already-formatted line to the log file. Holds logger_file_mutex
+ * (so it may block on disk I/O) but NOT logger_mutex — producers run free. */
+static void logger_emit_to_file(const char* line) {
+    logger_data_t* logger = g_logger;
+    int written;
+
+    if (logger == NULL || line == NULL) {
+        return;
+    }
+
+    pthread_mutex_lock(&logger_file_mutex);
+    if (logger->log_to_file && logger->file_stream != NULL) {
+        written = fprintf(logger->file_stream, "%s\n", line);
+        fflush(logger->file_stream);
+        if (written > 0) {
+            logger->current_file_size += written;
+        }
+        logger_check_rotation(logger);
+    }
+    pthread_mutex_unlock(&logger_file_mutex);
+}
+
+/* The writer thread: pop a line, write it to disk, repeat. The line is not
+ * committed (head/count advanced) until AFTER the write completes, so
+ * logger_flush() only observes count==0 once everything is actually on disk. */
+static void* logger_writer_main(void* arg) {
+    char line[LOG_LINE_MAX];
+    unsigned long dropped;
+
+    (void)arg;
+
+    for (;;) {
+        pthread_mutex_lock(&log_queue.lock);
+        while (log_queue.count == 0 && !log_queue.shutting_down) {
+            pthread_cond_broadcast(&log_queue.drained);
+            pthread_cond_wait(&log_queue.not_empty, &log_queue.lock);
+        }
+        if (log_queue.count == 0 && log_queue.shutting_down) {
+            pthread_cond_broadcast(&log_queue.drained);
+            pthread_mutex_unlock(&log_queue.lock);
+            break;
+        }
+        /* Peek the head; commit it only after the write succeeds. */
+        memcpy(line, log_queue.lines[log_queue.head], LOG_LINE_MAX);
+        dropped = log_queue.dropped;
+        log_queue.dropped = 0;
+        pthread_mutex_unlock(&log_queue.lock);
+
+        if (dropped > 0) {
+            char notice[LOG_LINE_MAX];
+            snprintf(notice, sizeof(notice),
+                "[logger] dropped %lu log line(s): writer fell behind", dropped);
+            logger_emit_to_file(notice);
+        }
+        logger_emit_to_file(line);
+
+        pthread_mutex_lock(&log_queue.lock);
+        log_queue.head = (log_queue.head + 1) % LOG_QUEUE_CAP;
+        log_queue.count--;
+        if (log_queue.count == 0) {
+            pthread_cond_broadcast(&log_queue.drained);
+        }
+        pthread_mutex_unlock(&log_queue.lock);
+    }
+
+    return NULL;
+}
+
+/* Lazily create the writer thread the first time file logging is enabled.
+ * Called from logger_set_log_to_file() while it holds logger_file_mutex. */
+static void logger_writer_start(void) {
+    pthread_mutex_lock(&log_queue.lock);
+    if (log_queue.started) {
+        pthread_mutex_unlock(&log_queue.lock);
+        return;
+    }
+    /* Reset the queue so a restart after logger_shutdown() is clean. */
+    log_queue.shutting_down = 0;
+    log_queue.head = 0;
+    log_queue.count = 0;
+    log_queue.dropped = 0;
+    if (pthread_create(&log_queue.thread, NULL, logger_writer_main, NULL) == 0) {
+        log_queue.started = 1;
+    }
+    pthread_mutex_unlock(&log_queue.lock);
+}
+
+/* Append a formatted line to the queue and wake the writer. Never blocks on
+ * disk; drops (and counts) the line if the queue is full. */
+static void logger_enqueue(const char* line) {
+    int tail;
+    size_t n;
+
+    pthread_mutex_lock(&log_queue.lock);
+    if (!log_queue.started || log_queue.shutting_down) {
+        pthread_mutex_unlock(&log_queue.lock);
+        return;
+    }
+    if (log_queue.count >= LOG_QUEUE_CAP) {
+        log_queue.dropped++;           /* bounded memory: drop the newest line */
+        pthread_mutex_unlock(&log_queue.lock);
+        return;
+    }
+    tail = (log_queue.head + log_queue.count) % LOG_QUEUE_CAP;
+    n = strlen(line);
+    if (n >= LOG_LINE_MAX) {
+        n = LOG_LINE_MAX - 1;
+    }
+    memcpy(log_queue.lines[tail], line, n);
+    log_queue.lines[tail][n] = '\0';
+    log_queue.count++;
+    pthread_cond_signal(&log_queue.not_empty);
+    pthread_mutex_unlock(&log_queue.lock);
+}
+
+/* Block until every queued line has been written to disk. Used at shutdown
+ * checkpoints and by the unit test. No-op if the writer isn't running. */
+void logger_flush(void) {
+    pthread_mutex_lock(&log_queue.lock);
+    while (log_queue.started && log_queue.count > 0) {
+        pthread_cond_wait(&log_queue.drained, &log_queue.lock);
+    }
+    pthread_mutex_unlock(&log_queue.lock);
+}
+
+/* Drain the queue, stop the writer thread, and close the log file. Idempotent.
+ * Call once during daemon shutdown after the final log line is emitted. */
+void logger_shutdown(void) {
+    int started;
+
+    pthread_mutex_lock(&log_queue.lock);
+    started = log_queue.started;
+    log_queue.shutting_down = 1;
+    pthread_cond_broadcast(&log_queue.not_empty);
+    pthread_mutex_unlock(&log_queue.lock);
+
+    if (started) {
+        pthread_join(log_queue.thread, NULL);
+        pthread_mutex_lock(&log_queue.lock);
+        log_queue.started = 0;
+        pthread_mutex_unlock(&log_queue.lock);
+    }
+
+    pthread_mutex_lock(&logger_file_mutex);
+    if (g_logger != NULL && g_logger->file_stream != NULL) {
+        fclose(g_logger->file_stream);
+        g_logger->file_stream = NULL;
+    }
+    pthread_mutex_unlock(&logger_file_mutex);
+}
 
 
 logger_data_t* logger_get_instance(void) {
@@ -45,9 +241,10 @@ void logger_set_log_file(const char* filename) {
         return;
     }
     
+    pthread_mutex_lock(&logger_file_mutex);
     strncpy(logger->log_file, filename, sizeof(logger->log_file) - 1);
     logger->log_file[sizeof(logger->log_file) - 1] = '\0';
-    
+
     if (logger->log_to_file) {
         if (logger->file_stream != NULL) {
             fclose(logger->file_stream);
@@ -61,6 +258,7 @@ void logger_set_log_file(const char* filename) {
             logger->current_file_size = ftell(logger->file_stream);
         }
     }
+    pthread_mutex_unlock(&logger_file_mutex);
 }
 
 void logger_set_log_to_console(int enable) {
@@ -76,6 +274,7 @@ void logger_set_log_to_file(int enable) {
         return;
     }
     
+    pthread_mutex_lock(&logger_file_mutex);
     logger->log_to_file = enable;
     if (enable && strlen(logger->log_file) > 0) {
         if (logger->file_stream != NULL) {
@@ -88,6 +287,7 @@ void logger_set_log_to_file(int enable) {
         } else {
             fseek(logger->file_stream, 0, SEEK_END);
             logger->current_file_size = ftell(logger->file_stream);
+            logger_writer_start();   /* spin up the async writer thread */
         }
     } else {
         if (logger->file_stream != NULL) {
@@ -95,6 +295,7 @@ void logger_set_log_to_file(int enable) {
             logger->file_stream = NULL;
         }
     }
+    pthread_mutex_unlock(&logger_file_mutex);
 }
 
 void logger_set_rotation(long max_file_size, int max_rotated_files) {
@@ -102,8 +303,10 @@ void logger_set_rotation(long max_file_size, int max_rotated_files) {
     if (logger == NULL) {
         return;
     }
+    pthread_mutex_lock(&logger_file_mutex);
     logger->max_file_size = max_file_size;
     logger->max_rotated_files = (max_rotated_files > 0) ? max_rotated_files : 0;
+    pthread_mutex_unlock(&logger_file_mutex);
 }
 
 static void logger_rotate_files(logger_data_t* logger) {
@@ -202,26 +405,27 @@ void logger_write_log(log_level_t level, const char* category, const char* messa
     char timestamp[64];  /* Increased buffer size for timestamp */
     char formatted_message[512];
     const char* level_str;
-    
+    int to_file;
+
     if (logger == NULL || message == NULL) {
         return;
     }
-    
+
     pthread_mutex_lock(&logger_mutex);
-    
+
     logger_format_timestamp(timestamp, sizeof(timestamp));
     level_str = logger_format_level(level);
-    
+
     /* Format the log message */
     if (category != NULL && strlen(category) > 0) {
         snprintf(formatted_message, sizeof(formatted_message), "[%s] [%s] [%s] %s", timestamp, level_str, category, message);
     } else {
         snprintf(formatted_message, sizeof(formatted_message), "[%s] [%s] %s", timestamp, level_str, message);
     }
-    
+
     /* Store in memory */
     logger_add_to_memory(formatted_message);
-    
+
     /* Output to console */
     if (logger->log_to_console) {
         if (level >= LOG_LEVEL_WARN) {
@@ -230,18 +434,17 @@ void logger_write_log(log_level_t level, const char* category, const char* messa
             printf("%s\n", formatted_message);
         }
     }
-    
-    /* Output to file */
-    if (logger->log_to_file && logger->file_stream != NULL) {
-        int written = fprintf(logger->file_stream, "%s\n", formatted_message);
-        fflush(logger->file_stream);
-        if (written > 0) {
-            logger->current_file_size += written;
-        }
-        logger_check_rotation(logger);
-    }
-    
+
+    to_file = logger->log_to_file;
+
     pthread_mutex_unlock(&logger_mutex);
+
+    /* File output is handed off to the async writer thread (issue #123) so a
+     * slow disk never blocks this producer. The writer drains the queue under
+     * logger_file_mutex and performs the actual fprintf/fflush/rotation. */
+    if (to_file) {
+        logger_enqueue(formatted_message);
+    }
 }
 
 void logger_format_timestamp(char* buffer, size_t buffer_size) {

--- a/host/logger.h
+++ b/host/logger.h
@@ -45,6 +45,13 @@ void logger_set_log_to_console(int enable);
 void logger_set_log_to_file(int enable);
 void logger_set_rotation(long max_file_size, int max_rotated_files);
 
+/* Asynchronous file writer control (issue #123). File output is drained to
+ * disk by a dedicated writer thread so a slow log target never blocks a thread
+ * that logs. logger_flush() blocks until the queue is on disk; logger_shutdown()
+ * drains the queue, stops the writer, and closes the file (call once at exit). */
+void logger_flush(void);
+void logger_shutdown(void);
+
 /* Logging methods */
 void logger_log(log_level_t level, const char* message);
 void logger_log_with_category(log_level_t level, const char* category, const char* message);

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -856,6 +856,48 @@ static void test_card_empty_list(void) {
     TEST_ASSERT_EQ_INT(0, config_is_admin_card(&cfg, "1234567890123456"));
 }
 
+/* ── Logger (async file writer, issue #123) ─────────────────────── */
+
+/* File logging is drained to disk by a background writer thread so a slow disk
+ * can't block a producer. Verify the contract callers depend on: after
+ * logger_flush(), every enqueued line is actually on disk (nothing lost in the
+ * queue), and logger_shutdown() stops the writer cleanly. */
+static void test_logger_async_file_write(void) {
+    const char *path = "/tmp/millennium_logger_async_test.log";
+    char buf[16384];
+    FILE *f;
+    size_t got;
+    int i;
+
+    remove(path);
+    logger_set_log_to_console(0);          /* keep the 200 lines off the console */
+    logger_set_level(LOG_LEVEL_VERBOSE);   /* let INFO lines pass the level gate */
+    logger_set_log_file(path);
+    logger_set_log_to_file(1);
+
+    for (i = 0; i < 200; i++) {
+        logger_infof_with_category("AsyncTest", "line %d", i);
+    }
+
+    logger_flush();   /* block until the writer has drained the queue to disk */
+
+    f = fopen(path, "r");
+    TEST_ASSERT_NOT_NULL(f);
+    got = fread(buf, 1, sizeof(buf) - 1, f);
+    buf[got] = '\0';
+    fclose(f);
+
+    /* First and last lines must both be present once flush() returns. */
+    TEST_ASSERT_NOT_NULL(strstr(buf, "[AsyncTest] line 0"));
+    TEST_ASSERT_NOT_NULL(strstr(buf, "[AsyncTest] line 199"));
+
+    logger_shutdown();                 /* stop the writer, close the file */
+    logger_set_log_to_file(0);
+    logger_set_log_to_console(1);      /* restore defaults for later suites */
+    logger_set_level(LOG_LEVEL_ERROR);
+    remove(path);
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -933,6 +975,9 @@ int main(void) {
     TEST_SUITE_RUN(test_version_no_update_initially);
     TEST_SUITE_RUN(test_updater_apply_null_dir);
     TEST_SUITE_RUN(test_updater_apply_bad_dir);
+
+    TEST_SUITE_BEGIN("Logger");
+    TEST_SUITE_RUN(test_logger_async_file_write);
 
     TEST_REPORT();
 }


### PR DESCRIPTION
## Summary
Fixes #123. The logger held `logger_mutex` across `fprintf()` + `fflush()`, so a slow log target (NFS, full disk, busy spindle) blocked **every** thread that logged — main loop, web server, health monitor, PJSIP callbacks. One slow write cascaded into event-processing delay and a growing serial backlog.

This decouples log producers from the disk:

- A producer formats its line, appends it to the in-memory ring + console under `logger_mutex` (fast, no disk), then drops the line into a **bounded queue** and returns.
- A dedicated **writer thread** drains the queue to disk under a separate `logger_file_mutex`, doing the actual `fprintf`/`fflush`/rotation. Disk latency is absorbed by the queue, never by a producer.
- The queue is bounded (1024 lines). If the writer falls behind, the newest lines are dropped and counted, and the writer emits a single notice line — memory stays bounded, the system never stalls.
- New `logger_flush()` blocks until the queue is on disk; `logger_shutdown()` drains, stops the writer, and closes the file. `daemon.c` calls `logger_shutdown()` at exit so the final lines are persisted.

## Design notes
- `logger_file_mutex` (held only by the writer thread + the startup `set_*` config calls) now guards the file stream and rotation bookkeeping, fully separate from `logger_mutex` (memory ring + console).
- The writer commits a line (advances head/count) **after** the write completes, so `logger_flush()` only sees an empty queue once everything is actually persisted.
- Lock ordering is acyclic: no thread ever holds the queue lock while requesting the file mutex.
- The writer thread starts lazily when file logging is first enabled; if file logging is never enabled (simulator, unit tests), no thread is created and behavior is unchanged.

## Testing
- New unit test (`Logger` suite): enables file logging, writes 200 lines, calls `logger_flush()`, and asserts the first and last lines are on disk — proving nothing is lost in the queue and the writer drains correctly. Ran 8× with no flakiness.
- `make test`: all 58 unit tests and every scenario test pass.
- `daemon.c` compiles clean under `-Wall -Wextra -Wdeclaration-after-statement -Werror -std=gnu89`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)