### PR TITLE
Harden state_persistence_load against corrupt files

### DIFF
--- a/host/state_persistence.c
+++ b/host/state_persistence.c
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <errno.h>
+#include <limits.h>
 
 int state_persistence_save(const persisted_state_t *state, const char *filepath) {
     FILE *f;
@@ -42,9 +44,30 @@ int state_persistence_save(const persisted_state_t *state, const char *filepath)
     return 0;
 }
 
+/*
+ * Parse a whole token as a base-10 int. Returns 1 only if the entire (trimmed)
+ * token is a valid integer with no trailing garbage; 0 otherwise. This is
+ * stricter than atoi(), which silently yields 0 for non-numeric input.
+ */
+static int parse_strict_int(const char *s, int *out) {
+    char *end;
+    long val;
+
+    if (!s || *s == '\0') return 0;
+    errno = 0;
+    val = strtol(s, &end, 10);
+    if (end == s) return 0;          /* no digits consumed */
+    while (*end == ' ' || *end == '\t') end++;
+    if (*end != '\0') return 0;      /* trailing non-numeric garbage */
+    if (errno == ERANGE || val < INT_MIN || val > INT_MAX) return 0;
+    *out = (int)val;
+    return 1;
+}
+
 int state_persistence_load(persisted_state_t *state, const char *filepath) {
     FILE *f;
     char line[256];
+    int have_cents = 0, have_state = 0;
 
     if (!state || !filepath) return -1;
 
@@ -52,30 +75,62 @@ int state_persistence_load(persisted_state_t *state, const char *filepath) {
 
     f = fopen(filepath, "r");
     if (!f) {
+        /* Missing file is the normal first-boot case; not an error worth logging. */
         return -1;
     }
 
     while (fgets(line, sizeof(line), f)) {
         char *eq = strchr(line, '=');
-        char *newline;
+        char *val, *nl;
         if (!eq) continue;
 
         *eq = '\0';
-        eq++;
+        val = eq + 1;
 
-        newline = strchr(eq, '\n');
-        if (newline) *newline = '\0';
+        /* Strip the trailing newline (and a stray CR from CRLF files). */
+        nl = val + strlen(val);
+        while (nl > val && (nl[-1] == '\n' || nl[-1] == '\r')) *--nl = '\0';
 
         if (strcmp(line, "inserted_cents") == 0) {
-            state->inserted_cents = atoi(eq);
+            int v;
+            if (!parse_strict_int(val, &v) || v < 0 || v > STATE_MAX_INSERTED_CENTS) {
+                logger_warn_with_category("Persistence",
+                    "Corrupt state file: invalid inserted_cents; ignoring");
+                goto corrupt;
+            }
+            state->inserted_cents = v;
+            have_cents = 1;
         } else if (strcmp(line, "last_state") == 0) {
-            state->last_state = atoi(eq);
+            int v;
+            if (!parse_strict_int(val, &v) ||
+                v < (int)DAEMON_STATE_INVALID || v > (int)DAEMON_STATE_CALL_ACTIVE) {
+                logger_warn_with_category("Persistence",
+                    "Corrupt state file: invalid last_state; ignoring");
+                goto corrupt;
+            }
+            state->last_state = v;
+            have_state = 1;
         } else if (strcmp(line, "active_plugin") == 0) {
-            strncpy(state->active_plugin, eq, sizeof(state->active_plugin) - 1);
+            strncpy(state->active_plugin, val, sizeof(state->active_plugin) - 1);
             state->active_plugin[sizeof(state->active_plugin) - 1] = '\0';
         }
     }
 
     fclose(f);
+
+    /* The writer always emits both numeric fields; a file missing either one is
+     * truncated/corrupt, so reject it rather than restore a half-state. */
+    if (!have_cents || !have_state) {
+        logger_warn_with_category("Persistence",
+            "Corrupt state file: missing required fields; ignoring");
+        memset(state, 0, sizeof(persisted_state_t));
+        return -1;
+    }
+
     return 0;
+
+corrupt:
+    fclose(f);
+    memset(state, 0, sizeof(persisted_state_t));
+    return -1;
 }

--- a/host/state_persistence.h
+++ b/host/state_persistence.h
@@ -10,15 +10,30 @@ typedef struct {
 } persisted_state_t;
 
 /*
+ * Sanity bound on a restored coin balance. A real balance is a few dollars;
+ * anything beyond this is corruption (e.g. a torn write or random garbage), so
+ * the loader rejects the whole file rather than restoring an absurd balance.
+ * 100000 cents = $1000, far above any plausible inserted amount.
+ */
+#define STATE_MAX_INSERTED_CENTS 100000
+
+/*
  * Save current state to disk. Uses fsync for durability.
  * Returns 0 on success, -1 on failure.
  */
 int state_persistence_save(const persisted_state_t *state, const char *filepath);
 
 /*
- * Load persisted state from disk.
- * Returns 0 on success, -1 if file doesn't exist or is corrupt.
- * On failure, *state is zeroed out.
+ * Load persisted state from disk and validate it.
+ *
+ * A file is accepted only if it carries both numeric fields and every value is
+ * in range: inserted_cents in [0, STATE_MAX_INSERTED_CENTS] and last_state a
+ * valid daemon_state_t (DAEMON_STATE_INVALID..DAEMON_STATE_CALL_ACTIVE). A
+ * missing file, a missing required field, a non-numeric value, or an
+ * out-of-range value is treated as "no usable state".
+ *
+ * Returns 0 on success, -1 if the file doesn't exist or is corrupt. On failure
+ * *state is zeroed out, so the caller can boot as if no state were persisted.
  */
 int state_persistence_load(persisted_state_t *state, const char *filepath);
 

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -9,6 +9,7 @@
 #include "../updater.h"
 #include "../plugin_sdk.h"
 #include "../clock_source.h"
+#include "../state_persistence.h"
 #include <stdlib.h>
 
 /* ── Stubs for linker (plugins.c references these) ──────────────── */
@@ -936,6 +937,141 @@ static void test_logger_queue_stats(void) {
     remove(path);
 }
 
+/* ── State persistence tests ────────────────────────────────────── */
+
+#define SP_PATH "/tmp/millennium_test_persist"
+
+/* Write the given body to the persistence test file. */
+static void sp_write(const char *body) {
+    FILE *f = fopen(SP_PATH, "w");
+    if (f) { fputs(body, f); fclose(f); }
+}
+
+static void test_persist_save_load_roundtrip(void) {
+    persisted_state_t in, out;
+    in.inserted_cents = 75;
+    in.last_state = (int)DAEMON_STATE_IDLE_UP;
+    strcpy(in.active_plugin, "Fortune Teller");
+
+    TEST_ASSERT_EQ_INT(state_persistence_save(&in, SP_PATH), 0);
+    TEST_ASSERT_EQ_INT(state_persistence_load(&out, SP_PATH), 0);
+    TEST_ASSERT_EQ_INT(out.inserted_cents, 75);
+    TEST_ASSERT_EQ_INT(out.last_state, (int)DAEMON_STATE_IDLE_UP);
+    TEST_ASSERT_EQ_STR(out.active_plugin, "Fortune Teller");
+    remove(SP_PATH);
+}
+
+static void test_persist_load_valid(void) {
+    persisted_state_t st;
+    sp_write("inserted_cents=50\nlast_state=2\nactive_plugin=Jukebox\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load(&st, SP_PATH), 0);
+    TEST_ASSERT_EQ_INT(st.inserted_cents, 50);
+    TEST_ASSERT_EQ_INT(st.last_state, 2);
+    TEST_ASSERT_EQ_STR(st.active_plugin, "Jukebox");
+    remove(SP_PATH);
+}
+
+static void test_persist_missing_file(void) {
+    persisted_state_t st;
+    remove(SP_PATH);
+    TEST_ASSERT_EQ_INT(state_persistence_load(&st, SP_PATH), -1);
+    TEST_ASSERT_EQ_INT(st.inserted_cents, 0);
+}
+
+static void test_persist_null_args(void) {
+    persisted_state_t st;
+    TEST_ASSERT_EQ_INT(state_persistence_load(NULL, SP_PATH), -1);
+    TEST_ASSERT_EQ_INT(state_persistence_load(&st, NULL), -1);
+}
+
+/* A file with no recognizable keys is corrupt: reject and zero out. */
+static void test_persist_garbage_rejected(void) {
+    persisted_state_t st;
+    sp_write("this is not a valid state file\n\x01\x02\x03\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load(&st, SP_PATH), -1);
+    TEST_ASSERT_EQ_INT(st.inserted_cents, 0);
+    TEST_ASSERT_EQ_INT(st.last_state, 0);
+    remove(SP_PATH);
+}
+
+/* Missing required field (only active_plugin present) is corrupt. */
+static void test_persist_missing_fields_rejected(void) {
+    persisted_state_t st;
+    sp_write("active_plugin=Simon\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load(&st, SP_PATH), -1);
+    TEST_ASSERT_EQ_STR(st.active_plugin, "");
+    remove(SP_PATH);
+}
+
+static void test_persist_nonnumeric_cents_rejected(void) {
+    persisted_state_t st;
+    sp_write("inserted_cents=lots\nlast_state=1\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load(&st, SP_PATH), -1);
+    TEST_ASSERT_EQ_INT(st.inserted_cents, 0);
+    remove(SP_PATH);
+}
+
+/* atoi() would have accepted "25xyz" as 25; the strict parser rejects it. */
+static void test_persist_trailing_garbage_rejected(void) {
+    persisted_state_t st;
+    sp_write("inserted_cents=25xyz\nlast_state=1\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load(&st, SP_PATH), -1);
+    remove(SP_PATH);
+}
+
+static void test_persist_negative_cents_rejected(void) {
+    persisted_state_t st;
+    sp_write("inserted_cents=-5\nlast_state=1\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load(&st, SP_PATH), -1);
+    remove(SP_PATH);
+}
+
+static void test_persist_huge_cents_rejected(void) {
+    persisted_state_t st;
+    sp_write("inserted_cents=999999\nlast_state=1\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load(&st, SP_PATH), -1);
+    remove(SP_PATH);
+}
+
+static void test_persist_bad_last_state_rejected(void) {
+    persisted_state_t st;
+    /* 9 is outside the daemon_state_t enum range (0..4). */
+    sp_write("inserted_cents=10\nlast_state=9\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load(&st, SP_PATH), -1);
+    remove(SP_PATH);
+}
+
+static void test_persist_negative_last_state_rejected(void) {
+    persisted_state_t st;
+    sp_write("inserted_cents=10\nlast_state=-1\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load(&st, SP_PATH), -1);
+    remove(SP_PATH);
+}
+
+/* Boundary values must be accepted: cents at the cap, last_state at the
+ * top of the enum. */
+static void test_persist_boundary_values_accepted(void) {
+    persisted_state_t st;
+    char body[128];
+    sprintf(body, "inserted_cents=%d\nlast_state=%d\n",
+            STATE_MAX_INSERTED_CENTS, (int)DAEMON_STATE_CALL_ACTIVE);
+    sp_write(body);
+    TEST_ASSERT_EQ_INT(state_persistence_load(&st, SP_PATH), 0);
+    TEST_ASSERT_EQ_INT(st.inserted_cents, STATE_MAX_INSERTED_CENTS);
+    TEST_ASSERT_EQ_INT(st.last_state, (int)DAEMON_STATE_CALL_ACTIVE);
+    remove(SP_PATH);
+}
+
+/* A CRLF file (stray carriage returns) must still parse cleanly. */
+static void test_persist_crlf_tolerated(void) {
+    persisted_state_t st;
+    sp_write("inserted_cents=30\r\nlast_state=1\r\nactive_plugin=Trivia\r\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load(&st, SP_PATH), 0);
+    TEST_ASSERT_EQ_INT(st.inserted_cents, 30);
+    TEST_ASSERT_EQ_STR(st.active_plugin, "Trivia");
+    remove(SP_PATH);
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -1017,6 +1153,22 @@ int main(void) {
     TEST_SUITE_BEGIN("Logger");
     TEST_SUITE_RUN(test_logger_async_file_write);
     TEST_SUITE_RUN(test_logger_queue_stats);
+
+    TEST_SUITE_BEGIN("State Persistence");
+    TEST_SUITE_RUN(test_persist_save_load_roundtrip);
+    TEST_SUITE_RUN(test_persist_load_valid);
+    TEST_SUITE_RUN(test_persist_missing_file);
+    TEST_SUITE_RUN(test_persist_null_args);
+    TEST_SUITE_RUN(test_persist_garbage_rejected);
+    TEST_SUITE_RUN(test_persist_missing_fields_rejected);
+    TEST_SUITE_RUN(test_persist_nonnumeric_cents_rejected);
+    TEST_SUITE_RUN(test_persist_trailing_garbage_rejected);
+    TEST_SUITE_RUN(test_persist_negative_cents_rejected);
+    TEST_SUITE_RUN(test_persist_huge_cents_rejected);
+    TEST_SUITE_RUN(test_persist_bad_last_state_rejected);
+    TEST_SUITE_RUN(test_persist_negative_last_state_rejected);
+    TEST_SUITE_RUN(test_persist_boundary_values_accepted);
+    TEST_SUITE_RUN(test_persist_crlf_tolerated);
 
     TEST_REPORT();
 }


### PR DESCRIPTION
## Problem

`state_persistence_load()`'s header contract promises it returns `-1` and zeroes the struct when a state file is *corrupt*, but the implementation did **no validation**:

- It used `atoi()`, which silently yields `0` for non-numeric input (`"lots"` → `0`, `"25xyz"` → `25`).
- It returned `0` as long as the file merely *opened* — even for an empty or all-garbage file with no recognized keys.

So a torn write (the atomic-rename guard is recent), a partial flush, or disk corruption could restore an out-of-range `last_state`, a negative or absurd coin balance, or an all-zero struct masquerading as success — and `daemon.c` trusts the result on boot (sets `inserted_cents`, re-activates the plugin, and keys the unclean-shutdown recovery off `last_state`).

## Fix

Make the loader live up to its documented contract:

- **Strict numeric parsing** via a `strtol`-based helper that rejects non-numeric values *and* trailing garbage.
- **Range checks**: `inserted_cents` ∈ `[0, STATE_MAX_INSERTED_CENTS]` ($1000); `last_state` ∈ the valid `daemon_state_t` enum range.
- **Required fields**: both numeric fields must be present, else the file is treated as truncated/corrupt.
- On any corruption: log a warning, zero `*state`, return `-1` — so the daemon boots as if nothing were persisted. A genuinely *missing* file stays the silent first-boot path.
- Tolerate CRLF line endings.

No daemon changes needed — it already treats `load() != 0` as "no usable state".

## Tests

New 14-case **State Persistence** unit suite: save/load round trip, valid load, missing file, NULL args, garbage, missing fields, non-numeric / trailing-garbage / negative / over-cap cents, out-of-range and negative `last_state`, boundary values, and CRLF.

`make test`: **73 unit tests pass** (was 59), all scenarios pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)