### PR TITLE
metrics: record call-setup failures by reason

### DIFF
--- a/host/plugins/classic_phone.c
+++ b/host/plugins/classic_phone.c
@@ -152,6 +152,7 @@ static int classic_phone_handle_call_state(int call_state) {
             classic_phone_data.is_dialing = 0;
             display_manager_set_text("Call failed", "Coins refunded");
             logger_info_with_category("ClassicPhone", "Call failed - coins refunded");
+            metrics_increment_counter("calls_failed", 1);
         } else if (classic_phone_data.is_in_call) {
             /* #90: Remote hung up - reset call state */
             logger_info_with_category("ClassicPhone", "Call ended by remote party - resetting");
@@ -338,6 +339,7 @@ static void classic_phone_start_call(void) {
         if (sip_registered != 1) {
             display_manager_set_text("SIP unavailable", "Check connection");
             logger_warn_with_category("ClassicPhone", "Call refused - SIP not registered");
+            metrics_increment_counter("calls_refused_sip_unavailable", 1);
             return;
         }
     }

--- a/host/simulator.c
+++ b/host/simulator.c
@@ -91,6 +91,7 @@ static int sim_call_pending  = 0;
 static int sim_call_active   = 0;
 static int sim_hangup_called = 0;
 static int sim_sip_registered = 1;  /* 1=registered (default), 0=unavailable */
+static int sim_fail_next_call = 0;  /* 1=next placed call fails instead of connecting */
 
 /* ── Millennium SDK stubs ──────────────────────────────────────────── */
 
@@ -424,14 +425,23 @@ static void sim_drain_events(void) {
     }
 }
 
-/* If a call was placed by the plugin, auto-generate CALL_ACTIVE event */
+/* If a call was placed by the plugin, auto-generate the resulting event:
+ * CALL_ACTIVE when it connects, or CALL_INVALID when fail_next_call armed it
+ * to fail (e.g. unreachable number / SIP error during dialing). */
 static void sim_check_pending_call(void) {
     call_state_event_t *ev;
     if (!sim_call_pending) return;
     sim_call_pending = 0;
-    sim_call_active  = 1;
 
-    ev = call_state_event_create("CALL_ESTABLISHED", NULL, EVENT_CALL_STATE_ACTIVE);
+    if (sim_fail_next_call) {
+        sim_fail_next_call = 0;
+        sim_call_active    = 0;
+        ev = call_state_event_create("CALL_CLOSED", NULL, EVENT_CALL_STATE_INVALID);
+    } else {
+        sim_call_active = 1;
+        ev = call_state_event_create("CALL_ESTABLISHED", NULL, EVENT_CALL_STATE_ACTIVE);
+    }
+
     if (ev) {
         sim_process_event((event_t *)ev);
         event_destroy((event_t *)ev);
@@ -455,6 +465,40 @@ static int display_contains(const char *text) {
     return 0;
 }
 
+/*
+ * Resolve a metric reference to a numeric value for assert_metric.
+ *   <name>                  counter or gauge (gauge wins if both exist)
+ *   <name>.count|.sum|.min|.max|.mean|.median|.p95|.p99   histogram stat
+ * Returns 0 on success (value in *out), -1 if the metric is unknown.
+ */
+static int sim_read_metric(const char *ref, double *out) {
+    const char *dot = strrchr(ref, '.');
+    if (dot) {
+        char base[128];
+        size_t blen = (size_t)(dot - ref);
+        metrics_histogram_stats_t st;
+        const char *field = dot + 1;
+        if (blen >= sizeof(base)) return -1;
+        memcpy(base, ref, blen);
+        base[blen] = '\0';
+        if (metrics_get_histogram_stats(base, &st) != 0) return -1;
+        if      (strcmp(field, "count")  == 0) *out = (double)st.count;
+        else if (strcmp(field, "sum")    == 0) *out = st.sum;
+        else if (strcmp(field, "min")    == 0) *out = st.min;
+        else if (strcmp(field, "max")    == 0) *out = st.max;
+        else if (strcmp(field, "mean")   == 0) *out = st.mean;
+        else if (strcmp(field, "median") == 0) *out = st.median;
+        else if (strcmp(field, "p95")    == 0) *out = st.p95;
+        else if (strcmp(field, "p99")    == 0) *out = st.p99;
+        else return -1;
+        return 0;
+    }
+    /* No dot: gauge takes precedence over counter (gauges can read 0). */
+    if (metrics_get_gauge(ref) != 0.0) { *out = metrics_get_gauge(ref); return 0; }
+    *out = (double)metrics_get_counter(ref);
+    return 0;
+}
+
 /* ── Scenario runner ───────────────────────────────────────────────── */
 
 static int run_scenario(const char *path) {
@@ -472,6 +516,8 @@ static int run_scenario(const char *path) {
     }
 
     sim_sip_registered = 1;  /* default: SIP registered for each scenario */
+    sim_fail_next_call = 0;  /* default: placed calls connect */
+    metrics_reset_all();     /* isolate metric assertions from prior scenarios */
 
     while (fgets(line, sizeof(line), f)) {
         line_num++;
@@ -630,6 +676,38 @@ static int run_scenario(const char *path) {
             }
         }
 
+        /* ── assert_metric <name> <op> <value> ───────────────────── */
+        /* op is one of == != >= <= > < ; <name> may be a counter, gauge,
+         * or a histogram stat via the <name>.count|sum|min|max|mean|... form */
+        else if (strncmp(cmd, "assert_metric ", 14) == 0) {
+            char name[128], op[4];
+            double expected, actual = 0.0;
+            arg = trim(cmd + 14);
+            if (sscanf(arg, "%127s %3s %lf", name, op, &expected) != 3) {
+                fprintf(stderr, "  ERROR: usage: assert_metric <name> <op> <value>\n");
+                failures++;
+            } else if (sim_read_metric(name, &actual) != 0) {
+                fprintf(stderr, "  FAIL: unknown metric \"%s\"\n", name);
+                failures++;
+            } else {
+                int ok;
+                if      (strcmp(op, "==") == 0) ok = (actual == expected);
+                else if (strcmp(op, "!=") == 0) ok = (actual != expected);
+                else if (strcmp(op, ">=") == 0) ok = (actual >= expected);
+                else if (strcmp(op, "<=") == 0) ok = (actual <= expected);
+                else if (strcmp(op, ">")  == 0) ok = (actual >  expected);
+                else if (strcmp(op, "<")  == 0) ok = (actual <  expected);
+                else { ok = 0; fprintf(stderr, "  ERROR: bad operator \"%s\"\n", op); }
+                if (ok) {
+                    fprintf(stderr, "  PASS: %s (%.2f) %s %.2f\n", name, actual, op, expected);
+                } else {
+                    fprintf(stderr, "  FAIL: %s is %.2f, expected %s %.2f\n",
+                            name, actual, op, expected);
+                    failures++;
+                }
+            }
+        }
+
         /* ── print (debug) ───────────────────────────────────────── */
         else if (strcmp(cmd, "print") == 0) {
             fprintf(stderr, "  state=%s  coins=%d  display=\"%s\" | \"%s\"\n",
@@ -701,6 +779,12 @@ static int run_scenario(const char *path) {
             while (*p == ' ') p++;
             sim_sip_registered = (*p == '1') ? 1 : 0;
             fprintf(stderr, "  sip_registered = %d\n", sim_sip_registered);
+        }
+
+        /* ── fail_next_call — next placed call fails instead of connecting */
+        else if (strcmp(cmd, "fail_next_call") == 0) {
+            sim_fail_next_call = 1;
+            fprintf(stderr, "  fail_next_call armed\n");
         }
 
         /* ── config <key> <value> ──────────────────────────────── */

--- a/host/tests/test_call_failed.scenario
+++ b/host/tests/test_call_failed.scenario
@@ -1,0 +1,25 @@
+# Test: Call-failed metric (#91 dial-failure path)
+# When a paid call is placed but the SIP leg never connects (unreachable
+# number, mid-dial SIP error), the plugin refunds the coins, shows "Call
+# failed", and the calls_failed counter is incremented. `fail_next_call`
+# arms the simulator so the next placed call resolves to CALL_INVALID while
+# the plugin is still dialing, instead of auto-connecting.
+
+hook_up
+assert_state IDLE_UP
+coin 25
+coin 25
+assert_display Have: 50c
+
+# Arm the failure, then dial a complete number to place the call.
+fail_next_call
+keys 5551234567
+
+# The dial failed: coins refunded, failure shown, still on-hook-up (no call).
+assert_display Call failed
+assert_display Coins refunded
+assert_state IDLE_UP
+assert_metric calls_failed == 1
+
+hook_down
+assert_state IDLE_DOWN

--- a/host/tests/test_sip_unavailable.scenario
+++ b/host/tests/test_sip_unavailable.scenario
@@ -15,6 +15,9 @@ assert_display SIP unavailable
 assert_display Check connection
 assert_state IDLE_UP
 
+# The refusal is recorded so operators can see SIP-down call attempts.
+assert_metric calls_refused_sip_unavailable == 1
+
 # Coins and number remain in plugin state; display shows error until next update
 
 hook_down


### PR DESCRIPTION
## Summary

Successful calls (`calls_established`), timeouts (`calls_timed_out`), and many other lifecycle events are already counted, but the two ways a **paid call can fail to connect** were invisible to the metrics endpoint. This adds counters for them:

- **`calls_refused_sip_unavailable`** — a paid call refused up front because SIP isn't registered (the #94 pre-check in `classic_phone_start_call`).
- **`calls_failed`** — a call that fails mid-dial and refunds the inserted coins (the #91 path in `classic_phone_handle_call_state`).

For a payphone operator these are the signals worth alerting on — *"calls are failing, is the SIP trunk down?"* — and they cost two `metrics_increment_counter` calls at sites that already log the same events. They're exported automatically via the existing Prometheus/JSON metrics endpoints (no registry to update).

## Test infrastructure

To drive the failure paths deterministically in the scenario simulator, this PR adds:

- **`assert_metric <name> <op> <value>`** — reads a counter, gauge, or `name.count|sum|min|max|...` histogram stat and compares with `== != >= <= > <`. Metrics are now reset per scenario so assertions are isolated.
- **`fail_next_call`** — arms the simulator so the next placed call resolves to `CALL_INVALID` while the plugin is still dialing (instead of auto-connecting), exercising the refund/failure branch.

## Tests

- New `test_call_failed.scenario`: dials with funds, arms `fail_next_call`, asserts the "Call failed / Coins refunded" display, that the phone stays `IDLE_UP`, and `calls_failed == 1`.
- Extended `test_sip_unavailable.scenario`: asserts `calls_refused_sip_unavailable == 1`.

`make test` passes (59 unit tests + all scenarios); clean `-Werror` build.

> Note: the `assert_metric` directive is also being introduced by the pending call-duration-metric PR; the implementation here is byte-identical to keep any merge trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)