### PR TITLE
health: report real diagnostic messages from health checks

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -122,9 +122,9 @@ simulator: $(SIM_OBJS)
 all: daemon
 
 # Unit test binary
-UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o updater.o
+UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o health_monitor.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o updater.o
 
-tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h millennium_sdk.h updater.h
+tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h millennium_sdk.h updater.h health_monitor.h
 	gcc tests/unit_tests.c -o tests/unit_tests.o -c $(CFLAGS) -I.
 
 # Unit tests don't use time wrapping; link ALSA on Linux for jukebox

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -78,11 +78,11 @@ static void generate_display_bytes(char *output, size_t output_size);
 static void update_display(void);
 static int is_phone_ready_for_operation(void);
 static int keypad_has_space(void);
-static health_status_t check_serial_connection(void);
+static health_status_t check_serial_connection(char *message, size_t message_len);
 static void daemon_save_state(void);
 static void daemon_broadcast_state(const char *event_type);
-static health_status_t check_sip_connection(void);
-static health_status_t check_daemon_activity(void);
+static health_status_t check_sip_connection(char *message, size_t message_len);
+static health_status_t check_daemon_activity(char *message, size_t message_len);
 static void update_metrics(void);
 
 /* C-compatible functions for web server */
@@ -778,25 +778,40 @@ void signal_handler(int signal) {
 }
 
 /* Health check functions */
-health_status_t check_serial_connection(void) {
-    if (!client) return HEALTH_STATUS_UNKNOWN;
-    return millennium_client_serial_is_healthy(client)
-        ? HEALTH_STATUS_HEALTHY : HEALTH_STATUS_CRITICAL;
+health_status_t check_serial_connection(char *message, size_t message_len) {
+    if (!client) {
+        snprintf(message, message_len, "Serial client not initialized");
+        return HEALTH_STATUS_UNKNOWN;
+    }
+    if (millennium_client_serial_is_healthy(client)) {
+        snprintf(message, message_len, "Serial link healthy");
+        return HEALTH_STATUS_HEALTHY;
+    }
+    snprintf(message, message_len, "Serial link down: no recent data from Arduino");
+    return HEALTH_STATUS_CRITICAL;
 }
 
-health_status_t check_sip_connection(void) {
+health_status_t check_sip_connection(char *message, size_t message_len) {
     int registered = 0;
     millennium_sdk_get_sip_status(&registered, NULL, 0);
-    if (registered == 1) return HEALTH_STATUS_HEALTHY;
-    if (registered == -1) return HEALTH_STATUS_CRITICAL;
+    if (registered == 1) {
+        snprintf(message, message_len, "SIP registered");
+        return HEALTH_STATUS_HEALTHY;
+    }
+    if (registered == -1) {
+        snprintf(message, message_len, "SIP registration failed");
+        return HEALTH_STATUS_CRITICAL;
+    }
+    snprintf(message, message_len, "SIP registration pending");
     return HEALTH_STATUS_UNKNOWN;
 }
 
-health_status_t check_daemon_activity(void) {
+health_status_t check_daemon_activity(char *message, size_t message_len) {
     time_t now;
     time_t last_activity;
     time_t time_since_activity;
     if (!daemon_state) {
+        snprintf(message, message_len, "Daemon state unavailable");
         return HEALTH_STATUS_CRITICAL;
     }
 
@@ -809,9 +824,13 @@ health_status_t check_daemon_activity(void) {
     time_since_activity = now - last_activity;
 
     if (time_since_activity > 3600) { /* No activity for more than 1 hour */
+        snprintf(message, message_len, "No event activity for %ld minutes",
+                 (long)(time_since_activity / 60));
         return HEALTH_STATUS_WARNING;
     }
-    
+
+    snprintf(message, message_len, "Last event %ld s ago",
+             (long)time_since_activity);
     return HEALTH_STATUS_HEALTHY;
 }
 

--- a/host/health_monitor.c
+++ b/host/health_monitor.c
@@ -17,6 +17,7 @@ static pthread_t g_monitoring_thread;
 static void* monitoring_loop(void* arg);
 static void update_statistics(health_status_t status);
 static int find_check_index(const char* name);
+static health_status_t execute_check(health_check_t* check);
 
 health_monitor_t* health_monitor_get_instance(void) {
     if (!g_initialized) {
@@ -180,31 +181,23 @@ void health_monitor_run_check(const char* name) {
     health_monitor_t* monitor = health_monitor_get_instance();
     int index;
     health_status_t status;
-    time_t now;
-    
+
     if (!name) {
         return;
     }
-    
+
     pthread_mutex_lock(&g_monitor_mutex);
-    
+
     index = find_check_index(name);
     if (index < 0) {
         pthread_mutex_unlock(&g_monitor_mutex);
         logger_warn_with_category("HealthMonitor", "Health check not found");
         return;
     }
-    
+
     /* Run the check */
-    status = monitor->checks[index].check_function();
-    now = time(NULL);
-    
-    monitor->checks[index].last_status = status;
-    monitor->checks[index].last_check_time = now;
-    strcpy(monitor->checks[index].last_message, "Check completed successfully");
-    
-    update_statistics(status);
-    
+    status = execute_check(&monitor->checks[index]);
+
     pthread_mutex_unlock(&g_monitor_mutex);
     
     if (status != HEALTH_STATUS_HEALTHY) {
@@ -215,21 +208,13 @@ void health_monitor_run_check(const char* name) {
 void health_monitor_run_all_checks(void) {
     health_monitor_t* monitor = health_monitor_get_instance();
     int i;
-    health_status_t status;
-    time_t now;
-    
+
     pthread_mutex_lock(&g_monitor_mutex);
-    
-    now = time(NULL);
+
     for (i = 0; i < monitor->checks_count; i++) {
-        status = monitor->checks[i].check_function();
-        monitor->checks[i].last_status = status;
-        monitor->checks[i].last_check_time = now;
-        strcpy(monitor->checks[i].last_message, "Check completed successfully");
-        
-        update_statistics(status);
+        execute_check(&monitor->checks[i]);
     }
-    
+
     pthread_mutex_unlock(&g_monitor_mutex);
 }
 
@@ -341,12 +326,7 @@ static void* monitoring_loop(void* arg) {
         
         for (i = 0; i < monitor->checks_count; i++) {
             if (now - monitor->checks[i].last_check_time >= monitor->checks[i].interval_seconds) {
-                health_status_t status = monitor->checks[i].check_function();
-                monitor->checks[i].last_status = status;
-                monitor->checks[i].last_check_time = now;
-                strcpy(monitor->checks[i].last_message, "Check completed successfully");
-                
-                update_statistics(status);
+                execute_check(&monitor->checks[i]);
             }
         }
         
@@ -356,6 +336,32 @@ static void* monitoring_loop(void* arg) {
     }
     
     return NULL;
+}
+
+/* Run one check, recording status, timestamp, and message. The check may fill
+ * `message` with a diagnostic; if it leaves the buffer empty we synthesize a
+ * status-derived default so the /api/health "message" field always reflects the
+ * actual finding (it was previously hard-coded to "Check completed successfully"
+ * even when a check returned CRITICAL). Caller must hold g_monitor_mutex. */
+static health_status_t execute_check(health_check_t* check) {
+    char message[256];
+    health_status_t status;
+
+    message[0] = '\0';
+    status = check->check_function(message, sizeof(message));
+
+    check->last_status = status;
+    check->last_check_time = time(NULL);
+    if (message[0] != '\0') {
+        strncpy(check->last_message, message, sizeof(check->last_message) - 1);
+        check->last_message[sizeof(check->last_message) - 1] = '\0';
+    } else {
+        snprintf(check->last_message, sizeof(check->last_message),
+                 "Status: %s", health_monitor_status_to_string(status));
+    }
+
+    update_statistics(status);
+    return status;
 }
 
 static void update_statistics(health_status_t status) {
@@ -383,20 +389,23 @@ static int find_check_index(const char* name) {
     return -1;
 }
 
-/* System health check implementations */
-health_status_t system_health_check_serial_connection(void) {
-    /* This would check if the serial connection to the Arduino is working */
-    /* For now, we'll simulate a check */
+/* System health check implementations.
+ *
+ * These are generic, registerable checks kept alongside the monitor. The daemon
+ * registers its own hardware-aware serial/SIP checks (see daemon.c); the two
+ * here are simple stand-ins for builds without that wiring. Each writes a short
+ * diagnostic into `message` for /api/health. */
+health_status_t system_health_check_serial_connection(char *message, size_t message_len) {
+    snprintf(message, message_len, "Serial connection assumed up (generic check)");
     return HEALTH_STATUS_HEALTHY;
 }
 
-health_status_t system_health_check_sip_connection(void) {
-    /* This would check if the SIP connection is active */
-    /* For now, we'll simulate a check */
+health_status_t system_health_check_sip_connection(char *message, size_t message_len) {
+    snprintf(message, message_len, "SIP connection assumed up (generic check)");
     return HEALTH_STATUS_HEALTHY;
 }
 
-health_status_t system_health_check_memory_usage(void) {
+health_status_t system_health_check_memory_usage(char *message, size_t message_len) {
     FILE* status_file;
     char line[256];
     char key[32];
@@ -404,60 +413,73 @@ health_status_t system_health_check_memory_usage(void) {
     char unit[32];
     long memory_kb;
     long memory_mb;
-    
+
     status_file = fopen("/proc/self/status", "r");
     if (!status_file) {
+        snprintf(message, message_len, "Could not read /proc/self/status");
         return HEALTH_STATUS_UNKNOWN;
     }
-    
+
     while (fgets(line, sizeof(line), status_file)) {
         if (strncmp(line, "VmRSS:", 6) == 0) {
             if (sscanf(line, "%31s %31s %31s", key, value, unit) == 3) {
                 memory_kb = atol(value);
                 memory_mb = memory_kb / 1024;
-                
+
                 fclose(status_file);
-                
+
                 if (memory_mb > 1000) { /* More than 1GB */
+                    snprintf(message, message_len,
+                             "Resident memory %ld MB exceeds 1000 MB", memory_mb);
                     return HEALTH_STATUS_CRITICAL;
                 } else if (memory_mb > 500) { /* More than 500MB */
+                    snprintf(message, message_len,
+                             "Resident memory %ld MB exceeds 500 MB", memory_mb);
                     return HEALTH_STATUS_WARNING;
                 }
-                
+
+                snprintf(message, message_len, "Resident memory %ld MB", memory_mb);
                 return HEALTH_STATUS_HEALTHY;
             }
         }
     }
-    
+
     fclose(status_file);
+    snprintf(message, message_len, "VmRSS not found in /proc/self/status");
     return HEALTH_STATUS_UNKNOWN;
 }
 
-health_status_t system_health_check_disk_space(void) {
+health_status_t system_health_check_disk_space(char *message, size_t message_len) {
     struct statvfs stat;
     unsigned long free_space;
     unsigned long total_space;
     double free_percentage;
-    
+
     if (statvfs("/", &stat) != 0) {
+        snprintf(message, message_len, "statvfs(\"/\") failed");
         return HEALTH_STATUS_UNKNOWN;
     }
-    
+
     free_space = stat.f_bavail * stat.f_frsize;
     total_space = stat.f_blocks * stat.f_frsize;
-    
+
     free_percentage = (double)free_space / total_space * 100.0;
-    
+
     if (free_percentage < 5.0) {
+        snprintf(message, message_len,
+                 "Root filesystem %.1f%% free (below 5%%)", free_percentage);
         return HEALTH_STATUS_CRITICAL;
     } else if (free_percentage < 10.0) {
+        snprintf(message, message_len,
+                 "Root filesystem %.1f%% free (below 10%%)", free_percentage);
         return HEALTH_STATUS_WARNING;
     }
-    
+
+    snprintf(message, message_len, "Root filesystem %.1f%% free", free_percentage);
     return HEALTH_STATUS_HEALTHY;
 }
 
-health_status_t system_health_check_system_load(void) {
+health_status_t system_health_check_system_load(char *message, size_t message_len) {
     FILE* loadavg_file;
     char line[256];
     double load1, load5, load15;
@@ -465,12 +487,13 @@ health_status_t system_health_check_system_load(void) {
     char cpu_line[256];
     int cpu_count = 0;
     double load_percentage;
-    
+
     loadavg_file = fopen("/proc/loadavg", "r");
     if (!loadavg_file) {
+        snprintf(message, message_len, "Could not read /proc/loadavg");
         return HEALTH_STATUS_UNKNOWN;
     }
-    
+
     if (fgets(line, sizeof(line), loadavg_file)) {
         if (sscanf(line, "%lf %lf %lf", &load1, &load5, &load15) == 3) {
             /* Get number of CPU cores */
@@ -483,25 +506,35 @@ health_status_t system_health_check_system_load(void) {
                 }
                 fclose(cpuinfo);
             }
-            
+
             if (cpu_count == 0) {
                 cpu_count = 1; /* Fallback */
             }
-            
+
             load_percentage = (load1 / cpu_count) * 100.0;
-            
+
             fclose(loadavg_file);
-            
+
             if (load_percentage > 90.0) {
+                snprintf(message, message_len,
+                         "Load %.2f = %.0f%% of %d core(s)",
+                         load1, load_percentage, cpu_count);
                 return HEALTH_STATUS_CRITICAL;
             } else if (load_percentage > 70.0) {
+                snprintf(message, message_len,
+                         "Load %.2f = %.0f%% of %d core(s)",
+                         load1, load_percentage, cpu_count);
                 return HEALTH_STATUS_WARNING;
             }
-            
+
+            snprintf(message, message_len,
+                     "Load %.2f = %.0f%% of %d core(s)",
+                     load1, load_percentage, cpu_count);
             return HEALTH_STATUS_HEALTHY;
         }
     }
-    
+
     fclose(loadavg_file);
+    snprintf(message, message_len, "Could not parse /proc/loadavg");
     return HEALTH_STATUS_UNKNOWN;
 }

--- a/host/health_monitor.h
+++ b/host/health_monitor.h
@@ -12,8 +12,14 @@ typedef enum {
     HEALTH_STATUS_UNKNOWN = 3
 } health_status_t;
 
-/* Function pointer type for health check functions */
-typedef health_status_t (*health_check_func_t)(void);
+/* Function pointer type for health check functions.
+ *
+ * A check returns its status and may write a short, human-readable diagnostic
+ * into `message` (at most message_len bytes, NUL-terminated). The monitor
+ * records this as the check's last_message, surfaced verbatim by /api/health.
+ * A check that leaves the buffer empty gets a status-derived default message,
+ * so the reported message always reflects the actual finding. */
+typedef health_status_t (*health_check_func_t)(char *message, size_t message_len);
 
 /* C89 compatible health check structure */
 typedef struct {
@@ -73,10 +79,10 @@ const char* health_monitor_status_to_string(health_status_t status);
 health_status_t health_monitor_string_to_status(const char* status_str);
 
 /* Predefined system health checks */
-health_status_t system_health_check_serial_connection(void);
-health_status_t system_health_check_sip_connection(void);
-health_status_t system_health_check_memory_usage(void);
-health_status_t system_health_check_disk_space(void);
-health_status_t system_health_check_system_load(void);
+health_status_t system_health_check_serial_connection(char *message, size_t message_len);
+health_status_t system_health_check_sip_connection(char *message, size_t message_len);
+health_status_t system_health_check_memory_usage(char *message, size_t message_len);
+health_status_t system_health_check_disk_space(char *message, size_t message_len);
+health_status_t system_health_check_system_load(char *message, size_t message_len);
 
 #endif /* HEALTH_MONITOR_H */

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -9,6 +9,7 @@
 #include "../updater.h"
 #include "../plugin_sdk.h"
 #include "../clock_source.h"
+#include "../health_monitor.h"
 #include <stdlib.h>
 
 /* ── Stubs for linker (plugins.c references these) ──────────────── */
@@ -936,6 +937,46 @@ static void test_logger_queue_stats(void) {
     remove(path);
 }
 
+/* Health checks return a status and may write a human-readable diagnostic.
+ * /api/health surfaces that message verbatim, so the monitor must record what
+ * the check wrote — and synthesize a status-derived default when a check writes
+ * nothing — instead of the old hard-coded "Check completed successfully" that
+ * was reported even for a CRITICAL check. */
+static health_status_t ut_health_with_message(char *message, size_t message_len) {
+    snprintf(message, message_len, "serial link down: no data for 45s");
+    return HEALTH_STATUS_CRITICAL;
+}
+
+static health_status_t ut_health_silent_warning(char *message, size_t message_len) {
+    (void)message;       /* deliberately writes no message */
+    (void)message_len;
+    return HEALTH_STATUS_WARNING;
+}
+
+static void test_health_check_records_message(void) {
+    health_check_t check;
+
+    health_monitor_register_check("ut_msg", ut_health_with_message, 30);
+    health_monitor_run_all_checks();
+    TEST_ASSERT(health_monitor_get_check("ut_msg", &check));
+    TEST_ASSERT_EQ_INT((int)check.last_status, (int)HEALTH_STATUS_CRITICAL);
+    TEST_ASSERT(strcmp(check.last_message, "serial link down: no data for 45s") == 0);
+    health_monitor_unregister_check("ut_msg");
+}
+
+static void test_health_check_default_message(void) {
+    health_check_t check;
+
+    health_monitor_register_check("ut_silent", ut_health_silent_warning, 30);
+    health_monitor_run_all_checks();
+    TEST_ASSERT(health_monitor_get_check("ut_silent", &check));
+    TEST_ASSERT_EQ_INT((int)check.last_status, (int)HEALTH_STATUS_WARNING);
+    /* No hard-coded success string; the default reflects the real status. */
+    TEST_ASSERT(strstr(check.last_message, "Check completed successfully") == NULL);
+    TEST_ASSERT(strstr(check.last_message, "WARNING") != NULL);
+    health_monitor_unregister_check("ut_silent");
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -1017,6 +1058,10 @@ int main(void) {
     TEST_SUITE_BEGIN("Logger");
     TEST_SUITE_RUN(test_logger_async_file_write);
     TEST_SUITE_RUN(test_logger_queue_stats);
+
+    TEST_SUITE_BEGIN("Health Monitor");
+    TEST_SUITE_RUN(test_health_check_records_message);
+    TEST_SUITE_RUN(test_health_check_default_message);
 
     TEST_REPORT();
 }


### PR DESCRIPTION
## Problem

The health monitor recorded a hard-coded `"Check completed successfully"` message for **every** check, regardless of the status it returned. Since `/api/health` (and the dashboard **Health** button) surface that message verbatim, an operator triaging a real failure saw a self-contradictory response:

```json
"serial_connection": { "status": "CRITICAL", "message": "Check completed successfully" }
```

i.e. the message field was actively misleading exactly when it mattered — a dead serial link or a failed SIP registration.

## Change

Health-check functions now take a `(char *message, size_t len)` buffer and write a short diagnostic describing what they actually found:

| check | healthy | unhealthy |
|-------|---------|-----------|
| `serial_connection` | `Serial link healthy` | `Serial link down: no recent data from Arduino` |
| `sip_connection` | `SIP registered` | `SIP registration failed` / `SIP registration pending` |
| `daemon_activity` | `Last event N s ago` | `No event activity for N minutes` |

The generic memory/disk/load stubs now include their measured value (RSS MB, % free, load vs core count).

A new `execute_check()` helper centralizes running a check, recording its message, and synthesizing a status-derived default (`"Status: WARNING"`) when a check writes nothing — collapsing the three former copy-paste call sites (`run_check`, `run_all_checks`, `monitoring_loop`) into one.

## Tests

- New **Health Monitor** unit suite: verifies a check's message is recorded verbatim, and that a silent check gets a status-derived default (never the old success string).
- `health_monitor.o` is now linked into the unit-test target.
- `make test` — all unit + scenario tests pass (61 unit, all scenarios). `daemon.c` syntax-checks clean under `-std=gnu89 -Wall -Wextra -Wdeclaration-after-statement`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)