### PR TITLE
metrics: record call duration as the call_duration_seconds histogram

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -23,7 +23,7 @@ config.o: config.c config.h
 clock_source.o: clock_source.c clock_source.h
 	gcc clock_source.c -o clock_source.o -c $(CFLAGS)
 
-daemon_state.o: daemon_state.c daemon_state.h clock_source.h
+daemon_state.o: daemon_state.c daemon_state.h clock_source.h metrics.h
 	gcc daemon_state.c -o daemon_state.o -c $(CFLAGS)
 
 logger.o: logger.c logger.h

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -363,14 +363,16 @@ void handle_call_state_event(call_state_event_t *call_state_event) {
         metrics_increment_counter("calls_established", 1);
         
         update_display_with_content("Call active", "Audio connected");
-        
+
         daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
+        daemon_state_call_begin(daemon_state);
         daemon_state_update_activity(daemon_state);
     } else if (call_state_event_get_state(call_state_event) == EVENT_CALL_STATE_INVALID) {
         /* #90/#91: Call ended - remote hung up or call failed during dial */
         if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE) {
             logger_info_with_category("Call", "Call ended by remote party");
             metrics_increment_counter("calls_ended", 1);
+            daemon_state_call_end(daemon_state);
             daemon_state_clear_keypad(daemon_state);
             daemon_state->inserted_cents = 0;
             daemon_state->current_state = DAEMON_STATE_IDLE_UP;
@@ -439,10 +441,11 @@ void handle_hook_event(hook_state_change_event_t *hook_event) {
         if (call_incoming) {
             logger_info_with_category("Call", "Call answered");
             metrics_increment_counter("calls_answered", 1);
-            
+
             daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
+            daemon_state_call_begin(daemon_state);
             daemon_state_update_activity(daemon_state);
-            
+
         } else if (phone_down) {
             logger_info_with_category("Hook", "Hook lifted, transitioning to IDLE_UP");
             metrics_increment_counter("hook_lifted", 1);
@@ -461,8 +464,9 @@ void handle_hook_event(hook_state_change_event_t *hook_event) {
         
         if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE) {
             metrics_increment_counter("calls_ended", 1);
+            daemon_state_call_end(daemon_state);
         }
-        
+
         daemon_state_clear_keypad(daemon_state);
         daemon_state->inserted_cents = 0;
         

--- a/host/daemon_state.c
+++ b/host/daemon_state.c
@@ -1,5 +1,6 @@
 #include "daemon_state.h"
 #include "clock_source.h"
+#include "metrics.h"
 #include <string.h>
 #include <time.h>
 #include <ctype.h>
@@ -11,20 +12,41 @@ void daemon_state_init(daemon_state_data_t* state) {
     memset(state->keypad_buffer, 0, sizeof(state->keypad_buffer));
     state->inserted_cents = 0;
     state->last_activity = mclock_now();
+    state->call_active_since = 0;
 }
 
 void daemon_state_reset(daemon_state_data_t* state) {
     if (!state) return;
-    
+
     state->current_state = DAEMON_STATE_IDLE_DOWN;
     daemon_state_clear_keypad(state);
     state->inserted_cents = 0;
     state->last_activity = mclock_now();
+    state->call_active_since = 0;
 }
 
 void daemon_state_update_activity(daemon_state_data_t* state) {
     if (!state) return;
     state->last_activity = mclock_now();
+}
+
+void daemon_state_call_begin(daemon_state_data_t* state) {
+    if (!state) return;
+    state->call_active_since = mclock_now();
+}
+
+long daemon_state_call_end(daemon_state_data_t* state) {
+    long duration;
+    if (!state || state->call_active_since <= 0) {
+        if (state) state->call_active_since = 0;
+        return -1;
+    }
+    duration = (long)(mclock_now() - state->call_active_since);
+    if (duration < 0) duration = 0;  /* clock skew guard */
+    state->call_active_since = 0;
+    metrics_observe_histogram("call_duration_seconds", (double)duration);
+    metrics_set_gauge("last_call_duration_seconds", (double)duration);
+    return duration;
 }
 
 const char* daemon_state_to_string(daemon_state_t state) {

--- a/host/daemon_state.h
+++ b/host/daemon_state.h
@@ -17,6 +17,7 @@ typedef struct {
     char keypad_buffer[11];  /* Fixed size: 10 digits + null terminator */
     int inserted_cents;
     time_t last_activity;  /* C89 compatible time representation */
+    time_t call_active_since;  /* mclock_now() when the call became active, 0 if no active call */
 } daemon_state_data_t;
 
 /* Function declarations (C equivalent of class methods) */
@@ -24,6 +25,15 @@ void daemon_state_init(daemon_state_data_t* state);
 void daemon_state_reset(daemon_state_data_t* state);
 void daemon_state_update_activity(daemon_state_data_t* state);
 const char* daemon_state_to_string(daemon_state_t state);
+
+/* Call-duration accounting. daemon_state_call_begin() stamps the moment a call
+ * becomes active; daemon_state_call_end() observes the elapsed time into the
+ * call_duration_seconds histogram (and last_call_duration_seconds gauge) and
+ * clears the stamp. Both read the clock seam (mclock_now) so the simulator's
+ * advanceable clock yields real durations in scenario tests. call_end() returns
+ * the duration in seconds, or -1 (recording nothing) if no call was active. */
+void daemon_state_call_begin(daemon_state_data_t* state);
+long daemon_state_call_end(daemon_state_data_t* state);
 
 /* Utility functions */
 int daemon_state_get_keypad_length(const daemon_state_data_t* state);

--- a/host/simulator.c
+++ b/host/simulator.c
@@ -175,11 +175,13 @@ void millennium_client_call(millennium_client_t *c, const char *number) {
     (void)c;
     fprintf(stderr, "[CALL] Dialing %s\n", number ? number : "(null)");
     sim_call_pending = 1;
+    sim_hangup_called = 0;  /* a fresh call clears any stale hangup signal */
 }
 
 void millennium_client_answer_call(millennium_client_t *c) {
     (void)c;
     fprintf(stderr, "[CALL] Answered\n");
+    sim_hangup_called = 0;  /* a fresh call clears any stale hangup signal */
 }
 
 void millennium_client_hangup(millennium_client_t *c) {
@@ -318,6 +320,7 @@ static void sim_handle_hook(hook_state_change_event_t *ev) {
     if (hook_up) {
         if (daemon_state->current_state == DAEMON_STATE_CALL_INCOMING) {
             daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
+            daemon_state_call_begin(daemon_state);
         } else if (daemon_state->current_state == DAEMON_STATE_IDLE_DOWN) {
             daemon_state->current_state = DAEMON_STATE_IDLE_UP;
             daemon_state->inserted_cents = 0;
@@ -325,6 +328,8 @@ static void sim_handle_hook(hook_state_change_event_t *ev) {
         }
         daemon_state_update_activity(daemon_state);
     } else if (hook_down) {
+        if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE)
+            daemon_state_call_end(daemon_state);
         daemon_state_clear_keypad(daemon_state);
         daemon_state->inserted_cents = 0;
         daemon_state->current_state = DAEMON_STATE_IDLE_DOWN;
@@ -369,11 +374,14 @@ static void sim_handle_call_state(call_state_event_t *ev) {
         daemon_state_update_activity(daemon_state);
     } else if (st == EVENT_CALL_STATE_ACTIVE) {
         daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
+        daemon_state_call_begin(daemon_state);
         daemon_state_update_activity(daemon_state);
     } else if (st == EVENT_CALL_STATE_INVALID) {
         /* #90: Remote hung up */
         if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE ||
             daemon_state->current_state == DAEMON_STATE_CALL_INCOMING) {
+            if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE)
+                daemon_state_call_end(daemon_state);
             daemon_state_clear_keypad(daemon_state);
             daemon_state->inserted_cents = 0;
             daemon_state->current_state = DAEMON_STATE_IDLE_UP;
@@ -455,6 +463,40 @@ static int display_contains(const char *text) {
     return 0;
 }
 
+/*
+ * Resolve a metric reference to a numeric value for assert_metric.
+ *   <name>                  counter or gauge (gauge wins if both exist)
+ *   <name>.count|.sum|.min|.max|.mean|.median|.p95|.p99   histogram stat
+ * Returns 0 on success (value in *out), -1 if the metric is unknown.
+ */
+static int sim_read_metric(const char *ref, double *out) {
+    const char *dot = strrchr(ref, '.');
+    if (dot) {
+        char base[128];
+        size_t blen = (size_t)(dot - ref);
+        metrics_histogram_stats_t st;
+        const char *field = dot + 1;
+        if (blen >= sizeof(base)) return -1;
+        memcpy(base, ref, blen);
+        base[blen] = '\0';
+        if (metrics_get_histogram_stats(base, &st) != 0) return -1;
+        if      (strcmp(field, "count")  == 0) *out = (double)st.count;
+        else if (strcmp(field, "sum")    == 0) *out = st.sum;
+        else if (strcmp(field, "min")    == 0) *out = st.min;
+        else if (strcmp(field, "max")    == 0) *out = st.max;
+        else if (strcmp(field, "mean")   == 0) *out = st.mean;
+        else if (strcmp(field, "median") == 0) *out = st.median;
+        else if (strcmp(field, "p95")    == 0) *out = st.p95;
+        else if (strcmp(field, "p99")    == 0) *out = st.p99;
+        else return -1;
+        return 0;
+    }
+    /* No dot: gauge takes precedence over counter (gauges can read 0). */
+    if (metrics_get_gauge(ref) != 0.0) { *out = metrics_get_gauge(ref); return 0; }
+    *out = (double)metrics_get_counter(ref);
+    return 0;
+}
+
 /* ── Scenario runner ───────────────────────────────────────────────── */
 
 static int run_scenario(const char *path) {
@@ -472,6 +514,7 @@ static int run_scenario(const char *path) {
     }
 
     sim_sip_registered = 1;  /* default: SIP registered for each scenario */
+    metrics_reset_all();     /* isolate metric assertions from prior scenarios */
 
     while (fgets(line, sizeof(line), f)) {
         line_num++;
@@ -586,7 +629,10 @@ static int run_scenario(const char *path) {
                 sim_drain_events();
                 if (sim_hangup_called) {
                     sim_hangup_called = 0;
-                    daemon_state->current_state = DAEMON_STATE_IDLE_DOWN;
+                    if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE) {
+                        daemon_state_call_end(daemon_state);
+                        daemon_state->current_state = DAEMON_STATE_IDLE_DOWN;
+                    }
                 }
             }
         }
@@ -627,6 +673,38 @@ static int run_scenario(const char *path) {
                 fprintf(stderr, "  FAIL: expected state containing \"%s\", got \"%s\"\n",
                         arg, actual);
                 failures++;
+            }
+        }
+
+        /* ── assert_metric <name> <op> <value> ───────────────────── */
+        /* op is one of == != >= <= > < ; <name> may be a counter, gauge,
+         * or a histogram stat via the <name>.count|sum|min|max|mean|... form */
+        else if (strncmp(cmd, "assert_metric ", 14) == 0) {
+            char name[128], op[4];
+            double expected, actual = 0.0;
+            arg = trim(cmd + 14);
+            if (sscanf(arg, "%127s %3s %lf", name, op, &expected) != 3) {
+                fprintf(stderr, "  ERROR: usage: assert_metric <name> <op> <value>\n");
+                failures++;
+            } else if (sim_read_metric(name, &actual) != 0) {
+                fprintf(stderr, "  FAIL: unknown metric \"%s\"\n", name);
+                failures++;
+            } else {
+                int ok;
+                if      (strcmp(op, "==") == 0) ok = (actual == expected);
+                else if (strcmp(op, "!=") == 0) ok = (actual != expected);
+                else if (strcmp(op, ">=") == 0) ok = (actual >= expected);
+                else if (strcmp(op, "<=") == 0) ok = (actual <= expected);
+                else if (strcmp(op, ">")  == 0) ok = (actual >  expected);
+                else if (strcmp(op, "<")  == 0) ok = (actual <  expected);
+                else { ok = 0; fprintf(stderr, "  ERROR: bad operator \"%s\"\n", op); }
+                if (ok) {
+                    fprintf(stderr, "  PASS: %s (%.2f) %s %.2f\n", name, actual, op, expected);
+                } else {
+                    fprintf(stderr, "  FAIL: %s is %.2f, expected %s %.2f\n",
+                            name, actual, op, expected);
+                    failures++;
+                }
             }
         }
 

--- a/host/tests/test_call_duration_metric.scenario
+++ b/host/tests/test_call_duration_metric.scenario
@@ -1,0 +1,45 @@
+# Test: Call duration metric
+# Verifies that ending a call records its length into the
+# call_duration_seconds histogram and the last_call_duration_seconds gauge.
+# Durations are timed via the simulated clock, so `wait N` yields exactly N
+# seconds of call time. Both call-end paths are exercised: a local hang-up
+# (hook down) and a remote hang-up (CALL_CLOSED). Each call stays under the
+# simulator's 5s call timeout so the timeout path doesn't end it early.
+
+# --- Call 1: local hang-up after 3 seconds ---
+hook_up
+assert_state IDLE_UP
+coin 25
+coin 25
+assert_display Have: 50c
+keys 5551234567
+assert_state CALL_ACTIVE
+assert_display Call active
+
+wait 3
+hook_down
+assert_state IDLE_DOWN
+
+assert_metric call_duration_seconds.count == 1
+assert_metric call_duration_seconds.max >= 3
+assert_metric last_call_duration_seconds == 3
+
+# --- Call 2: remote hang-up after 2 seconds ---
+hook_up
+assert_state IDLE_UP
+coin 25
+coin 25
+keys 5551234567
+assert_state CALL_ACTIVE
+
+wait 2
+call_ended
+assert_state IDLE_UP
+
+# Second sample recorded; histogram now holds both calls (3 + 2 = 5 seconds).
+assert_metric call_duration_seconds.count == 2
+assert_metric call_duration_seconds.sum == 5
+assert_metric last_call_duration_seconds == 2
+
+hook_down
+assert_state IDLE_DOWN

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -300,6 +300,75 @@ static void test_state_null_safety(void) {
     TEST_ASSERT(1);
 }
 
+/* ── Call-duration accounting ───────────────────────────────────── */
+
+static time_t g_call_clock = 0;
+static time_t call_clock_source(void) { return g_call_clock; }
+
+static void test_call_duration_records_histogram(void) {
+    daemon_state_data_t state;
+    metrics_histogram_stats_t stats;
+
+    metrics_init();
+    metrics_reset_all();
+    daemon_state_init(&state);
+    mclock_set_source(call_clock_source);
+
+    /* A 30-second call records one sample of 30 and clears the stamp. */
+    g_call_clock = 10000;
+    daemon_state_call_begin(&state);
+    TEST_ASSERT(state.call_active_since == 10000);
+
+    g_call_clock = 10030;
+    TEST_ASSERT_EQ_INT((int)daemon_state_call_end(&state), 30);
+    TEST_ASSERT(state.call_active_since == 0);
+
+    TEST_ASSERT_EQ_INT(metrics_get_histogram_stats("call_duration_seconds", &stats), 0);
+    TEST_ASSERT_EQ_INT((int)stats.count, 1);
+    TEST_ASSERT_EQ_INT((int)stats.sum, 30);
+    TEST_ASSERT_EQ_INT((int)stats.max, 30);
+    TEST_ASSERT_EQ_INT((int)metrics_get_gauge("last_call_duration_seconds"), 30);
+
+    mclock_set_source(NULL);
+}
+
+static void test_call_duration_no_active_call(void) {
+    daemon_state_data_t state;
+    metrics_histogram_stats_t stats;
+
+    metrics_init();
+    metrics_reset_all();
+    daemon_state_init(&state);  /* call_active_since == 0, no call in progress */
+
+    /* Ending without a begin records nothing and reports -1. */
+    TEST_ASSERT_EQ_INT((int)daemon_state_call_end(&state), -1);
+    TEST_ASSERT(metrics_get_histogram_stats("call_duration_seconds", &stats) != 0
+                || stats.count == 0);
+
+    /* NULL-safe. */
+    TEST_ASSERT_EQ_INT((int)daemon_state_call_end(NULL), -1);
+    daemon_state_call_begin(NULL);
+    TEST_ASSERT(1);
+}
+
+static void test_call_duration_clock_skew_clamps_to_zero(void) {
+    daemon_state_data_t state;
+
+    metrics_init();
+    metrics_reset_all();
+    daemon_state_init(&state);
+    mclock_set_source(call_clock_source);
+
+    /* If the clock moves backwards mid-call, the duration clamps to 0 rather
+     * than recording a negative sample. */
+    g_call_clock = 5000;
+    daemon_state_call_begin(&state);
+    g_call_clock = 4990;
+    TEST_ASSERT_EQ_INT((int)daemon_state_call_end(&state), 0);
+
+    mclock_set_source(NULL);
+}
+
 /* ── Plugin tests ───────────────────────────────────────────────── */
 
 static int test_coin_handler(int v, const char *c) { (void)v; (void)c; return 0; }
@@ -964,6 +1033,9 @@ int main(void) {
     TEST_SUITE_RUN(test_state_keypad_rejects_non_digit);
     TEST_SUITE_RUN(test_state_reset);
     TEST_SUITE_RUN(test_state_null_safety);
+    TEST_SUITE_RUN(test_call_duration_records_histogram);
+    TEST_SUITE_RUN(test_call_duration_no_active_call);
+    TEST_SUITE_RUN(test_call_duration_clock_skew_clamps_to_zero);
 
     TEST_SUITE_BEGIN("Plugins");
     TEST_SUITE_RUN(test_plugins_register_and_activate);


### PR DESCRIPTION
## What & why

The metrics layer has shipped full histogram support — `metrics_observe_histogram`, percentile stats, Prometheus + JSON export — since it was written, but **nothing ever observed a histogram**. So operators got call *counts* (`calls_established`, `calls_ended`) with no sense of how long calls actually ran. This wires up the first real histogram by tracking per-call duration.

## How

Call duration is timed at the **daemon level**, so it covers every plugin rather than just the classic phone (which already tracked its own `call_start_time` for timeout enforcement). The timing logic lives in `daemon_state.c`, which is linked into the daemon, the simulator, and the unit tests — giving the production handlers and the simulator's reimplemented handlers a single source of truth.

- `daemon_state` gains a `call_active_since` stamp and a small begin/end API:
  - `daemon_state_call_begin()` — stamps `mclock_now()` when a call goes active
  - `daemon_state_call_end()` — observes the elapsed seconds into the `call_duration_seconds` histogram, updates a `last_call_duration_seconds` gauge, and clears the stamp. Returns `-1` and records nothing if no call was active; clamps negative deltas (clock skew) to 0.
- Timing reads the **clock seam** (`mclock_now`), so the same code yields real durations under the scenario simulator's advanceable clock.
- Both call-end paths that already bump `calls_ended` — remote hang-up (`CALL_CLOSED`) and local hook-down — now also record the duration.

Once a call ends, the new series appear automatically in both `/api/metrics` formats (e.g. `call_duration_seconds_count/_sum/_mean/_p95/...` and the `last_call_duration_seconds` gauge), with no exporter changes needed.

## Testing

- **New `assert_metric` scenario command** in the simulator: `assert_metric <name> <op> <value>`, supporting counters, gauges, and histogram stats via the `name.count|.sum|.max|.mean|...` form. Metrics are now reset per scenario for assertion isolation.
- **Fixed a latent simulator bug**: a manual hook-down left a stale hangup flag that would force-end the *next* call during a `wait` loop (surfaced once a scenario placed two calls in one run).
- `tests/test_call_duration_metric.scenario` — exercises local + remote hang-up and asserts the histogram count/sum/max and the gauge.
- Three unit tests covering the begin/end accounting, the no-active-call case, and the clock-skew clamp.

`make test` (62 unit tests + all scenarios) and `make compile-check` both pass clean under `-Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)