### PR TITLE
display: enforce per-line budget for plugin content

### DIFF
--- a/host/PLUGIN_AUTHORING.md
+++ b/host/PLUGIN_AUTHORING.md
@@ -105,7 +105,16 @@ void register_hello_plugin(void) {
   `config_get_int/string/bool(config_get_instance(), "your.key", default)`.
   Exposing a "forced" value (e.g. `guess.secret`) makes scenario tests
   deterministic.
-- **Display width.** The VFD is two 20-char lines; longer lines auto-scroll.
+- **Display width.** The VFD is two 20-char lines (`DISPLAY_WIDTH`). A line at
+  or under 20 chars is shown statically; a longer line auto-scrolls. The
+  pipeline scrolls up to `DISPLAY_MAX_TEXT_LEN`-1 (255) chars per line; a line
+  longer than that is silently truncated, so keep every display string within
+  that budget — and ideally within `2 × DISPLAY_WIDTH` (40) so a two-line
+  message fits without scrolling. The unit-test guardrail
+  `test_plugin_display_lines_fit` enforces the no-truncation budget across the
+  built-in plugins by round-tripping their static strings through the display;
+  if you add a content table, expose it the way `trivia_display_strings` does
+  and add it to that test.
 
 ## Testing
 

--- a/host/display_manager.c
+++ b/host/display_manager.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#define MAX_TEXT_LEN 256
+#define MAX_TEXT_LEN DISPLAY_MAX_TEXT_LEN
 
 static millennium_client_t *dm_client = NULL;
 

--- a/host/display_manager.h
+++ b/host/display_manager.h
@@ -7,6 +7,16 @@
 #define DISPLAY_SCROLL_GAP 3  /* spaces between end and start during scroll */
 
 /*
+ * Per-line storage/scroll budget. The VFD shows DISPLAY_WIDTH (20) chars at a
+ * time: a line up to that length is static, a longer line auto-scrolls. The
+ * pipeline can scroll a line up to DISPLAY_MAX_TEXT_LEN-1 chars; anything
+ * longer is silently truncated, so plugin display content must stay under this
+ * budget. The unit-test guardrail (test_plugin_display_lines_fit) enforces it
+ * for every built-in plugin.
+ */
+#define DISPLAY_MAX_TEXT_LEN 256
+
+/*
  * Initialize the display manager with the SDK client handle.
  * Must be called before any other display_manager functions.
  */

--- a/host/plugin_sdk.c
+++ b/host/plugin_sdk.c
@@ -37,7 +37,9 @@ void sdk_display_line(const char *line1) {
 }
 
 void sdk_displayf(const char *fmt, ...) {
-    char line1[64];
+    char line1[DISPLAY_MAX_TEXT_LEN];   /* match the display line budget so a
+                                         * long formatted line scrolls rather
+                                         * than being truncated here first */
     va_list ap;
     if (!fmt) { display_manager_set_text(NULL, NULL); return; }
     va_start(ap, fmt);

--- a/host/plugins/dial_a_joke.c
+++ b/host/plugins/dial_a_joke.c
@@ -107,6 +107,20 @@ static void dj_handle_tick(void) {
     }
 }
 
+/* Test/introspection hook (see test_plugin_display_lines_fit): expose every
+ * static display string so the unit-test guardrail can verify none exceeds the
+ * display line budget. Returns the total count; fills up to `max` into out[]. */
+int dial_a_joke_display_strings(const char **out, int max) {
+    int n = 0, i;
+    for (i = 0; i < NUM_JOKES; i++) {
+        if (out && n < max) out[n] = jokes[i].setup;
+        n++;
+        if (out && n < max) out[n] = jokes[i].punch;
+        n++;
+    }
+    return n;
+}
+
 void register_dial_a_joke_plugin(void) {
     memset(&dj, 0, sizeof(dj));
     dj.phase = DJ_IDLE;

--- a/host/plugins/fortune_teller.c
+++ b/host/plugins/fortune_teller.c
@@ -228,6 +228,32 @@ static const char* fortune_teller_get_random_fortune(int category) {
     return "The future is unclear";
 }
 
+/* Test/introspection hook (see test_plugin_display_lines_fit): expose every
+ * category label and fortune so the unit-test guardrail can verify none
+ * exceeds the display line budget. Returns the count; fills up to `max`. */
+int fortune_teller_display_strings(const char **out, int max) {
+    const char **groups[5];
+    int n = 0, g, i;
+
+    groups[0] = love_fortunes;
+    groups[1] = career_fortunes;
+    groups[2] = health_fortunes;
+    groups[3] = money_fortunes;
+    groups[4] = general_fortunes;
+
+    for (i = 0; i < 5; i++) {
+        if (out && n < max) out[n] = fortune_categories[i];
+        n++;
+    }
+    for (g = 0; g < 5; g++) {
+        for (i = 0; i < 4; i++) {
+            if (out && n < max) out[n] = groups[g][i];
+            n++;
+        }
+    }
+    return n;
+}
+
 /* Plugin registration function */
 void register_fortune_teller_plugin(void) {
     /* Initialize plugin data */

--- a/host/plugins/jukebox.c
+++ b/host/plugins/jukebox.c
@@ -452,6 +452,20 @@ static void jukebox_stop_audio(void) {
     logger_info_with_category("Jukebox", "Audio stopped");
 }
 
+/* Test/introspection hook (see test_plugin_display_lines_fit): expose every
+ * static song title and artist so the unit-test guardrail can verify none
+ * exceeds the display line budget. Returns the count; fills up to `max`. */
+int jukebox_display_strings(const char **out, int max) {
+    int n = 0, i;
+    for (i = 0; i < (int)NUM_SONGS; i++) {
+        if (out && n < max) out[n] = songs[i].title;
+        n++;
+        if (out && n < max) out[n] = songs[i].artist;
+        n++;
+    }
+    return n;
+}
+
 /* Plugin registration function */
 void register_jukebox_plugin(void) {
     /* Initialize plugin data */

--- a/host/plugins/trivia.c
+++ b/host/plugins/trivia.c
@@ -140,6 +140,18 @@ static void tq_handle_tick(void) {
     }
 }
 
+/* Test/introspection hook (see test_plugin_display_lines_fit): expose every
+ * static claim so the unit-test guardrail can verify none exceeds the display
+ * line budget. Returns the total count; fills up to `max` into out[]. */
+int trivia_display_strings(const char **out, int max) {
+    int n = 0, i;
+    for (i = 0; i < NUM_Q; i++) {
+        if (out && n < max) out[n] = questions[i].claim;
+        n++;
+    }
+    return n;
+}
+
 void register_trivia_plugin(void) {
     memset(&tq, 0, sizeof(tq));
     tq.phase = TQ_IDLE;

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -9,7 +9,9 @@
 #include "../updater.h"
 #include "../plugin_sdk.h"
 #include "../clock_source.h"
+#include "../display_manager.h"
 #include <stdlib.h>
+#include <string.h>
 
 /* ── Stubs for linker (plugins.c references these) ──────────────── */
 
@@ -634,6 +636,53 @@ static void test_number_guess_compare(void) {
     TEST_ASSERT(number_guess_compare(99, 1) < 0);
 }
 
+/* ── Display line budget guardrail ──────────────────────────────────── */
+
+/* Each content-heavy built-in exposes its static display strings (mirroring
+ * the number_guess_compare export). The VFD scrolls long lines, but the
+ * pipeline silently truncates anything >= DISPLAY_MAX_TEXT_LEN, so every
+ * authored line must round-trip through the display without loss. */
+int dial_a_joke_display_strings(const char **out, int max);
+int trivia_display_strings(const char **out, int max);
+int jukebox_display_strings(const char **out, int max);
+int fortune_teller_display_strings(const char **out, int max);
+
+static void check_display_strings(const char *plugin,
+                                  int (*collect)(const char **, int)) {
+    const char *strings[128];
+    char back[DISPLAY_MAX_TEXT_LEN];
+    int count, i;
+
+    count = collect(strings, 128);
+    TEST_ASSERT(count > 0);
+    TEST_ASSERT(count <= 128);          /* buffer holds the whole table */
+
+    for (i = 0; i < count; i++) {
+        /* Push the real string through the real display pipeline and read it
+         * back: a line over the budget comes back truncated, which fails. */
+        display_manager_set_text(strings[i], NULL);
+        display_manager_get_text(back, sizeof(back), NULL, 0);
+        if (strcmp(back, strings[i]) != 0) {
+            fprintf(stderr, "  %s display line truncated: \"%s\" -> \"%s\"\n",
+                    plugin, strings[i], back);
+        }
+        TEST_ASSERT_EQ_STR(back, strings[i]);
+    }
+}
+
+static void test_plugin_display_lines_fit(void) {
+    client = millennium_client_create();
+    display_manager_init(client);
+
+    check_display_strings("Dial-A-Joke", dial_a_joke_display_strings);
+    check_display_strings("Trivia", trivia_display_strings);
+    check_display_strings("Jukebox", jukebox_display_strings);
+    check_display_strings("Fortune Teller", fortune_teller_display_strings);
+
+    millennium_client_destroy(client);
+    client = NULL;
+}
+
 /* ── Plugin SDK ─────────────────────────────────────────────────────── */
 
 static void test_sdk_rand_bounds(void) {
@@ -979,6 +1028,7 @@ int main(void) {
     TEST_SUITE_RUN(test_plugins_to_json);
     TEST_SUITE_RUN(test_plugins_to_json_escapes);
     TEST_SUITE_RUN(test_number_guess_compare);
+    TEST_SUITE_RUN(test_plugin_display_lines_fit);
 
     TEST_SUITE_BEGIN("Plugin SDK");
     TEST_SUITE_RUN(test_sdk_rand_bounds);


### PR DESCRIPTION
## Problem
The VFD is two 20-char lines; longer lines **auto-scroll**, which is the intended, documented behavior. But nothing guarded against plugin content that exceeds what the display pipeline can actually render — and `sdk_displayf()` formatted into a 64-byte buffer, silently truncating a long formatted line **4× earlier** than the display manager (256).

## Change
Keep scrolling; make the per-line limit explicit, enforced, and safe.

- **Explicit budget** — `DISPLAY_MAX_TEXT_LEN` (256) added to `display_manager.h` with the static / scroll / truncate tiers documented; `display_manager.c` references it.
- **Fix latent truncation** — `sdk_displayf()` now formats into a `DISPLAY_MAX_TEXT_LEN` buffer so a long formatted line scrolls instead of being cut at 64. The whole display pipeline now has one coherent boundary.
- **Guardrail test** — `test_plugin_display_lines_fit` round-trips every static display string from the four content plugins (dial_a_joke, trivia, jukebox, fortune_teller — 69 strings) through the *real* display pipeline and asserts none is truncated. Each plugin exposes its strings via a small `*_display_strings()` accessor, mirroring the existing `number_guess_compare` export pattern.
- **Docs** — `PLUGIN_AUTHORING.md` documents the budget tiers and tells authors to add new content tables to the guardrail.

## Testing
- Clean compile under `-Wall -Wextra -Werror -std=gnu89`
- `./unit_tests` → **60 passed, 0 failed** (new test included)
- `make test` → all scenarios pass

Note: `make daemon` (full PJSIP build) is Pi-only and unverified here; all changed files are covered by the host-side `make test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)