### PR TITLE
web_server: return HTTP 503 from /api/health when unhealthy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ New plugins should be written against `plugin_sdk.h`, which wraps the hardware/s
 Base URL: `http://<pi>` (port 80)
 
 - `GET /api/state` — phone state, coins, keypad, SIP status
+- `GET /api/health` — health-check JSON; returns HTTP **200** when serving (overall HEALTHY/WARNING) and **503** when not (CRITICAL/UNKNOWN), so liveness/readiness probes can key off the status code alone
 - `GET /api/metrics` — Prometheus or JSON metrics
 - `POST /api/control` — inject events (coin, keypad, hook, plugin activation)
 - `GET /ws` — WebSocket real-time state broadcasts

--- a/host/Makefile
+++ b/host/Makefile
@@ -122,9 +122,9 @@ simulator: $(SIM_OBJS)
 all: daemon
 
 # Unit test binary
-UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o updater.o
+UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o health_monitor.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o updater.o
 
-tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h millennium_sdk.h updater.h
+tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h health_monitor.h millennium_sdk.h updater.h
 	gcc tests/unit_tests.c -o tests/unit_tests.o -c $(CFLAGS) -I.
 
 # Unit tests don't use time wrapping; link ALSA on Linux for jukebox

--- a/host/health_monitor.c
+++ b/host/health_monitor.c
@@ -307,6 +307,18 @@ const char* health_monitor_status_to_string(health_status_t status) {
     }
 }
 
+int health_monitor_status_is_serving(health_status_t status) {
+    switch (status) {
+        case HEALTH_STATUS_HEALTHY:
+        case HEALTH_STATUS_WARNING:
+            return 1;
+        case HEALTH_STATUS_CRITICAL:
+        case HEALTH_STATUS_UNKNOWN:
+        default:
+            return 0;
+    }
+}
+
 health_status_t health_monitor_string_to_status(const char* status_str) {
     if (!status_str) {
         return HEALTH_STATUS_UNKNOWN;

--- a/host/health_monitor.h
+++ b/host/health_monitor.h
@@ -72,6 +72,13 @@ int health_monitor_get_statistics(health_statistics_t* stats_out);
 const char* health_monitor_status_to_string(health_status_t status);
 health_status_t health_monitor_string_to_status(const char* status_str);
 
+/* Returns 1 if a status means the daemon should still be considered "up" and
+ * able to serve traffic, 0 otherwise. HEALTHY and WARNING are serving (the
+ * latter is degraded but operational); CRITICAL and UNKNOWN are not (UNKNOWN
+ * fails safe, e.g. before the first check has run). Used to map the overall
+ * health onto an HTTP status code for liveness/readiness probes. */
+int health_monitor_status_is_serving(health_status_t status);
+
 /* Predefined system health checks */
 health_status_t system_health_check_serial_connection(void);
 health_status_t system_health_check_sip_connection(void);

--- a/host/tests/api_test.sh
+++ b/host/tests/api_test.sh
@@ -39,6 +39,10 @@ echo ""
 run "GET /api/state returns JSON" "curl -s $BASE/api/state" "current_state"
 run "GET /api/state has sip_registered" "curl -s $BASE/api/state" "sip_registered"
 run "GET /api/health returns JSON" "curl -s $BASE/api/health" "overall_status"
+# A healthy daemon must answer probes with HTTP 200 (it returns 503 when the
+# overall status is CRITICAL/UNKNOWN, so probes can react to the code alone).
+run "GET /api/health returns HTTP 200 when healthy" \
+    "curl -s -o /dev/null -w '%{http_code}' $BASE/api/health" "200"
 
 # Control: handset_up
 run "POST handset_up" \

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -5,6 +5,7 @@
 #include "../plugins.h"
 #include "../logger.h"
 #include "../metrics.h"
+#include "../health_monitor.h"
 #include "../millennium_sdk.h"
 #include "../updater.h"
 #include "../plugin_sdk.h"
@@ -936,6 +937,54 @@ static void test_logger_queue_stats(void) {
     remove(path);
 }
 
+/* The /api/health handler maps the overall health onto an HTTP status code via
+ * health_monitor_status_is_serving() so probes can react to the code alone.
+ * HEALTHY and WARNING serve (200); CRITICAL and UNKNOWN do not (503), with
+ * UNKNOWN failing safe before any check has run. */
+static void test_health_status_is_serving(void) {
+    TEST_ASSERT_EQ_INT(health_monitor_status_is_serving(HEALTH_STATUS_HEALTHY), 1);
+    TEST_ASSERT_EQ_INT(health_monitor_status_is_serving(HEALTH_STATUS_WARNING), 1);
+    TEST_ASSERT_EQ_INT(health_monitor_status_is_serving(HEALTH_STATUS_CRITICAL), 0);
+    TEST_ASSERT_EQ_INT(health_monitor_status_is_serving(HEALTH_STATUS_UNKNOWN), 0);
+}
+
+/* A check-backed status reporter the test can steer, so we can drive the
+ * monitor's overall status through every level. */
+static health_status_t g_test_check_status = HEALTH_STATUS_HEALTHY;
+static health_status_t test_steerable_check(void) { return g_test_check_status; }
+
+/* With no checks registered the overall status is UNKNOWN and therefore not
+ * serving; once a check runs, the overall status follows it and the serving
+ * verdict tracks accordingly. This is the exact path /api/health takes. */
+static void test_health_overall_reflects_checks(void) {
+    health_check_t check;
+
+    /* Fresh monitor: nothing registered yet -> UNKNOWN -> not serving. */
+    TEST_ASSERT_EQ_INT(health_monitor_get_overall_status(), HEALTH_STATUS_UNKNOWN);
+    TEST_ASSERT_EQ_INT(health_monitor_status_is_serving(
+        health_monitor_get_overall_status()), 0);
+
+    health_monitor_register_check("steerable", test_steerable_check, 30);
+
+    g_test_check_status = HEALTH_STATUS_HEALTHY;
+    health_monitor_run_check("steerable");
+    TEST_ASSERT_EQ_INT(health_monitor_get_overall_status(), HEALTH_STATUS_HEALTHY);
+    TEST_ASSERT_EQ_INT(health_monitor_status_is_serving(
+        health_monitor_get_overall_status()), 1);
+
+    g_test_check_status = HEALTH_STATUS_CRITICAL;
+    health_monitor_run_check("steerable");
+    TEST_ASSERT_EQ_INT(health_monitor_get_overall_status(), HEALTH_STATUS_CRITICAL);
+    TEST_ASSERT_EQ_INT(health_monitor_status_is_serving(
+        health_monitor_get_overall_status()), 0);
+
+    /* The stored check carries the latest status for the JSON body too. */
+    TEST_ASSERT_EQ_INT(health_monitor_get_check("steerable", &check), 1);
+    TEST_ASSERT_EQ_INT(check.last_status, HEALTH_STATUS_CRITICAL);
+
+    health_monitor_unregister_check("steerable");
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -1017,6 +1066,10 @@ int main(void) {
     TEST_SUITE_BEGIN("Logger");
     TEST_SUITE_RUN(test_logger_async_file_write);
     TEST_SUITE_RUN(test_logger_queue_stats);
+
+    TEST_SUITE_BEGIN("Health Monitor");
+    TEST_SUITE_RUN(test_health_status_is_serving);
+    TEST_SUITE_RUN(test_health_overall_reflects_checks);
 
     TEST_REPORT();
 }

--- a/host/web_server.c
+++ b/host/web_server.c
@@ -797,6 +797,7 @@ char* web_server_serialize_response(const struct http_response* response) {
         case 500: status_text = "Internal Server Error"; break;
         case 101: status_text = "Switching Protocols"; break;
         case 429: status_text = "Too Many Requests"; break;
+        case 503: status_text = "Service Unavailable"; break;
         default: status_text = "Unknown"; break;
     }
     
@@ -965,6 +966,10 @@ struct http_response web_server_handle_api_health(const struct http_request* req
 
     overall_status = health_monitor_get_overall_status();
     checks_count = health_monitor_get_all_checks(checks, 32);
+
+    /* Reflect health in the HTTP status so liveness/readiness probes and load
+     * balancers can detect an unhealthy daemon without parsing the body. */
+    response.status_code = health_monitor_status_is_serving(overall_status) ? 200 : 503;
 
     web_server_json_escape(health_monitor_status_to_string(overall_status),
                           escaped_overall, sizeof(escaped_overall));


### PR DESCRIPTION
## Problem

`GET /api/health` always returned **HTTP 200 OK** regardless of the daemon's actual health. External liveness/readiness probes, load balancers, and uptime monitors key off the HTTP **status code** — so with the old behavior they could never detect a sick daemon without fetching and parsing the JSON body, defeating the purpose of a health endpoint.

## Change

Map the overall health status onto the HTTP status code:

| Overall status | HTTP code | Rationale |
|---|---|---|
| `HEALTHY` | 200 | serving |
| `WARNING` | 200 | degraded but operational |
| `CRITICAL` | 503 | not serving |
| `UNKNOWN` | 503 | fail-safe — before the first check has run, the daemon isn't ready for traffic |

The JSON body is unchanged, so existing consumers keep working; this only adds signal on the status line.

The serve/don't-serve decision lives in a new pure predicate, `health_monitor_status_is_serving()`, which keeps the health module HTTP-agnostic and makes the policy unit-testable without standing up the web server. `503 Service Unavailable` is added to the response serializer's reason-phrase table.

## Tests

- `health_monitor.o` now links into the unit-test binary.
- New **Health Monitor** unit suite: covers the status→serving mapping for all four levels, and drives a steerable registered check through HEALTHY → CRITICAL to verify the exact path `/api/health` takes (overall status + serving verdict + stored per-check status).
- `api_test.sh` now asserts a healthy live daemon answers `/api/health` with HTTP 200.
- `make test` green (61 unit tests + all scenarios). `web_server.o` and `health_monitor.o` compile clean under `-Wall -Wextra -Werror -std=gnu89`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)