### PR TITLE
web_server: expose worker-pool queue health as metrics

### DIFF
--- a/host/conn_queue.c
+++ b/host/conn_queue.c
@@ -12,6 +12,9 @@ int conn_queue_init(struct conn_queue* q, int capacity) {
     q->head = 0;
     q->count = 0;
     q->closed = 0;
+    q->high_water = 0;
+    q->pushed_total = 0;
+    q->rejected_total = 0;
 
     if (pthread_mutex_init(&q->mutex, NULL) != 0) {
         free(q->fds);
@@ -43,13 +46,23 @@ int conn_queue_try_push(struct conn_queue* q, int fd) {
     if (!q) return -1;
 
     pthread_mutex_lock(&q->mutex);
-    if (q->closed || q->count >= q->capacity) {
+    if (q->closed) {
+        /* Shutting down — not load shedding, so don't count as a rejection. */
+        pthread_mutex_unlock(&q->mutex);
+        return -1;
+    }
+    if (q->count >= q->capacity) {
+        q->rejected_total++; /* queue saturated: a shed connection */
         pthread_mutex_unlock(&q->mutex);
         return -1;
     }
     tail = (q->head + q->count) % q->capacity;
     q->fds[tail] = fd;
     q->count++;
+    q->pushed_total++;
+    if ((unsigned long)q->count > q->high_water) {
+        q->high_water = (unsigned long)q->count;
+    }
     pthread_cond_signal(&q->not_empty);
     pthread_mutex_unlock(&q->mutex);
     return 0;
@@ -90,4 +103,23 @@ int conn_queue_count(struct conn_queue* q) {
     c = q->count;
     pthread_mutex_unlock(&q->mutex);
     return c;
+}
+
+void conn_queue_get_stats(struct conn_queue* q, struct conn_queue_stats* out) {
+    if (!out) return;
+    if (!q) {
+        out->capacity = 0;
+        out->depth = 0;
+        out->high_water = 0;
+        out->pushed_total = 0;
+        out->rejected_total = 0;
+        return;
+    }
+    pthread_mutex_lock(&q->mutex);
+    out->capacity = q->capacity;
+    out->depth = q->count;
+    out->high_water = q->high_water;
+    out->pushed_total = q->pushed_total;
+    out->rejected_total = q->rejected_total;
+    pthread_mutex_unlock(&q->mutex);
 }

--- a/host/conn_queue.h
+++ b/host/conn_queue.h
@@ -25,8 +25,27 @@ struct conn_queue {
     int head;   /* index of the next fd to pop */
     int count;  /* number of fds currently queued */
     int closed; /* set by conn_queue_close(); pop drains then returns -1 */
+    /* Lifetime health counters (see conn_queue_get_stats). Cheap to maintain
+     * under the existing lock; let the daemon publish queue saturation and load
+     * shedding as metrics. */
+    unsigned long high_water;          /* max depth observed since init */
+    unsigned long long pushed_total;   /* connections enqueued (accepted) */
+    unsigned long long rejected_total; /* connections shed because queue was full */
     pthread_mutex_t mutex;
     pthread_cond_t not_empty;
+};
+
+/* Read-only snapshot of a queue's health. depth/capacity are instantaneous;
+ * high_water/pushed_total/rejected_total are lifetime totals so a metrics
+ * counter can rate() over them. rejected_total rising means the accept loop is
+ * shedding load (queue saturated) — the signal that the worker pool is
+ * undersized for current demand. */
+struct conn_queue_stats {
+    int capacity;
+    int depth;
+    unsigned long high_water;
+    unsigned long long pushed_total;
+    unsigned long long rejected_total;
 };
 
 /* Initialize a queue with room for `capacity` fds. Returns 0 on success,
@@ -50,6 +69,10 @@ void conn_queue_close(struct conn_queue* q);
 
 /* Current number of queued fds (snapshot). */
 int conn_queue_count(struct conn_queue* q);
+
+/* Snapshot the queue's health counters under its lock. NULL-safe (zeroes the
+ * output). Cheap enough to poll every metrics tick. */
+void conn_queue_get_stats(struct conn_queue* q, struct conn_queue_stats* out);
 
 #ifdef __cplusplus
 }

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -857,6 +857,26 @@ static void update_metrics(void) {
             last_dropped = lstats.dropped_total;
         }
     }
+
+    /* Web server worker-pool health (#125 follow-up). The accept thread sheds
+     * load with a 503 when the connection queue saturates; that rejection was
+     * only visible as a warning line in the log. Publish queue depth, the
+     * high-water mark (capacity headroom), and a true counter of shed
+     * connections so an undersized worker pool is alertable out-of-band. Runs
+     * on the single main-loop tick, so the static delta tracker needs no lock. */
+    {
+        struct conn_queue_stats wstats;
+        static unsigned long long last_rejected = 0;
+
+        web_server_get_conn_stats(web_server, &wstats);
+        metrics_set_gauge("web_conn_queue_depth", (double)wstats.depth);
+        metrics_set_gauge("web_conn_queue_high_water", (double)wstats.high_water);
+        if (wstats.rejected_total > last_rejected) {
+            metrics_increment_counter("web_conn_rejected",
+                (uint64_t)(wstats.rejected_total - last_rejected));
+            last_rejected = wstats.rejected_total;
+        }
+    }
 }
 
 int main(int argc, char *argv[]) {

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -1041,6 +1041,76 @@ static void test_conn_queue_blocking_pop_wakes(void) {
     conn_queue_destroy(&q);
 }
 
+/* The health snapshot (#125 follow-up) feeds the worker-pool metrics the daemon
+ * publishes. Verify the contract: capacity is reported, depth tracks the live
+ * count, high_water records the deepest the queue ever got (not the current
+ * depth), pushed_total counts only accepted fds, and rejected_total counts only
+ * connections shed when the queue was full. */
+static void test_conn_queue_stats(void) {
+    struct conn_queue q;
+    struct conn_queue_stats st;
+
+    TEST_ASSERT_EQ_INT(conn_queue_init(&q, 2), 0);
+
+    conn_queue_get_stats(&q, &st);
+    TEST_ASSERT_EQ_INT(st.capacity, 2);
+    TEST_ASSERT_EQ_INT(st.depth, 0);
+    TEST_ASSERT_EQ_INT((int)st.high_water, 0);
+    TEST_ASSERT_EQ_INT((int)st.pushed_total, 0);
+    TEST_ASSERT_EQ_INT((int)st.rejected_total, 0);
+
+    /* Fill to capacity, then overflow twice — both overflows are shed. */
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, 1), 0);
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, 2), 0);
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, 3), -1);
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, 4), -1);
+
+    conn_queue_get_stats(&q, &st);
+    TEST_ASSERT_EQ_INT(st.depth, 2);
+    TEST_ASSERT_EQ_INT((int)st.high_water, 2);
+    TEST_ASSERT_EQ_INT((int)st.pushed_total, 2);
+    TEST_ASSERT_EQ_INT((int)st.rejected_total, 2);
+
+    /* Draining leaves high_water and the lifetime totals intact. */
+    TEST_ASSERT_EQ_INT(conn_queue_pop(&q), 1);
+    TEST_ASSERT_EQ_INT(conn_queue_pop(&q), 2);
+    conn_queue_get_stats(&q, &st);
+    TEST_ASSERT_EQ_INT(st.depth, 0);
+    TEST_ASSERT_EQ_INT((int)st.high_water, 2);
+    TEST_ASSERT_EQ_INT((int)st.pushed_total, 2);
+    TEST_ASSERT_EQ_INT((int)st.rejected_total, 2);
+
+    /* Closing the queue is shutdown, not load shedding: try_push fails but the
+     * rejection counter must not move. */
+    conn_queue_close(&q);
+    TEST_ASSERT_EQ_INT(conn_queue_try_push(&q, 5), -1);
+    conn_queue_get_stats(&q, &st);
+    TEST_ASSERT_EQ_INT((int)st.rejected_total, 2);
+
+    conn_queue_destroy(&q);
+}
+
+/* The snapshot must be NULL-safe both ways: a NULL output is ignored, and a
+ * NULL queue zeroes the output (the daemon polls it when the web server is
+ * disabled). */
+static void test_conn_queue_stats_null_safety(void) {
+    struct conn_queue_stats st;
+
+    conn_queue_get_stats(NULL, NULL);   /* must not crash */
+
+    st.capacity = 7;
+    st.depth = 7;
+    st.high_water = 7;
+    st.pushed_total = 7;
+    st.rejected_total = 7;
+    conn_queue_get_stats(NULL, &st);
+    TEST_ASSERT_EQ_INT(st.capacity, 0);
+    TEST_ASSERT_EQ_INT(st.depth, 0);
+    TEST_ASSERT_EQ_INT((int)st.high_water, 0);
+    TEST_ASSERT_EQ_INT((int)st.pushed_total, 0);
+    TEST_ASSERT_EQ_INT((int)st.rejected_total, 0);
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -1130,6 +1200,8 @@ int main(void) {
     TEST_SUITE_RUN(test_conn_queue_close_drains_then_signals);
     TEST_SUITE_RUN(test_conn_queue_null_safety);
     TEST_SUITE_RUN(test_conn_queue_blocking_pop_wakes);
+    TEST_SUITE_RUN(test_conn_queue_stats);
+    TEST_SUITE_RUN(test_conn_queue_stats_null_safety);
 
     TEST_REPORT();
 }

--- a/host/web_server.c
+++ b/host/web_server.c
@@ -275,6 +275,12 @@ int web_server_is_paused(const struct web_server* server) {
     return server ? server->paused : 0;
 }
 
+void web_server_get_conn_stats(struct web_server* server, struct conn_queue_stats* out) {
+    if (!out) return;
+    /* conn_queue_get_stats zeroes the output when handed a NULL queue. */
+    conn_queue_get_stats(server ? &server->conn_queue : NULL, out);
+}
+
 void web_server_set_port(struct web_server* server, int port) {
     if (!server) return;
     

--- a/host/web_server.h
+++ b/host/web_server.h
@@ -131,6 +131,12 @@ void web_server_resume(struct web_server* server);
 int web_server_is_running(const struct web_server* server);
 int web_server_is_paused(const struct web_server* server);
 
+/* Snapshot the worker pool's connection-queue health (depth, high-water mark,
+ * connections accepted, connections shed under back-pressure). NULL-safe: zeroes
+ * the output if the server isn't running. Lets the daemon publish worker-pool
+ * saturation as metrics, the way #170 did for the async logger queue. */
+void web_server_get_conn_stats(struct web_server* server, struct conn_queue_stats* out);
+
 /* Configuration */
 void web_server_set_port(struct web_server* server, int port);
 int web_server_get_port(const struct web_server* server);


### PR DESCRIPTION
## Summary

Follow-up to the web-server worker pool (#125 / #174). The accept thread sheds load with a `503` when the connection queue saturates, but the only signal of that was a warning line in the log — easy to miss, impossible to alert or `rate()` on. An undersized worker pool under sustained load was effectively invisible.

This makes worker-pool saturation observable out-of-band via the existing Prometheus/JSON metrics endpoint, mirroring exactly what #170 did for the async-logger queue.

## What changed

- **`conn_queue`** gains three cheap lifetime counters, maintained under the lock it already holds:
  - `pushed_total` — connections accepted into the pool
  - `rejected_total` — connections shed because the queue was full
  - `high_water` — deepest the queue ever got
  
  A *closed* queue (shutdown) deliberately does **not** count as a rejection, so `rejected_total` only reflects real back-pressure. Exposed via `conn_queue_get_stats()`.
- **`web_server_get_conn_stats()`** — a NULL-safe accessor so the daemon can poll without reaching into internals (zeroes the output when the web server is disabled).
- **`update_metrics()`** publishes:

  | metric | type | meaning |
  |---|---|---|
  | `web_conn_queue_depth` | gauge | client fds awaiting a worker |
  | `web_conn_queue_high_water` | gauge | max depth seen — capacity headroom |
  | `web_conn_rejected` | counter | cumulative shed connections, `rate()`-able |

  The drop-delta tracker runs on the single main-loop tick (same as the logger block), so it needs no extra locking.

## Testing

- `make test` — all scenarios pass.
- `./unit_tests` — 67 passed, 0 failed, including two new tests covering the stats contract (depth vs. high-water, accepted vs. shed counting, close ≠ rejection) and NULL safety.
- `daemon.c` syntax-checks clean under the project's `-std=gnu89 -Werror` flags.

## Note on base

Stacked on `feature/web-server-worker-pool` (PR #174), since the `conn_queue` it instruments isn't on `main` yet. Retarget to `main` once #174 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)