### PR TITLE
metrics: expose health-check status by subsystem

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -32,7 +32,7 @@ daemon_state.o: daemon_state.c daemon_state.h clock_source.h
 logger.o: logger.c logger.h
 	gcc logger.c -o logger.o -c $(CFLAGS)
 
-health_monitor.o: health_monitor.c health_monitor.h logger.h
+health_monitor.o: health_monitor.c health_monitor.h logger.h metrics.h
 	gcc health_monitor.c -o health_monitor.o -c $(CFLAGS)
 
 metrics.o: metrics.c metrics.h

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -939,11 +939,15 @@ static void update_metrics(void) {
             last_rejected = wstats.rejected_total;
         }
     }
+
+    /* Surface the background health checks (serial link, SIP registration,
+     * daemon activity) as gauges so subsystem failures are alertable via the
+     * metrics endpoint, not just the web dashboard. */
+    health_monitor_publish_metrics();
 }
 
 int main(int argc, char *argv[]) {
     config_data_t* config;
-    /* health_monitor_t* health_monitor = health_monitor_get_instance(); */
     char config_file[MAX_STRING_LEN];
     cli_options_t cli;
 

--- a/host/health_monitor.c
+++ b/host/health_monitor.c
@@ -1,5 +1,6 @@
 #include "health_monitor.h"
 #include "logger.h"
+#include "metrics.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -278,8 +279,41 @@ int health_monitor_get_statistics(health_statistics_t* stats_out) {
     pthread_mutex_lock(&g_monitor_mutex);
     *stats_out = monitor->statistics;
     pthread_mutex_unlock(&g_monitor_mutex);
-    
+
     return 1;
+}
+
+void health_monitor_publish_metrics(void) {
+    health_check_t checks[32];
+    health_statistics_t stats;
+    int count;
+    int i;
+
+    /* Per-check status as a gauge (0=healthy, 1=warning, 2=critical,
+     * 3=unknown) so an operator scraping /metrics can alert on a specific
+     * subsystem — the serial link or SIP registration — going unhealthy,
+     * out-of-band from the web dashboard. */
+    count = health_monitor_get_all_checks(checks, 32);
+    for (i = 0; i < count; i++) {
+        char metric_name[128];
+        /* Bound the %s to the check name's field capacity (name[64]) so gcc's
+         * -Werror=format-truncation can see the output fits — the buffer holds
+         * "health_check_" (13) + 63 + "_status" (7) + NUL = 84 <= 128. */
+        snprintf(metric_name, sizeof(metric_name),
+                 "health_check_%.63s_status", checks[i].name);
+        metrics_set_gauge(metric_name, (double)checks[i].last_status);
+    }
+
+    /* Worst status across all checks: a single rollup to alert on. */
+    metrics_set_gauge("health_overall_status",
+                      (double)health_monitor_get_overall_status());
+
+    /* Cumulative check tallies (running totals the monitor maintains). */
+    if (health_monitor_get_statistics(&stats)) {
+        metrics_set_gauge("health_checks_total", (double)stats.total_checks);
+        metrics_set_gauge("health_checks_failed", (double)stats.failed_checks);
+        metrics_set_gauge("health_checks_warning", (double)stats.warning_checks);
+    }
 }
 
 const char* health_monitor_status_to_string(health_status_t status) {

--- a/host/health_monitor.h
+++ b/host/health_monitor.h
@@ -74,6 +74,12 @@ int health_monitor_is_monitoring(void);
 /* Statistics */
 int health_monitor_get_statistics(health_statistics_t* stats_out);
 
+/* Publish the current health-check results to the metrics subsystem as gauges
+ * (per-check status, an overall rollup, and cumulative tallies) so the serial
+ * link and SIP registration are observable out-of-band via /metrics. Reads a
+ * point-in-time snapshot; safe to call from the main-loop metrics tick. */
+void health_monitor_publish_metrics(void);
+
 /* Utility methods */
 const char* health_monitor_status_to_string(health_status_t status);
 health_status_t health_monitor_string_to_status(const char* status_str);

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -1959,6 +1959,48 @@ static void test_health_overall_reflects_checks(void) {
     health_monitor_unregister_check("steerable");
 }
 
+/* ── Health monitor → metrics ───────────────────────────────────── */
+
+static health_status_t ut_health_ok(char *message, size_t message_len) {
+    (void)message; (void)message_len;
+    return HEALTH_STATUS_HEALTHY;
+}
+static health_status_t ut_health_critical(char *message, size_t message_len) {
+    (void)message; (void)message_len;
+    return HEALTH_STATUS_CRITICAL;
+}
+
+/* The background health checks (serial link, SIP registration) are surfaced as
+ * gauges so subsystem failures are alertable via /metrics. Verify the contract
+ * the daemon's metrics tick relies on: each check publishes its last status,
+ * the overall gauge is the worst of them, and the cumulative tallies advance. */
+static void test_health_metrics_published(void) {
+    metrics_init();
+
+    health_monitor_register_check("ut_serial", ut_health_ok, 30);
+    health_monitor_register_check("ut_sip", ut_health_critical, 60);
+    health_monitor_run_all_checks();
+
+    health_monitor_publish_metrics();
+
+    /* Per-check status gauges mirror each check's last result. */
+    TEST_ASSERT_EQ_INT((int)metrics_get_gauge("health_check_ut_serial_status"),
+                       (int)HEALTH_STATUS_HEALTHY);
+    TEST_ASSERT_EQ_INT((int)metrics_get_gauge("health_check_ut_sip_status"),
+                       (int)HEALTH_STATUS_CRITICAL);
+
+    /* Overall rollup is the worst status across all checks. */
+    TEST_ASSERT_EQ_INT((int)metrics_get_gauge("health_overall_status"),
+                       (int)HEALTH_STATUS_CRITICAL);
+
+    /* Cumulative tallies: at least the two we ran, one of them failed. */
+    TEST_ASSERT((int)metrics_get_gauge("health_checks_total") >= 2);
+    TEST_ASSERT((int)metrics_get_gauge("health_checks_failed") >= 1);
+
+    health_monitor_unregister_check("ut_serial");
+    health_monitor_unregister_check("ut_sip");
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -2108,6 +2150,9 @@ int main(void) {
     TEST_SUITE_RUN(test_health_check_default_message);
     TEST_SUITE_RUN(test_health_status_is_serving);
     TEST_SUITE_RUN(test_health_overall_reflects_checks);
+
+    TEST_SUITE_BEGIN("Health Metrics");
+    TEST_SUITE_RUN(test_health_metrics_published);
 
     TEST_REPORT();
 }


### PR DESCRIPTION
## What

The background **health monitor** already runs periodic checks (serial link, SIP registration, daemon activity) and the web dashboard surfaces them — but **none of it reached the `/metrics` endpoint**. An operator scraping metrics could see coins, calls, and log-queue health while being blind to whether the Arduino serial link or the SIP trunk was actually up — exactly the signal worth alerting on. `daemon.c` even carried a dead, commented-out `health_monitor` hook in the metrics tick, a leftover from when this was meant to be wired.

## Change

`health_monitor_publish_metrics()` reads a point-in-time snapshot through the existing thread-safe accessors and publishes gauges on each main-loop metrics tick, right alongside the log-queue publishing:

| Metric | Meaning |
|--------|---------|
| `health_check_<name>_status` | Per-check status: `0`=healthy, `1`=warning, `2`=critical, `3`=unknown |
| `health_overall_status` | Worst status across all checks (single rollup to alert on) |
| `health_checks_total` / `_failed` / `_warning` | Cumulative check tallies |

So `health_check_sip_connection_status` going to `2` or `health_overall_status > 0` becomes alertable out-of-band. This follows the same pattern as the recent call-failure and logger-queue metrics work.

## Testing

- `health_monitor.o` now links into the `unit_tests` target.
- New `test_health_metrics_published` registers two checks (one healthy, one critical), runs them, publishes, and asserts the per-check gauges, the overall rollup, and the cumulative tallies.
- `make test` green — 60 unit tests + all scenario tests pass.
- `make compile-check` passes under `-Werror` (full daemon wiring, Pi-only target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)