### PR TITLE
web_server: serve requests from a worker pool instead of one thread (#125)

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -41,7 +41,10 @@ metrics_server.o: metrics_server.c metrics_server.h metrics.h logger.h
 websocket.o: websocket.c websocket.h
 	gcc websocket.c -o websocket.o -c $(CFLAGS)
 
-web_server.o: web_server.c web_server.h websocket.h config.h logger.h metrics.h health_monitor.h version.h updater.h
+conn_queue.o: conn_queue.c conn_queue.h
+	gcc conn_queue.c -o conn_queue.o -c $(CFLAGS)
+
+web_server.o: web_server.c web_server.h conn_queue.h websocket.h config.h logger.h metrics.h health_monitor.h version.h updater.h
 	gcc web_server.c -o web_server.o -c $(CFLAGS)
 
 pjsip_interface.o: pjsip_interface.c pjsip_interface.h logger.h
@@ -102,8 +105,8 @@ plugins/dial_a_joke.o: plugins/dial_a_joke.c plugins.h plugin_sdk.h config.h
 plugins/trivia.o: plugins/trivia.c plugins.h plugin_sdk.h config.h
 	gcc plugins/trivia.c -o plugins/trivia.o -c $(CFLAGS)
 
-daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o
-	gcc daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o -o daemon $(LDFLAGS) -lm
+daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o
+	gcc daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o -o daemon $(LDFLAGS) -lm
 
 # Simulator object file
 simulator.o: simulator.c millennium_sdk.h events.h config.h daemon_state.h logger.h metrics.h plugins.h
@@ -122,9 +125,9 @@ simulator: $(SIM_OBJS)
 all: daemon
 
 # Unit test binary
-UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o updater.o
+UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o updater.o conn_queue.o
 
-tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h millennium_sdk.h updater.h
+tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h millennium_sdk.h updater.h conn_queue.h
 	gcc tests/unit_tests.c -o tests/unit_tests.o -c $(CFLAGS) -I.
 
 # Unit tests don't use time wrapping; link ALSA on Linux for jukebox
@@ -162,7 +165,7 @@ test: simulator unit_tests
 # code on any Linux box with libasound2-dev (e.g. CI), short of a full link.
 COMPILE_CHECK_OBJS = daemon.o daemon_state.o clock_source.o millennium_sdk.o events.o \
 	event_processor.o config.o logger.o health_monitor.o metrics.o \
-	metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o \
+	metrics_server.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o \
 	plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o \
 	plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o \
 	plugins/trivia.o state_persistence.o display_manager.o version.o \

--- a/host/conn_queue.c
+++ b/host/conn_queue.c
@@ -1,0 +1,93 @@
+#include "conn_queue.h"
+
+#include <stdlib.h>
+
+int conn_queue_init(struct conn_queue* q, int capacity) {
+    if (!q || capacity <= 0) return -1;
+
+    q->fds = (int*)malloc((size_t)capacity * sizeof(int));
+    if (!q->fds) return -1;
+
+    q->capacity = capacity;
+    q->head = 0;
+    q->count = 0;
+    q->closed = 0;
+
+    if (pthread_mutex_init(&q->mutex, NULL) != 0) {
+        free(q->fds);
+        q->fds = NULL;
+        return -1;
+    }
+    if (pthread_cond_init(&q->not_empty, NULL) != 0) {
+        pthread_mutex_destroy(&q->mutex);
+        free(q->fds);
+        q->fds = NULL;
+        return -1;
+    }
+    return 0;
+}
+
+void conn_queue_destroy(struct conn_queue* q) {
+    if (!q) return;
+    pthread_cond_destroy(&q->not_empty);
+    pthread_mutex_destroy(&q->mutex);
+    free(q->fds);
+    q->fds = NULL;
+    q->capacity = 0;
+    q->head = 0;
+    q->count = 0;
+}
+
+int conn_queue_try_push(struct conn_queue* q, int fd) {
+    int tail;
+    if (!q) return -1;
+
+    pthread_mutex_lock(&q->mutex);
+    if (q->closed || q->count >= q->capacity) {
+        pthread_mutex_unlock(&q->mutex);
+        return -1;
+    }
+    tail = (q->head + q->count) % q->capacity;
+    q->fds[tail] = fd;
+    q->count++;
+    pthread_cond_signal(&q->not_empty);
+    pthread_mutex_unlock(&q->mutex);
+    return 0;
+}
+
+int conn_queue_pop(struct conn_queue* q) {
+    int fd;
+    if (!q) return -1;
+
+    pthread_mutex_lock(&q->mutex);
+    while (q->count == 0 && !q->closed) {
+        pthread_cond_wait(&q->not_empty, &q->mutex);
+    }
+    if (q->count == 0) {
+        /* Closed and drained. */
+        pthread_mutex_unlock(&q->mutex);
+        return -1;
+    }
+    fd = q->fds[q->head];
+    q->head = (q->head + 1) % q->capacity;
+    q->count--;
+    pthread_mutex_unlock(&q->mutex);
+    return fd;
+}
+
+void conn_queue_close(struct conn_queue* q) {
+    if (!q) return;
+    pthread_mutex_lock(&q->mutex);
+    q->closed = 1;
+    pthread_cond_broadcast(&q->not_empty);
+    pthread_mutex_unlock(&q->mutex);
+}
+
+int conn_queue_count(struct conn_queue* q) {
+    int c;
+    if (!q) return 0;
+    pthread_mutex_lock(&q->mutex);
+    c = q->count;
+    pthread_mutex_unlock(&q->mutex);
+    return c;
+}

--- a/host/conn_queue.h
+++ b/host/conn_queue.h
@@ -1,0 +1,58 @@
+#ifndef CONN_QUEUE_H
+#define CONN_QUEUE_H
+
+#include <pthread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * conn_queue: a small bounded, thread-safe FIFO of file descriptors.
+ *
+ * The web server's accept loop pushes accepted client fds onto the queue; a
+ * pool of worker threads pops and services them. This decouples accepting a
+ * connection from handling it, so one slow request no longer stalls every
+ * other client (see issue #125).
+ *
+ * Push is non-blocking and reports back-pressure (queue full) to the caller so
+ * the accept loop can shed load rather than grow unboundedly. Pop blocks until
+ * an fd is available or the queue is closed.
+ */
+struct conn_queue {
+    int* fds;
+    int capacity;
+    int head;   /* index of the next fd to pop */
+    int count;  /* number of fds currently queued */
+    int closed; /* set by conn_queue_close(); pop drains then returns -1 */
+    pthread_mutex_t mutex;
+    pthread_cond_t not_empty;
+};
+
+/* Initialize a queue with room for `capacity` fds. Returns 0 on success,
+ * -1 on bad argument or allocation failure. */
+int conn_queue_init(struct conn_queue* q, int capacity);
+
+/* Free resources. The queue must not be in use by other threads. */
+void conn_queue_destroy(struct conn_queue* q);
+
+/* Enqueue an fd without blocking. Returns 0 on success, -1 if the queue is
+ * full or closed (the caller still owns `fd` in that case). */
+int conn_queue_try_push(struct conn_queue* q, int fd);
+
+/* Dequeue an fd, blocking until one is available. Returns the fd (>= 0), or
+ * -1 once the queue is both closed and empty. */
+int conn_queue_pop(struct conn_queue* q);
+
+/* Mark the queue closed and wake every blocked popper. After this, pop drains
+ * any remaining fds and then returns -1; try_push returns -1. */
+void conn_queue_close(struct conn_queue* q);
+
+/* Current number of queued fds (snapshot). */
+int conn_queue_count(struct conn_queue* q);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONN_QUEUE_H */

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -9,7 +9,9 @@
 #include "../updater.h"
 #include "../plugin_sdk.h"
 #include "../clock_source.h"
+#include "../conn_queue.h"
 #include <stdlib.h>
+#include <pthread.h>
 
 /* ── Stubs for linker (plugins.c references these) ──────────────── */
 
@@ -936,6 +938,109 @@ static void test_logger_queue_stats(void) {
     remove(path);
 }
 
+/* ── Connection queue (web server worker pool, #125) ────────────── */
+
+static void test_conn_queue_fifo_order(void) {
+    struct conn_queue q;
+    TEST_ASSERT_EQ_INT(conn_queue_init(&q, 4), 0);
+    TEST_ASSERT_EQ_INT(conn_queue_count(&q), 0);
+
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, 10), 0);
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, 20), 0);
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, 30), 0);
+    TEST_ASSERT_EQ_INT(conn_queue_count(&q), 3);
+
+    /* Pops come back in the order they went in. */
+    TEST_ASSERT_EQ_INT(conn_queue_pop(&q), 10);
+    TEST_ASSERT_EQ_INT(conn_queue_pop(&q), 20);
+    TEST_ASSERT_EQ_INT(conn_queue_pop(&q), 30);
+    TEST_ASSERT_EQ_INT(conn_queue_count(&q), 0);
+
+    conn_queue_destroy(&q);
+}
+
+static void test_conn_queue_full_rejects(void) {
+    struct conn_queue q;
+    TEST_ASSERT_EQ_INT(conn_queue_init(&q, 2), 0);
+
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, 1), 0);
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, 2), 0);
+    /* Third push is back-pressure: queue is full. */
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, 3), -1);
+    TEST_ASSERT_EQ_INT(conn_queue_count(&q), 2);
+
+    conn_queue_destroy(&q);
+}
+
+static void test_conn_queue_wraps_around(void) {
+    struct conn_queue q;
+    int i;
+    TEST_ASSERT_EQ_INT(conn_queue_init(&q, 3), 0);
+
+    /* Fill, drain partway, refill — exercises the ring buffer wrap. */
+    for (i = 0; i < 3; i++) TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, i), 0);
+    TEST_ASSERT_EQ_INT(conn_queue_pop(&q), 0);
+    TEST_ASSERT_EQ_INT(conn_queue_pop(&q), 1);
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, 3), 0);  /* wraps to head slot 0 */
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, 4), 0);
+    TEST_ASSERT_EQ_INT(conn_queue_pop(&q), 2);
+    TEST_ASSERT_EQ_INT(conn_queue_pop(&q), 3);
+    TEST_ASSERT_EQ_INT(conn_queue_pop(&q), 4);
+
+    conn_queue_destroy(&q);
+}
+
+static void test_conn_queue_close_drains_then_signals(void) {
+    struct conn_queue q;
+    TEST_ASSERT_EQ_INT(conn_queue_init(&q, 4), 0);
+
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, 7), 0);
+    conn_queue_close(&q);
+
+    /* Push after close is rejected. */
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, 8), -1);
+    /* Already-queued items still drain... */
+    TEST_ASSERT_EQ_INT(conn_queue_pop(&q), 7);
+    /* ...then pop reports closed-and-empty without blocking. */
+    TEST_ASSERT_EQ_INT(conn_queue_pop(&q), -1);
+
+    conn_queue_destroy(&q);
+}
+
+static void test_conn_queue_null_safety(void) {
+    TEST_ASSERT_EQ_INT(conn_queue_init(NULL, 4), -1);
+    TEST_ASSERT_EQ_INT(conn_queue_init((struct conn_queue*)0, 0), -1);
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(NULL, 1), -1);
+    TEST_ASSERT_EQ_INT(conn_queue_pop(NULL), -1);
+    TEST_ASSERT_EQ_INT(conn_queue_count(NULL), 0);
+    conn_queue_close(NULL);    /* must not crash */
+    conn_queue_destroy(NULL);  /* must not crash */
+}
+
+/* A blocked pop must wake and return the fd once a producer pushes. Run the
+ * producer on a second thread so the main thread genuinely blocks in pop. */
+struct cq_producer_arg { struct conn_queue* q; int fd; };
+static void* cq_producer(void* arg) {
+    struct cq_producer_arg* a = (struct cq_producer_arg*)arg;
+    conn_queue_try_push(a->q, a->fd);
+    return NULL;
+}
+static void test_conn_queue_blocking_pop_wakes(void) {
+    struct conn_queue q;
+    struct cq_producer_arg arg;
+    pthread_t producer;
+    TEST_ASSERT_EQ_INT(conn_queue_init(&q, 4), 0);
+
+    arg.q = &q;
+    arg.fd = 42;
+    TEST_ASSERT_EQ_INT(pthread_create(&producer, NULL, cq_producer, &arg), 0);
+    /* Blocks until the producer pushes, then returns its fd. */
+    TEST_ASSERT_EQ_INT(conn_queue_pop(&q), 42);
+    pthread_join(producer, NULL);
+
+    conn_queue_destroy(&q);
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -1017,6 +1122,14 @@ int main(void) {
     TEST_SUITE_BEGIN("Logger");
     TEST_SUITE_RUN(test_logger_async_file_write);
     TEST_SUITE_RUN(test_logger_queue_stats);
+
+    TEST_SUITE_BEGIN("Connection Queue");
+    TEST_SUITE_RUN(test_conn_queue_fifo_order);
+    TEST_SUITE_RUN(test_conn_queue_full_rejects);
+    TEST_SUITE_RUN(test_conn_queue_wraps_around);
+    TEST_SUITE_RUN(test_conn_queue_close_drains_then_signals);
+    TEST_SUITE_RUN(test_conn_queue_null_safety);
+    TEST_SUITE_RUN(test_conn_queue_blocking_pop_wakes);
 
     TEST_REPORT();
 }

--- a/host/web_server.c
+++ b/host/web_server.c
@@ -39,6 +39,7 @@ int send_control_command(const char* action);
 
 /* Thread function for web server */
 void* web_server_thread_func(void* arg);
+static void* web_server_worker_func(void* arg);
 
 /* String utility functions */
 void web_server_strcpy_safe(char* dest, const char* src, size_t dest_size) {
@@ -137,12 +138,25 @@ struct web_server* web_server_create(int port) {
     server->static_count = 0;
     server->websocket_count = 0;
     server->rate_limit_count = 0;
-    
+    server->worker_count = 0;
+
+    if (conn_queue_init(&server->conn_queue, WEB_SERVER_QUEUE_DEPTH) != 0) {
+        logger_error_with_category("WebServer", "Failed to init connection queue");
+        web_server_free(server);
+        return NULL;
+    }
+    if (pthread_mutex_init(&server->state_mutex, NULL) != 0) {
+        logger_error_with_category("WebServer", "Failed to init state mutex");
+        conn_queue_destroy(&server->conn_queue);
+        web_server_free(server);
+        return NULL;
+    }
+
     /* Initialize static route flags */
     for (i = 0; i < 16; i++) {
         server->static_is_file[i] = 0;
     }
-    
+
     return server;
 }
 
@@ -150,6 +164,8 @@ void web_server_destroy(struct web_server* server) {
     if (!server) return;
     
     web_server_stop(server);
+    conn_queue_destroy(&server->conn_queue);
+    pthread_mutex_destroy(&server->state_mutex);
     web_server_free(server);
 }
 
@@ -166,9 +182,42 @@ void web_server_start(struct web_server* server) {
     /* Initialize server socket */
     web_server_init_socket(server);
     
-    /* Start server thread */
+    /* Start worker pool before the accept thread so a connection is never
+     * enqueued with no one to service it. */
+    server->worker_count = 0;
+    {
+        int w;
+        for (w = 0; w < WEB_SERVER_WORKER_COUNT; w++) {
+            if (pthread_create(&server->worker_threads[w], NULL,
+                               web_server_worker_func, server) != 0) {
+                logger_error_with_category("WebServer", "Failed to create worker thread");
+                break;
+            }
+            server->worker_count++;
+        }
+    }
+    if (server->worker_count == 0) {
+        logger_error_with_category("WebServer", "No worker threads started; aborting web server");
+        server->running = 0;
+        if (server->server_fd >= 0) {
+            close(server->server_fd);
+            server->server_fd = -1;
+        }
+        return;
+    }
+
+    /* Start the accept thread */
     if (pthread_create(&server->server_thread, NULL, web_server_thread_func, server) != 0) {
         logger_error_with_category("WebServer", "Failed to create server thread");
+        /* Unwind the workers we just started. */
+        conn_queue_close(&server->conn_queue);
+        {
+            int w;
+            for (w = 0; w < server->worker_count; w++) {
+                pthread_join(server->worker_threads[w], NULL);
+            }
+        }
+        server->worker_count = 0;
         server->running = 0;
         if (server->server_fd >= 0) {
             close(server->server_fd);
@@ -181,17 +230,28 @@ void web_server_stop(struct web_server* server) {
     if (!server || !server->running) return;
     
     server->should_stop = 1;
-    
-    /* Wait for thread to finish */
+
+    /* Stop accepting first: the accept thread sees should_stop and returns. */
     pthread_join(server->server_thread, NULL);
-    
+
+    /* Then drain the worker pool: close the queue so blocked workers wake and
+     * exit once any remaining queued connections are serviced. */
+    conn_queue_close(&server->conn_queue);
+    {
+        int w;
+        for (w = 0; w < server->worker_count; w++) {
+            pthread_join(server->worker_threads[w], NULL);
+        }
+    }
+    server->worker_count = 0;
+
     server->running = 0;
-    
+
     if (server->server_fd >= 0) {
         close(server->server_fd);
         server->server_fd = -1;
     }
-    
+
     logger_info_with_category("WebServer", "Web server stopped");
 }
 
@@ -496,35 +556,73 @@ void web_server_init_socket(struct web_server* server) {
     logger_info_with_category("WebServer", start_msg);
 }
 
-/* Thread function for web server */
+/* Short reply sent when the worker queue is saturated, so a flooded server
+ * sheds load with a proper 503 instead of silently dropping the connection. */
+static void web_server_send_busy(int client_fd) {
+    static const char* busy =
+        "HTTP/1.1 503 Service Unavailable\r\n"
+        "Content-Type: application/json\r\n"
+        "Retry-After: 1\r\n"
+        "Connection: close\r\n"
+        "Content-Length: 23\r\n"
+        "\r\n"
+        "{\"error\":\"Server busy\"}";
+    send(client_fd, busy, strlen(busy), 0);
+}
+
+/* Accept thread: accepts connections and hands each off to a worker via the
+ * connection queue. Accepting stays cheap so the listen backlog drains quickly
+ * even while workers are busy with slow requests (#125). */
 void* web_server_thread_func(void* arg) {
     struct web_server* server = (struct web_server*)arg;
     if (!server) return NULL;
-    
-    /* Main server loop - runs in separate thread */
+
     while (!server->should_stop) {
         struct sockaddr_in client_addr;
         socklen_t client_len = sizeof(client_addr);
         struct timeval tv;
         int client_fd = accept(server->server_fd, (struct sockaddr*)&client_addr, &client_len);
-        
+
         if (client_fd >= 0) {
-            /* Handle request in a simple way (no threading to save resources) */
-            web_server_handle_client(server, client_fd);
+            if (conn_queue_try_push(&server->conn_queue, client_fd) != 0) {
+                /* Backlog full: shed load rather than grow unboundedly. */
+                logger_warn_with_category("WebServer",
+                    "Connection queue full; rejecting client with 503");
+                web_server_send_busy(client_fd);
+                close(client_fd);
+            }
         } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
             /* Log error if it's not just a non-blocking accept */
             char error_msg[256];
             snprintf(error_msg, sizeof(error_msg), "Accept failed with error: %d", errno);
             logger_error_with_category("WebServer", error_msg);
         }
-        
+
         /* Small sleep to prevent busy waiting */
         /* Use select() for C89-compatible microsecond sleep */
         tv.tv_sec = 0;
         tv.tv_usec = 1000; /* 1ms */
         select(0, NULL, NULL, NULL, &tv);
     }
-    
+
+    return NULL;
+}
+
+/* Worker thread: services one accepted connection at a time, pulled from the
+ * shared queue. Multiple workers run concurrently, so a slow or expensive
+ * request only occupies its own worker instead of blocking every client. */
+static void* web_server_worker_func(void* arg) {
+    struct web_server* server = (struct web_server*)arg;
+    if (!server) return NULL;
+
+    for (;;) {
+        int client_fd = conn_queue_pop(&server->conn_queue);
+        if (client_fd < 0) {
+            break; /* Queue closed and drained: shut the worker down. */
+        }
+        web_server_handle_client(server, client_fd);
+    }
+
     return NULL;
 }
 
@@ -612,8 +710,12 @@ void web_server_handle_client(struct web_server* server, int client_fd) {
         /* Get client IP for rate limiting */
         struct sockaddr_in client_addr;
         socklen_t client_len = sizeof(client_addr);
-        if (getpeername(client_fd, (struct sockaddr*)&client_addr, &client_len) == 0) {
-            web_server_strcpy_safe(parsed_request.client_ip, inet_ntoa(client_addr.sin_addr), sizeof(parsed_request.client_ip));
+        /* inet_ntop (not inet_ntoa) so concurrent workers don't race on a
+         * shared static buffer. */
+        if (getpeername(client_fd, (struct sockaddr*)&client_addr, &client_len) == 0 &&
+            inet_ntop(AF_INET, &client_addr.sin_addr, parsed_request.client_ip,
+                      sizeof(parsed_request.client_ip)) != NULL) {
+            /* client_ip populated by inet_ntop */
         } else {
             web_server_strcpy_safe(parsed_request.client_ip, "unknown", sizeof(parsed_request.client_ip));
         }
@@ -627,12 +729,17 @@ void web_server_handle_client(struct web_server* server, int client_fd) {
                 send(client_fd, response_str, strlen(response_str), 0);
                 web_server_free(response_str);
             }
+            pthread_mutex_lock(&server->state_mutex);
             if (server->websocket_count < 32) {
+                int total;
                 server->websocket_connections[server->websocket_count++] = client_fd;
+                total = server->websocket_count;
+                pthread_mutex_unlock(&server->state_mutex);
                 logger_infof_with_category("WebServer",
                     "WebSocket client connected (fd=%d, total=%d)",
-                    client_fd, server->websocket_count);
+                    client_fd, total);
             } else {
+                pthread_mutex_unlock(&server->state_mutex);
                 logger_warn_with_category("WebServer", "Max WebSocket connections reached");
                 close(client_fd);
             }
@@ -1735,6 +1842,9 @@ int web_server_check_rate_limit(struct web_server* server, const char* client_ip
     now = time(NULL);
     snprintf(key, sizeof(key), "%s:%s", client_ip, endpoint);
 
+    /* The rate-limit table is shared across worker threads. */
+    pthread_mutex_lock(&server->state_mutex);
+
     /* Clean up old entries (older than 60 seconds) */
     for (i = 0; i < server->rate_limit_count; i++) {
         if (now - server->rate_limit_infos[i].last_request > 60) {
@@ -1767,14 +1877,16 @@ int web_server_check_rate_limit(struct web_server* server, const char* client_ip
             server->rate_limit_infos[found_idx].request_count = 0;
             server->rate_limit_count++;
         } else {
+            pthread_mutex_unlock(&server->state_mutex);
             return 1; /* Rate limit table full, allow request */
         }
     }
-    
+
     /* Update counters */
     server->rate_limit_infos[found_idx].request_count++;
     server->rate_limit_infos[found_idx].last_request = now;
-    
+
+    pthread_mutex_unlock(&server->state_mutex);
     return 1; /* Allowed - simplified rate limiting for C89 */
 }
 
@@ -1808,22 +1920,45 @@ void web_server_add_websocket_route(struct web_server* server, const char* path,
     server->websocket_handler = handler;
 }
 
+/* Remove a websocket fd from the connection list (matched by value) and close
+ * it. Safe against the list shifting under concurrent registration because it
+ * re-scans under the lock rather than trusting a cached index. */
+static void web_server_drop_websocket(struct web_server* server, int fd) {
+    int i;
+    pthread_mutex_lock(&server->state_mutex);
+    for (i = 0; i < server->websocket_count; i++) {
+        if (server->websocket_connections[i] == fd) {
+            int j;
+            for (j = i; j < server->websocket_count - 1; j++) {
+                server->websocket_connections[j] = server->websocket_connections[j + 1];
+            }
+            server->websocket_count--;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&server->state_mutex);
+    close(fd);
+}
+
 void web_server_broadcast_to_websockets(struct web_server* server, const char* message) {
+    int fds[32];
+    int n = 0;
     int i;
     if (!server || !message) return;
 
-    for (i = 0; i < server->websocket_count; i++) {
-        int fd = server->websocket_connections[i];
-        if (ws_send_text(fd, message) != 0) {
-            close(fd);
-            {
-                int j;
-                for (j = i; j < server->websocket_count - 1; j++) {
-                    server->websocket_connections[j] = server->websocket_connections[j + 1];
-                }
-            }
-            server->websocket_count--;
-            i--;
+    /* Snapshot the connection list under the lock, then send outside it: a slow
+     * or stalled websocket client must not block workers registering new ones.
+     * Only this (single) broadcaster sends to or removes ws fds, so an fd can't
+     * be double-closed. */
+    pthread_mutex_lock(&server->state_mutex);
+    for (i = 0; i < server->websocket_count && n < (int)(sizeof(fds) / sizeof(fds[0])); i++) {
+        fds[n++] = server->websocket_connections[i];
+    }
+    pthread_mutex_unlock(&server->state_mutex);
+
+    for (i = 0; i < n; i++) {
+        if (ws_send_text(fds[i], message) != 0) {
+            web_server_drop_websocket(server, fds[i]);
         }
     }
 }

--- a/host/web_server.h
+++ b/host/web_server.h
@@ -6,9 +6,16 @@
 #include <time.h>
 #include <pthread.h>
 
+#include "conn_queue.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Worker threads that service accepted connections in parallel, and the depth
+ * of the backlog the accept loop will buffer before shedding load (#125). */
+#define WEB_SERVER_WORKER_COUNT 4
+#define WEB_SERVER_QUEUE_DEPTH 32
 
 /* Forward declarations */
 struct web_server;
@@ -76,7 +83,16 @@ struct web_server {
     int paused;
     int server_fd;
     pthread_t server_thread;
-    
+
+    /* Worker pool: the accept thread enqueues client fds; workers handle them
+     * concurrently so one slow request can't stall the dashboard (#125). */
+    struct conn_queue conn_queue;
+    pthread_t worker_threads[WEB_SERVER_WORKER_COUNT];
+    int worker_count;
+    /* Guards the rate-limit table and the websocket connection list, both of
+     * which are now mutated from multiple worker threads and the broadcaster. */
+    pthread_mutex_t state_mutex;
+
     /* Route storage - using arrays instead of maps */
     char route_methods[32][16];
     char route_paths[32][256];


### PR DESCRIPTION
## Problem (#125)

The web server accepted a connection and handled it **inline on the single accept thread** — read, parse, process, send, close. While one request was in flight, no other client was served. Any heavy handler (`/api/metrics`, `/api/logs`, `/api/update`, the streamed ~48KB dashboard) or a single slow client stalled the dashboard for everyone. This is worst during a call, when health/metrics refreshes pile up.

## Fix

Decouple **accepting** from **handling** with a small worker pool.

- **New `conn_queue` module** — a bounded, thread-safe FIFO of client fds: `try_push` (non-blocking, reports back-pressure), blocking `pop`, and `close` (drain-then-stop). Pure logic, fully unit-tested.
- **Accept thread** now only enqueues accepted fds. A fixed pool of **4 workers** (matching the Pi Zero 2 W's 4 cores) pops and services connections concurrently, so a slow/expensive request occupies only its own worker. When the backlog is full, the accept loop **sheds load with a 503** rather than growing unboundedly.
- **Thread-safe shared state** — a `state_mutex` now guards the rate-limit table and the websocket connection list. The websocket list was *already* racing between the accept thread and the daemon's broadcaster; broadcast now snapshots the fd list under the lock and sends outside it, so a stalled websocket client can't block new registrations.
- **`inet_ntoa` → `inet_ntop`** to drop a shared static buffer that multiple workers would race on.
- **Ordered shutdown** — stop accepting, close the queue so workers drain and exit, then join.

## Tests

- 6 new `conn_queue` unit tests: FIFO order, full-queue rejection, ring-buffer wrap, close-drains-then-signals, null safety, and a blocking-pop wakeup across threads.
- `make test` (unit + scenario) and `make compile-check` both pass locally on the Mac. Live concurrency behavior is exercised on-device via `make device-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)