### PR TITLE
logger: expose async writer queue health as metrics

### DIFF
--- a/host/daemon.c
+++ b/host/daemon.c
@@ -838,6 +838,25 @@ static void update_metrics(void) {
     metrics_set_gauge("current_state", current_state);
     metrics_set_gauge("inserted_cents", inserted_cents);
     metrics_set_gauge("keypad_buffer_size", keypad_size);
+
+    /* Async logger health (issue #123 follow-up). Publishes queue depth, the
+     * high-water mark (capacity headroom), and a true counter of dropped log
+     * lines so log loss is alertable out-of-band — the in-file drop notice is
+     * unreachable exactly when a slow/full disk is the cause. Called from the
+     * single main-loop tick, so the static delta tracker needs no lock. */
+    {
+        logger_queue_stats_t lstats;
+        static unsigned long long last_dropped = 0;
+
+        logger_get_queue_stats(&lstats);
+        metrics_set_gauge("log_queue_depth", (double)lstats.depth);
+        metrics_set_gauge("log_queue_high_water", (double)lstats.high_water);
+        if (lstats.dropped_total > last_dropped) {
+            metrics_increment_counter("log_lines_dropped",
+                (uint64_t)(lstats.dropped_total - last_dropped));
+            last_dropped = lstats.dropped_total;
+        }
+    }
 }
 
 int main(int argc, char *argv[]) {

--- a/host/logger.c
+++ b/host/logger.c
@@ -46,6 +46,8 @@ static struct {
     int head;                  /* index of the next line to write */
     int count;                 /* lines queued but not yet on disk */
     unsigned long dropped;     /* lines discarded on overflow since last notice */
+    unsigned long long dropped_total; /* cumulative drops since start (for metrics) */
+    unsigned long high_water;  /* max depth observed since start (for metrics) */
     int started;               /* writer thread is running */
     int shutting_down;         /* drain-and-exit requested */
     pthread_t thread;
@@ -53,7 +55,7 @@ static struct {
     pthread_cond_t not_empty;  /* a line was queued, or shutdown requested */
     pthread_cond_t drained;    /* queue emptied (count reached 0) */
 } log_queue = {
-    {{0}}, 0, 0, 0, 0, 0, 0,
+    {{0}}, 0, 0, 0, 0, 0, 0, 0, 0,
     PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, PTHREAD_COND_INITIALIZER
 };
 
@@ -157,6 +159,7 @@ static void logger_enqueue(const char* line) {
     }
     if (log_queue.count >= LOG_QUEUE_CAP) {
         log_queue.dropped++;           /* bounded memory: drop the newest line */
+        log_queue.dropped_total++;     /* lifetime total for metrics/alerting */
         pthread_mutex_unlock(&log_queue.lock);
         return;
     }
@@ -168,6 +171,9 @@ static void logger_enqueue(const char* line) {
     memcpy(log_queue.lines[tail], line, n);
     log_queue.lines[tail][n] = '\0';
     log_queue.count++;
+    if ((unsigned long)log_queue.count > log_queue.high_water) {
+        log_queue.high_water = (unsigned long)log_queue.count;
+    }
     pthread_cond_signal(&log_queue.not_empty);
     pthread_mutex_unlock(&log_queue.lock);
 }
@@ -179,6 +185,23 @@ void logger_flush(void) {
     while (log_queue.started && log_queue.count > 0) {
         pthread_cond_wait(&log_queue.drained, &log_queue.lock);
     }
+    pthread_mutex_unlock(&log_queue.lock);
+}
+
+/* Snapshot the async writer queue's health under its own lock. Cheap and
+ * non-blocking (never touches the file mutex), so the metrics refresh can poll
+ * it every tick. depth/started reflect the current instant; high_water and
+ * dropped_total are lifetime totals so a metrics counter can rate() over them. */
+void logger_get_queue_stats(logger_queue_stats_t* out) {
+    if (out == NULL) {
+        return;
+    }
+    pthread_mutex_lock(&log_queue.lock);
+    out->started = log_queue.started;
+    out->depth = (unsigned long)log_queue.count;
+    out->high_water = log_queue.high_water;
+    out->capacity = LOG_QUEUE_CAP;
+    out->dropped_total = log_queue.dropped_total;
     pthread_mutex_unlock(&log_queue.lock);
 }
 

--- a/host/logger.h
+++ b/host/logger.h
@@ -52,6 +52,21 @@ void logger_set_rotation(long max_file_size, int max_rotated_files);
 void logger_flush(void);
 void logger_shutdown(void);
 
+/* Read-only snapshot of the async writer queue's health. When the writer can't
+ * keep up the queue fills and the newest lines are dropped — but the only
+ * in-band signal is a notice written to the log file, which is unreachable
+ * exactly when a slow/full disk is the cause. Exposing these counters lets the
+ * daemon publish them as metrics so log loss is observable out-of-band. */
+typedef struct {
+    int started;                       /* writer thread running (file logging on) */
+    unsigned long depth;               /* lines queued but not yet on disk */
+    unsigned long high_water;          /* max depth observed since start */
+    unsigned long capacity;            /* queue size; drops begin at this depth */
+    unsigned long long dropped_total;  /* cumulative lines dropped since start */
+} logger_queue_stats_t;
+
+void logger_get_queue_stats(logger_queue_stats_t* out);
+
 /* Logging methods */
 void logger_log(log_level_t level, const char* message);
 void logger_log_with_category(log_level_t level, const char* category, const char* message);

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -898,6 +898,44 @@ static void test_logger_async_file_write(void) {
     remove(path);
 }
 
+/* The queue-health snapshot (issue #123 follow-up) feeds the metrics endpoint.
+ * Verify the contract the daemon relies on: capacity is reported, the writer is
+ * marked running while file logging is on, the queue drains to depth 0 after a
+ * flush, every enqueued line shows up in the high-water mark, and a normal run
+ * well under capacity drops nothing. */
+static void test_logger_queue_stats(void) {
+    const char *path = "/tmp/millennium_logger_stats_test.log";
+    logger_queue_stats_t st;
+    int i;
+
+    remove(path);
+    logger_set_log_to_console(0);
+    logger_set_level(LOG_LEVEL_VERBOSE);
+    logger_set_log_file(path);
+    logger_set_log_to_file(1);
+
+    /* Capacity is reported and the writer runs while file logging is enabled. */
+    logger_get_queue_stats(&st);
+    TEST_ASSERT_EQ_INT((int)st.capacity, 1024);
+    TEST_ASSERT_EQ_INT(st.started, 1);
+
+    for (i = 0; i < 50; i++) {
+        logger_infof_with_category("StatsTest", "line %d", i);
+    }
+    logger_flush();   /* block until the writer has drained the queue */
+
+    logger_get_queue_stats(&st);
+    TEST_ASSERT_EQ_INT((int)st.depth, 0);          /* drained after flush */
+    TEST_ASSERT_EQ_INT((int)st.dropped_total, 0);  /* 50 lines << 1024 cap */
+    TEST_ASSERT((int)st.high_water >= 1);          /* lines did pass through */
+
+    logger_shutdown();
+    logger_set_log_to_file(0);
+    logger_set_log_to_console(1);
+    logger_set_level(LOG_LEVEL_ERROR);
+    remove(path);
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -978,6 +1016,7 @@ int main(void) {
 
     TEST_SUITE_BEGIN("Logger");
     TEST_SUITE_RUN(test_logger_async_file_write);
+    TEST_SUITE_RUN(test_logger_queue_stats);
 
     TEST_REPORT();
 }


### PR DESCRIPTION
## Summary

Follow-up to #167 (the async logger, issue #123). That change moves file I/O onto a background writer thread and **drops log lines when the writer can't keep up** with a slow or full disk. The only signal of a drop was a notice line written *into the log file itself* — unreachable precisely when the disk is the bottleneck, so log loss was effectively invisible.

This PR makes log loss **observable out-of-band** via the existing Prometheus/JSON metrics endpoint.

## What changed

- **`logger.c` / `logger.h`** — add `logger_get_queue_stats()`, a cheap, non-blocking snapshot of the writer queue: current depth, lifetime high-water mark, cumulative dropped count, and capacity. It locks only the queue's own lock (never the file mutex), so the metrics refresh can poll it every tick without ever blocking on disk. Two lifetime counters (`dropped_total`, `high_water`) are tracked in `logger_enqueue()`.
- **`daemon.c`** — `update_metrics()` publishes three metrics:
  | metric | type | meaning |
  |---|---|---|
  | `log_queue_depth` | gauge | lines currently awaiting disk |
  | `log_queue_high_water` | gauge | max depth ever seen — capacity headroom |
  | `log_lines_dropped` | counter | cumulative dropped lines, `rate()`-able for alerting |

  The counter is driven by a delta tracker; `update_metrics()` runs on the single main-loop tick, so no extra locking is needed.
- **`tests/unit_tests.c`** — new `test_logger_queue_stats` covering the stats contract (capacity reported, writer marked running, queue drains to depth 0 after flush, lines register in the high-water mark, nothing dropped well under capacity).

Metrics auto-register on first use and the endpoint enumerates dynamically, so the three new series appear automatically with Prometheus HELP/TYPE lines — no list to maintain.

## Testing

- `make test` — all unit + scenario tests pass (59 unit assertions, including the new test).
- `daemon.o` compiles clean under `-Wall -Wextra -Wdeclaration-after-statement -Werror -std=gnu89`.

## Note

Stacked on #167 — base is `fix/issue-123-async-logger`, not `main`. Retarget to `main` once #167 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)