### PR TITLE
config: validate full config on startup and report the offending key

### DIFF
--- a/host/config.c
+++ b/host/config.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdarg.h>
 
 /* Global config instance */
 config_data_t* g_config = NULL;
@@ -168,17 +169,132 @@ int config_get_bool(const config_data_t* config, const char* key, int default_va
     return 0;
 }
 
-int config_validate(const config_data_t* config) {
-    /* Validate numeric values */
+/* Write a formatted reason into errmsg if it is non-NULL, then return 0 so
+   callers can `return config_fail(...)` from a failed check in one line. */
+static int config_fail(char* errmsg, size_t errmsg_size, const char* fmt, ...) {
+    va_list ap;
+    if (errmsg != NULL && errmsg_size > 0) {
+        va_start(ap, fmt);
+        vsnprintf(errmsg, errmsg_size, fmt, ap);
+        va_end(ap);
+    }
+    return 0;
+}
+
+/* Case-insensitive check that a logging.level string names a real level.
+   logger_parse_level() silently maps unknown strings to INFO, so a typo in
+   the config would otherwise pass unnoticed; validation rejects it here. */
+static int config_log_level_is_valid(const char* level) {
+    static const char* const valid[] = {
+        "VERBOSE", "DEBUG", "INFO", "WARN", "ERROR"
+    };
+    char upper[32];
+    size_t i;
+    int j;
+
+    if (level == NULL) {
+        return 0;
+    }
+    for (i = 0; level[i] != '\0' && i < sizeof(upper) - 1; i++) {
+        upper[i] = (char)toupper((unsigned char)level[i]);
+    }
+    upper[i] = '\0';
+
+    for (j = 0; j < (int)(sizeof(valid) / sizeof(valid[0])); j++) {
+        if (strcmp(upper, valid[j]) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int config_validate_detailed(const config_data_t* config, char* errmsg, size_t errmsg_size) {
+    int port;
+
+    if (errmsg != NULL && errmsg_size > 0) {
+        errmsg[0] = '\0';
+    }
+
+    if (config == NULL) {
+        return config_fail(errmsg, errmsg_size, "config is NULL");
+    }
+
+    /* Call pricing and timeouts */
     if (config_get_call_cost_cents(config) <= 0) {
-        return 0;
+        return config_fail(errmsg, errmsg_size,
+            "call.cost_cents must be positive (got %d)",
+            config_get_call_cost_cents(config));
     }
-    
+    if (config_get_call_timeout_seconds(config) <= 0) {
+        return config_fail(errmsg, errmsg_size,
+            "call.timeout_seconds must be positive (got %d)",
+            config_get_call_timeout_seconds(config));
+    }
+    if (config_get_idle_timeout_seconds(config) <= 0) {
+        return config_fail(errmsg, errmsg_size,
+            "call.idle_timeout_seconds must be positive (got %d)",
+            config_get_idle_timeout_seconds(config));
+    }
+
+    /* Hardware */
+    if (config_get_baud_rate(config) <= 0) {
+        return config_fail(errmsg, errmsg_size,
+            "hardware.baud_rate must be positive (got %d)",
+            config_get_baud_rate(config));
+    }
+
+    /* System loop */
     if (config_get_update_interval_ms(config) <= 0) {
-        return 0;
+        return config_fail(errmsg, errmsg_size,
+            "system.update_interval_ms must be positive (got %d)",
+            config_get_update_interval_ms(config));
     }
-    
+    if (config_get_max_retries(config) < 0) {
+        return config_fail(errmsg, errmsg_size,
+            "system.max_retries must not be negative (got %d)",
+            config_get_max_retries(config));
+    }
+
+    /* Logging */
+    if (!config_log_level_is_valid(config_get_log_level(config))) {
+        return config_fail(errmsg, errmsg_size,
+            "logging.level '%s' is not a valid level "
+            "(VERBOSE, DEBUG, INFO, WARN, ERROR)",
+            config_get_log_level(config));
+    }
+    if (config_get_log_max_size_bytes(config) <= 0) {
+        return config_fail(errmsg, errmsg_size,
+            "logging.max_size_bytes must be positive (got %d)",
+            config_get_log_max_size_bytes(config));
+    }
+    if (config_get_log_max_files(config) <= 0) {
+        return config_fail(errmsg, errmsg_size,
+            "logging.max_files must be positive (got %d)",
+            config_get_log_max_files(config));
+    }
+
+    /* Network ports (1..65535) */
+    port = config_get_web_server_port(config);
+    if (port < 1 || port > 65535) {
+        return config_fail(errmsg, errmsg_size,
+            "web_server.port must be 1..65535 (got %d)", port);
+    }
+    port = config_get_metrics_server_port(config);
+    if (port < 1 || port > 65535) {
+        return config_fail(errmsg, errmsg_size,
+            "metrics_server.port must be 1..65535 (got %d)", port);
+    }
+    if (config_get_web_server_port(config) == config_get_metrics_server_port(config)) {
+        return config_fail(errmsg, errmsg_size,
+            "web_server.port and metrics_server.port must differ (both %d)",
+            config_get_web_server_port(config));
+    }
+
     return 1;
+}
+
+int config_validate(const config_data_t* config) {
+    return config_validate_detailed(config, NULL, 0);
 }
 
 void config_set_default_values(config_data_t* config) {

--- a/host/config.h
+++ b/host/config.h
@@ -18,6 +18,10 @@ config_data_t* config_get_instance(void);
 int config_load_from_file(config_data_t* config, const char* config_path);
 int config_load_from_environment(config_data_t* config);
 int config_validate(const config_data_t* config);
+/* Like config_validate(), but writes a human-readable reason for the first
+   failure into errmsg (truncated to errmsg_size). On success errmsg[0] is set
+   to '\0'. errmsg may be NULL if the caller only wants the 0/1 result. */
+int config_validate_detailed(const config_data_t* config, char* errmsg, size_t errmsg_size);
 
 /* Configuration getters */
 const char* config_get_string(const config_data_t* config, const char* key, const char* default_value);

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -897,9 +897,13 @@ int main(int argc, char *argv[]) {
         logger_infof_with_category("Config", "Config loaded from %s", config_file);
     }
     
-    if (!config_validate(config)) {
-        logger_error_with_category("Config", "Configuration validation failed");
-        return 1;
+    {
+        char config_err[256];
+        if (!config_validate_detailed(config, config_err, sizeof(config_err))) {
+            logger_errorf_with_category("Config",
+                "Configuration validation failed: %s", config_err);
+            return 1;
+        }
     }
     
     /* Setup logging */

--- a/host/daemon.conf.example
+++ b/host/daemon.conf.example
@@ -1,5 +1,13 @@
 # Millennium Daemon Configuration File
 # Copy this file to /etc/millennium/daemon.conf and modify as needed
+#
+# The daemon validates this file on startup and refuses to run on a bad value,
+# logging the specific offending key. Constraints:
+#   - call.cost_cents, call.timeout_seconds, call.idle_timeout_seconds > 0
+#   - hardware.baud_rate, system.update_interval_ms > 0; system.max_retries >= 0
+#   - logging.level is one of VERBOSE, DEBUG, INFO, WARN, ERROR
+#   - logging.max_size_bytes, logging.max_files > 0
+#   - web_server.port and metrics_server.port are 1..65535 and must differ
 
 # Hardware Configuration
 hardware.display_device=/dev/serial/by-id/usb-Arduino_LLC_Millennium_Beta-if00

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -10,6 +10,7 @@
 #include "../plugin_sdk.h"
 #include "../clock_source.h"
 #include <stdlib.h>
+#include <string.h>
 
 /* ── Stubs for linker (plugins.c references these) ──────────────── */
 
@@ -144,6 +145,82 @@ static void test_config_validate_bad_cost(void) {
 
     config_set_value(&cfg, "call.cost_cents", "0");
     TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+}
+
+/* config_validate_detailed() reports the specific failing key. */
+static void test_config_validate_detailed_reports_reason(void) {
+    config_data_t cfg;
+    char err[256];
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+
+    /* Good config leaves err empty and returns 1. */
+    err[0] = 'x';
+    TEST_ASSERT_EQ_INT(config_validate_detailed(&cfg, err, sizeof(err)), 1);
+    TEST_ASSERT_EQ_STR(err, "");
+
+    /* Bad cost names call.cost_cents in the message. */
+    config_set_value(&cfg, "call.cost_cents", "-5");
+    TEST_ASSERT_EQ_INT(config_validate_detailed(&cfg, err, sizeof(err)), 0);
+    TEST_ASSERT(strstr(err, "call.cost_cents") != NULL);
+}
+
+/* An out-of-range port is rejected with a port-specific message. */
+static void test_config_validate_bad_port(void) {
+    config_data_t cfg;
+    char err[256];
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+
+    config_set_value(&cfg, "web_server.port", "70000");
+    TEST_ASSERT_EQ_INT(config_validate_detailed(&cfg, err, sizeof(err)), 0);
+    TEST_ASSERT(strstr(err, "web_server.port") != NULL);
+
+    config_set_value(&cfg, "web_server.port", "0");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+}
+
+/* web and metrics ports must not collide. */
+static void test_config_validate_port_collision(void) {
+    config_data_t cfg;
+    char err[256];
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+
+    config_set_value(&cfg, "web_server.port", "8080");
+    config_set_value(&cfg, "metrics_server.port", "8080");
+    TEST_ASSERT_EQ_INT(config_validate_detailed(&cfg, err, sizeof(err)), 0);
+    TEST_ASSERT(strstr(err, "differ") != NULL);
+}
+
+/* A typo'd logging.level is rejected rather than silently defaulting. */
+static void test_config_validate_bad_log_level(void) {
+    config_data_t cfg;
+    char err[256];
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+
+    config_set_value(&cfg, "logging.level", "TRACE");
+    TEST_ASSERT_EQ_INT(config_validate_detailed(&cfg, err, sizeof(err)), 0);
+    TEST_ASSERT(strstr(err, "logging.level") != NULL);
+
+    /* Valid levels (any case) still pass. */
+    config_set_value(&cfg, "logging.level", "warn");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 1);
+}
+
+/* errmsg may be NULL; result is still correct, and config NULL is rejected. */
+static void test_config_validate_detailed_null_safety(void) {
+    config_data_t cfg;
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+
+    TEST_ASSERT_EQ_INT(config_validate_detailed(&cfg, NULL, 0), 1);
+    TEST_ASSERT_EQ_INT(config_validate_detailed(NULL, NULL, 0), 0);
 }
 
 static void test_config_trim(void) {
@@ -949,6 +1026,11 @@ int main(void) {
     TEST_SUITE_RUN(test_config_get_bool_variants);
     TEST_SUITE_RUN(test_config_validate_good);
     TEST_SUITE_RUN(test_config_validate_bad_cost);
+    TEST_SUITE_RUN(test_config_validate_detailed_reports_reason);
+    TEST_SUITE_RUN(test_config_validate_bad_port);
+    TEST_SUITE_RUN(test_config_validate_port_collision);
+    TEST_SUITE_RUN(test_config_validate_bad_log_level);
+    TEST_SUITE_RUN(test_config_validate_detailed_null_safety);
     TEST_SUITE_RUN(test_config_trim);
     TEST_SUITE_RUN(test_config_null_safety);
     TEST_SUITE_RUN(test_config_overwrite_value);


### PR DESCRIPTION
## Summary

Make startup config validation **thorough** and **diagnostic**. Previously `config_validate()` checked only `call.cost_cents` and `system.update_interval_ms` and returned a bare `0/1`; the daemon then logged a generic `"Configuration validation failed"` with no indication of *what* was wrong. A typo in `daemon.conf` meant a refusal to start with nothing actionable in the log.

This adds `config_validate_detailed()`, which validates every numeric/range constraint and writes a human-readable reason for the first failure into a caller-supplied buffer. `main()` now logs that specific reason. This continues the recent observability theme (cf. `health: report real diagnostic messages from health checks`).

## What's now validated

- `call.cost_cents`, `call.timeout_seconds`, `call.idle_timeout_seconds` > 0
- `hardware.baud_rate`, `system.update_interval_ms` > 0; `system.max_retries` >= 0
- `logging.max_size_bytes`, `logging.max_files` > 0
- **`logging.level`** must name a real level — `logger_parse_level()` silently maps an unknown string to `INFO`, so a typo was previously swallowed; it's now rejected explicitly.
- **`web_server.port` / `metrics_server.port`** must be `1..65535` **and must differ** (catches an accidental port collision before two servers fight over a bind).

Example log on a bad file:
```
[ERROR][Config] Configuration validation failed: web_server.port must be 1..65535 (got 70000)
```

## API

- New: `int config_validate_detailed(const config_data_t*, char* errmsg, size_t errmsg_size)`
- `config_validate()` is retained as a thin wrapper (`errmsg = NULL`) — existing callers/tests unchanged.

## Tests

5 new unit tests (64 total pass): reason-message content, zero/out-of-range ports, port collision, invalid + case-insensitive log levels, and NULL safety. `make test` (unit + scenarios) passes; `daemon.c` syntax-checks clean under `-std=gnu89 -Werror`.

## Docs

`daemon.conf.example` now lists the constraints at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)