### PR TITLE
config: validate numeric settings against ranges, fail fast with specifics

### DIFF
--- a/host/config.c
+++ b/host/config.c
@@ -1,9 +1,11 @@
 #define _POSIX_C_SOURCE 200112L
 #include "config.h"
+#include "logger.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <limits.h>
 
 /* Global config instance */
 config_data_t* g_config = NULL;
@@ -168,17 +170,53 @@ int config_get_bool(const config_data_t* config, const char* key, int default_va
     return 0;
 }
 
-int config_validate(const config_data_t* config) {
-    /* Validate numeric values */
-    if (config_get_call_cost_cents(config) <= 0) {
+/* Range-check a single numeric setting. On failure, log which key and the
+ * accepted bounds so the operator sees exactly what to fix instead of a bare
+ * "validation failed". Returns 1 if in range, 0 otherwise. */
+static int config_validate_range(const char* key, int value, int min, int max) {
+    if (value < min || value > max) {
+        logger_errorf_with_category("Config",
+            "Invalid %s=%d (must be %d..%d)", key, value, min, max);
         return 0;
     }
-    
-    if (config_get_update_interval_ms(config) <= 0) {
-        return 0;
-    }
-    
     return 1;
+}
+
+int config_validate(const config_data_t* config) {
+    int ok = 1;
+
+    if (config == NULL) {
+        return 0;
+    }
+
+    /* Bitwise-AND (not &&) so every setting is checked in a single pass and the
+     * operator sees all problems at once, rather than fixing them one restart at
+     * a time. Each helper returns 0 or 1. */
+    ok &= config_validate_range("call.cost_cents",
+        config_get_call_cost_cents(config), 1, 100000);
+    ok &= config_validate_range("call.timeout_seconds",
+        config_get_call_timeout_seconds(config), 1, 86400);
+    ok &= config_validate_range("call.idle_timeout_seconds",
+        config_get_idle_timeout_seconds(config), 1, 86400);
+    ok &= config_validate_range("hardware.baud_rate",
+        config_get_baud_rate(config), 1, 4000000);
+    ok &= config_validate_range("system.update_interval_ms",
+        config_get_update_interval_ms(config), 1, 60000);
+    ok &= config_validate_range("system.max_retries",
+        config_get_max_retries(config), 0, 1000);
+    ok &= config_validate_range("logging.max_size_bytes",
+        config_get_log_max_size_bytes(config), 1, INT_MAX);
+    ok &= config_validate_range("logging.max_files",
+        config_get_log_max_files(config), 1, 1000);
+    ok &= config_validate_range("metrics_server.port",
+        config_get_metrics_server_port(config), 1, 65535);
+    ok &= config_validate_range("web_server.port",
+        config_get_web_server_port(config), 1, 65535);
+    /* sip.local_port: 0 is valid and means "auto/ephemeral". */
+    ok &= config_validate_range("sip.local_port",
+        config_get_int(config, "sip.local_port", 0), 0, 65535);
+
+    return ok;
 }
 
 void config_set_default_values(config_data_t* config) {

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -146,6 +146,75 @@ static void test_config_validate_bad_cost(void) {
     TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
 }
 
+/* Ports must be in 1..65535; 0 and out-of-range values are rejected. */
+static void test_config_validate_bad_ports(void) {
+    config_data_t cfg;
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "web_server.port", "0");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "web_server.port", "70000");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "metrics_server.port", "-1");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+}
+
+/* Negative or zero timeouts would disable the call/idle watchdogs. */
+static void test_config_validate_bad_timeouts(void) {
+    config_data_t cfg;
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "call.timeout_seconds", "0");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "call.idle_timeout_seconds", "-5");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+}
+
+/* Non-numeric garbage parses to 0 via atoi and must be rejected by the
+ * range check rather than silently accepted. */
+static void test_config_validate_garbage_int(void) {
+    config_data_t cfg;
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "hardware.baud_rate", "fast");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+}
+
+/* Log rotation needs at least one file and a positive size cap. */
+static void test_config_validate_bad_log_rotation(void) {
+    config_data_t cfg;
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "logging.max_files", "0");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "logging.max_size_bytes", "0");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+}
+
+/* sip.local_port == 0 means auto/ephemeral and must stay valid. */
+static void test_config_validate_sip_port_auto(void) {
+    config_data_t cfg;
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "sip.local_port", "0");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 1);
+
+    config_set_value(&cfg, "sip.local_port", "99999");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+}
+
 static void test_config_trim(void) {
     char result[64];
 
@@ -949,6 +1018,11 @@ int main(void) {
     TEST_SUITE_RUN(test_config_get_bool_variants);
     TEST_SUITE_RUN(test_config_validate_good);
     TEST_SUITE_RUN(test_config_validate_bad_cost);
+    TEST_SUITE_RUN(test_config_validate_bad_ports);
+    TEST_SUITE_RUN(test_config_validate_bad_timeouts);
+    TEST_SUITE_RUN(test_config_validate_garbage_int);
+    TEST_SUITE_RUN(test_config_validate_bad_log_rotation);
+    TEST_SUITE_RUN(test_config_validate_sip_port_auto);
     TEST_SUITE_RUN(test_config_trim);
     TEST_SUITE_RUN(test_config_null_safety);
     TEST_SUITE_RUN(test_config_overwrite_value);


### PR DESCRIPTION
## Problem

`config_validate()` only checked two of the daemon's many numeric settings — `call.cost_cents` and `system.update_interval_ms`. Everything else was accepted unconditionally, so the daemon would happily start in a broken state on:

- a port of `0` or `> 65535` (`web_server.port`, `metrics_server.port`) — bind fails or wraps
- a negative/zero `call.timeout_seconds` or `call.idle_timeout_seconds` — disables the call/idle watchdogs
- non-numeric garbage in any int field — `atoi()` silently yields `0`
- `logging.max_files=0` / `logging.max_size_bytes=0` — breaks log rotation

On failure the operator only saw a generic `Configuration validation failed` with no hint which key was wrong.

## Change

- Range-check every numeric setting the daemon relies on via a small `config_validate_range()` helper.
- On failure, log the offending key **and** its accepted bounds, e.g. `Invalid web_server.port=0 (must be 1..65535)`.
- Run all checks in a single pass (bitwise `&`, not short-circuit) so every problem is reported at once instead of one-per-restart.
- `sip.local_port == 0` stays valid — it means auto/ephemeral.

This continues the recent hardening theme (state-persistence validation, partial-read fixes) and fails fast on misconfiguration rather than limping along.

## Tests

Added unit tests for bad ports, bad timeouts, non-numeric ints, bad log-rotation settings, and the `sip.local_port==0` special case. Existing `config_validate_good` / `bad_cost` tests still pass.

```
64 passed, 0 failed
```

`make test` (unit + scenario) green; compiles clean under `-std=gnu89 -Wall -Wextra -Wdeclaration-after-statement -Werror`. Mac-only change, no hardware needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)