### PR TITLE
web_server: read full request body before parsing (fixes "Unknown action: unknown")

### DIFF
--- a/host/web_server.c
+++ b/host/web_server.c
@@ -528,17 +528,84 @@ void* web_server_thread_func(void* arg) {
     return NULL;
 }
 
+/* Case-insensitively scan request text line-by-line for the Content-Length
+ * header and return its value, or -1 if absent/malformed. Scanning per-line
+ * (not a raw substring search) avoids matching the token inside a body. */
+static long web_server_parse_content_length(const char* buf) {
+    const char* p = buf;
+    while (p && *p) {
+        const char* h = p;
+        const char* n = "content-length:";
+        while (*n && *h && (char)tolower((unsigned char)*h) == *n) {
+            h++;
+            n++;
+        }
+        if (*n == '\0') {
+            while (*h == ' ' || *h == '\t') h++;
+            return strtol(h, NULL, 10);
+        }
+        p = strchr(p, '\n');
+        if (p) p++;
+    }
+    return -1;
+}
+
 void web_server_handle_client(struct web_server* server, int client_fd) {
-    char buffer[4096] = {0};
+    char buffer[4096];
     ssize_t bytes_read;
+    size_t total = 0;
+    char* header_end = NULL;
+    long content_length = -1;
+    struct timeval tv;
     if (!server) {
         close(client_fd);
         return;
     }
 
-    bytes_read = read(client_fd, buffer, sizeof(buffer) - 1);
+    /* A request's headers and body can arrive in separate TCP segments, so a
+     * single read() often returns only the headers with the body still in
+     * flight. That left POST bodies empty — the cause of /api/control
+     * intermittently reporting "Unknown action: unknown". Read until the whole
+     * body (per Content-Length) has arrived. A receive timeout keeps a slow or
+     * stalled client from hanging the single-threaded accept loop. */
+    tv.tv_sec = 2;
+    tv.tv_usec = 0;
+    setsockopt(client_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 
-    if (bytes_read > 0) {
+    memset(buffer, 0, sizeof(buffer));
+    while (total < sizeof(buffer) - 1) {
+        bytes_read = read(client_fd, buffer + total, sizeof(buffer) - 1 - total);
+        if (bytes_read <= 0) {
+            break;   /* EOF, error, or receive timeout */
+        }
+        total += (size_t)bytes_read;
+        buffer[total] = '\0';
+
+        if (!header_end) {
+            header_end = strstr(buffer, "\r\n\r\n");
+            if (header_end) {
+                header_end += 4;
+            } else {
+                char* alt = strstr(buffer, "\n\n");
+                if (alt) header_end = alt + 2;
+            }
+            if (header_end) {
+                content_length = web_server_parse_content_length(buffer);
+            }
+        }
+        if (header_end) {
+            /* No body expected (e.g. GET): headers alone are enough. */
+            if (content_length < 0) {
+                break;
+            }
+            /* Stop once the declared body length has been received. */
+            if ((size_t)(buffer + total - header_end) >= (size_t)content_length) {
+                break;
+            }
+        }
+    }
+
+    if (total > 0) {
         struct http_request parsed_request = web_server_parse_request(buffer);
         struct http_response response;
 


### PR DESCRIPTION
## Symptom

Clicking an action button on the web dashboard intermittently shows **"Unknown action: unknown"** in a toast, and the action doesn't take effect.

## Root cause

`web_server_handle_client()` read the incoming request with a **single `read()`**:

```c
bytes_read = read(client_fd, buffer, sizeof(buffer) - 1);
```

A request's headers and body can arrive in **separate TCP segments**. When they do, that one `read()` returns only the headers — the JSON body (`{"action":"..."}`) is still in flight. `web_server_parse_request()` then finds an empty body, `web_server_handle_api_control()` never matches `"action":"..."`, and `action` keeps its default value `"unknown"`, producing the message `Unknown action: unknown`. Because it depends on TCP segmentation timing, it only happens on *some* clicks — exactly what was observed.

## Fix

Read in a loop until the full body has arrived:

- Accumulate into the buffer; once the header terminator (`\r\n\r\n`) is seen, parse `Content-Length`.
- Keep reading until the received body reaches `Content-Length`, the buffer fills, or the connection ends.
- Set a **2-second `SO_RCVTIMEO`** so a slow or stalled client can't hang the single-threaded accept loop.
- Requests with no `Content-Length` (e.g. `GET`) return as soon as the headers are complete.

Adds a small case-insensitive `Content-Length` parser that scans line-by-line (so it can't match the token inside a body).

## Testing

- `make test` — all unit + scenario tests pass.
- `web_server.o` compiles clean under `-Wall -Wextra -Wdeclaration-after-statement -Werror -std=gnu89`.
- Verified the read-loop algorithm with a `socketpair` harness: a POST whose body arrives 50 ms after its headers is now assembled correctly (`action` found), and a bodyless `GET` returns without blocking.
- The web server is exercised end-to-end on the live device via `tests/api_test.sh` (`make device-test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)