### PR TITLE
daemon: add --version/--help and robust --config CLI parsing

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -19,6 +19,9 @@ VERSION_CFLAGS = -DGIT_HASH='"$(GIT_HASH)"' -DBUILD_TIME='"$(BUILD_TIME)"'
 config.o: config.c config.h
 	gcc config.c -o config.o -c $(CFLAGS)
 
+cli.o: cli.c cli.h
+	gcc cli.c -o cli.o -c $(CFLAGS)
+
 # C object files
 clock_source.o: clock_source.c clock_source.h
 	gcc clock_source.c -o clock_source.o -c $(CFLAGS)
@@ -102,8 +105,8 @@ plugins/dial_a_joke.o: plugins/dial_a_joke.c plugins.h plugin_sdk.h config.h
 plugins/trivia.o: plugins/trivia.c plugins.h plugin_sdk.h config.h
 	gcc plugins/trivia.c -o plugins/trivia.o -c $(CFLAGS)
 
-daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o
-	gcc daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o -o daemon $(LDFLAGS) -lm
+daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o
+	gcc daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o -o daemon $(LDFLAGS) -lm
 
 # Simulator object file
 simulator.o: simulator.c millennium_sdk.h events.h config.h daemon_state.h logger.h metrics.h plugins.h
@@ -122,9 +125,9 @@ simulator: $(SIM_OBJS)
 all: daemon
 
 # Unit test binary
-UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o updater.o
+UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o cli.o logger.o metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o updater.o
 
-tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h millennium_sdk.h updater.h
+tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h cli.h daemon_state.h plugins.h logger.h metrics.h millennium_sdk.h updater.h
 	gcc tests/unit_tests.c -o tests/unit_tests.o -c $(CFLAGS) -I.
 
 # Unit tests don't use time wrapping; link ALSA on Linux for jukebox

--- a/host/README.md
+++ b/host/README.md
@@ -65,6 +65,33 @@ make clean         # Remove all build artifacts
 sudo make install  # Install daemon binary, ALSA config, and systemd service
 ```
 
+## Command-line options
+
+The daemon accepts a few flags (anything else is rejected with a usage message
+and exit code 2):
+
+```
+Usage: millennium-daemon [options]
+
+Options:
+  -c, --config <path>   Read configuration from <path>
+                        (default: /etc/millennium/daemon.conf)
+  -v, --version         Print version and build info, then exit
+  -h, --help            Print this help, then exit
+```
+
+`--version` prints the build's semantic version, git hash, and build time —
+useful for confirming which build is actually installed after a deploy:
+
+```bash
+millennium-daemon --version
+# millennium-daemon 0.3.0 (git 1f831a8, built 2026-06-11T12:00:00Z)
+```
+
+`--config` may appear anywhere on the command line and also accepts the
+`--config=<path>` form. The systemd unit passes
+`--config /etc/millennium/daemon.conf`.
+
 ## Systemd Setup
 
 ```bash

--- a/host/cli.c
+++ b/host/cli.c
@@ -1,0 +1,82 @@
+#include "cli.h"
+
+#include <string.h>
+#include <stddef.h>
+
+/* Strip any leading directory components from argv[0] so usage reads as the
+   bare program name regardless of how it was invoked. */
+static const char* cli_basename(const char* prog) {
+    const char* slash;
+    if (prog == NULL || prog[0] == '\0') {
+        return "millennium-daemon";
+    }
+    slash = strrchr(prog, '/');
+    return slash ? slash + 1 : prog;
+}
+
+static void cli_set_error(cli_options_t* opts, const char* fmt_arg, const char* arg) {
+    /* No printf-family formatting needed: messages are "<text><arg>" at most. */
+    size_t n;
+    opts->mode = CLI_MODE_ERROR;
+    opts->error[0] = '\0';
+    strncpy(opts->error, fmt_arg, sizeof(opts->error) - 1);
+    opts->error[sizeof(opts->error) - 1] = '\0';
+    if (arg != NULL) {
+        n = strlen(opts->error);
+        strncpy(opts->error + n, arg, sizeof(opts->error) - 1 - n);
+        opts->error[sizeof(opts->error) - 1] = '\0';
+    }
+}
+
+void cli_parse_args(int argc, char* const argv[], cli_options_t* opts) {
+    int i;
+
+    opts->mode = CLI_MODE_RUN;
+    opts->config_file = NULL;
+    opts->error[0] = '\0';
+
+    for (i = 1; i < argc; i++) {
+        const char* arg = argv[i];
+
+        if (strcmp(arg, "-h") == 0 || strcmp(arg, "--help") == 0) {
+            opts->mode = CLI_MODE_HELP;
+            return;
+        }
+        if (strcmp(arg, "-v") == 0 || strcmp(arg, "--version") == 0) {
+            opts->mode = CLI_MODE_VERSION;
+            return;
+        }
+        if (strcmp(arg, "-c") == 0 || strcmp(arg, "--config") == 0) {
+            if (i + 1 >= argc) {
+                cli_set_error(opts, "missing path after ", arg);
+                return;
+            }
+            opts->config_file = argv[++i];
+            continue;
+        }
+        if (strncmp(arg, "--config=", 9) == 0) {
+            if (arg[9] == '\0') {
+                cli_set_error(opts, "missing path after ", "--config=");
+                return;
+            }
+            opts->config_file = arg + 9;
+            continue;
+        }
+
+        cli_set_error(opts, "unknown argument: ", arg);
+        return;
+    }
+}
+
+void cli_print_usage(FILE* out, const char* prog) {
+    const char* name = cli_basename(prog);
+    fprintf(out, "Usage: %s [options]\n", name);
+    fprintf(out, "\n");
+    fprintf(out, "Millennium payphone daemon.\n");
+    fprintf(out, "\n");
+    fprintf(out, "Options:\n");
+    fprintf(out, "  -c, --config <path>   Read configuration from <path>\n");
+    fprintf(out, "                        (default: /etc/millennium/daemon.conf)\n");
+    fprintf(out, "  -v, --version         Print version and build info, then exit\n");
+    fprintf(out, "  -h, --help            Print this help, then exit\n");
+}

--- a/host/cli.h
+++ b/host/cli.h
@@ -1,0 +1,30 @@
+#ifndef CLI_H
+#define CLI_H
+
+#include <stdio.h>
+
+/* What the parsed command line tells main() to do. */
+typedef enum {
+    CLI_MODE_RUN = 0,   /* start the daemon normally */
+    CLI_MODE_HELP,      /* print usage and exit 0 */
+    CLI_MODE_VERSION,   /* print version and exit 0 */
+    CLI_MODE_ERROR      /* bad arguments; print error+usage, exit 2 */
+} cli_mode_t;
+
+typedef struct {
+    cli_mode_t mode;
+    const char* config_file;   /* path from --config, or NULL for the default */
+    char error[128];           /* human-readable reason when mode == CLI_MODE_ERROR */
+} cli_options_t;
+
+/* Parse argv into opts. Never exits or prints; the caller inspects opts.mode
+   and acts. Recognizes --help/-h, --version/-v, and --config <path> (also the
+   --config=<path> form). The first --help/--version wins; an unknown flag or a
+   --config with no value yields CLI_MODE_ERROR with a message in opts.error. */
+void cli_parse_args(int argc, char* const argv[], cli_options_t* opts);
+
+/* Write the usage/help text to `out`. `prog` is argv[0] (NULL falls back to a
+   sensible default program name). */
+void cli_print_usage(FILE* out, const char* prog);
+
+#endif /* CLI_H */

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -13,6 +13,8 @@
 #include "state_persistence.h"
 #include "display_manager.h"
 #include "audio_tones.h"
+#include "cli.h"
+#include "version.h"
 #include <signal.h>
 #include <string.h>
 #include <stdio.h>
@@ -863,6 +865,28 @@ int main(int argc, char *argv[]) {
     config_data_t* config;
     /* health_monitor_t* health_monitor = health_monitor_get_instance(); */
     char config_file[MAX_STRING_LEN];
+    cli_options_t cli;
+
+    /* Parse the command line before touching any hardware or state: --help and
+     * --version must work cheaply and side-effect-free even on the dev box. */
+    cli_parse_args(argc, argv, &cli);
+    switch (cli.mode) {
+    case CLI_MODE_HELP:
+        cli_print_usage(stdout, argv[0]);
+        return 0;
+    case CLI_MODE_VERSION:
+        printf("millennium-daemon %s (git %s, built %s)\n",
+               version_get_string(), version_get_git_hash(),
+               version_get_build_time());
+        return 0;
+    case CLI_MODE_ERROR:
+        fprintf(stderr, "millennium-daemon: %s\n", cli.error);
+        cli_print_usage(stderr, argv[0]);
+        return 2;
+    case CLI_MODE_RUN:
+    default:
+        break;
+    }
 
     /* Daemon has no controlling terminal: point stdin at /dev/null so nothing
      * accidentally polls fd 0 (which under systemd can be a non-pollable fd). */
@@ -885,8 +909,8 @@ int main(int argc, char *argv[]) {
     
     /* Load configuration */
     strcpy(config_file, "/etc/millennium/daemon.conf");
-    if (argc > 2 && strcmp(argv[1], "--config") == 0) {
-        strncpy(config_file, argv[2], MAX_STRING_LEN - 1);
+    if (cli.config_file != NULL) {
+        strncpy(config_file, cli.config_file, MAX_STRING_LEN - 1);
         config_file[MAX_STRING_LEN - 1] = '\0';
     }
     

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -1,6 +1,7 @@
 #define _POSIX_C_SOURCE 200112L
 #include "test_framework.h"
 #include "../config.h"
+#include "../cli.h"
 #include "../daemon_state.h"
 #include "../plugins.h"
 #include "../logger.h"
@@ -936,6 +937,94 @@ static void test_logger_queue_stats(void) {
     remove(path);
 }
 
+/* ── CLI argument parsing ───────────────────────────────────────── */
+
+static void test_cli_no_args_runs(void) {
+    cli_options_t opts;
+    char* argv[] = { "millennium-daemon" };
+    cli_parse_args(1, argv, &opts);
+    TEST_ASSERT_EQ_INT(opts.mode, CLI_MODE_RUN);
+    TEST_ASSERT_NULL((void*)opts.config_file);
+}
+
+static void test_cli_config_long(void) {
+    cli_options_t opts;
+    char* argv[] = { "millennium-daemon", "--config", "/etc/millennium/daemon.conf" };
+    cli_parse_args(3, argv, &opts);
+    TEST_ASSERT_EQ_INT(opts.mode, CLI_MODE_RUN);
+    TEST_ASSERT_EQ_STR(opts.config_file, "/etc/millennium/daemon.conf");
+}
+
+static void test_cli_config_short(void) {
+    cli_options_t opts;
+    char* argv[] = { "millennium-daemon", "-c", "/tmp/x.conf" };
+    cli_parse_args(3, argv, &opts);
+    TEST_ASSERT_EQ_INT(opts.mode, CLI_MODE_RUN);
+    TEST_ASSERT_EQ_STR(opts.config_file, "/tmp/x.conf");
+}
+
+static void test_cli_config_equals(void) {
+    cli_options_t opts;
+    char* argv[] = { "millennium-daemon", "--config=/tmp/y.conf" };
+    cli_parse_args(2, argv, &opts);
+    TEST_ASSERT_EQ_INT(opts.mode, CLI_MODE_RUN);
+    TEST_ASSERT_EQ_STR(opts.config_file, "/tmp/y.conf");
+}
+
+static void test_cli_config_missing_value(void) {
+    cli_options_t opts;
+    char* argv[] = { "millennium-daemon", "--config" };
+    cli_parse_args(2, argv, &opts);
+    TEST_ASSERT_EQ_INT(opts.mode, CLI_MODE_ERROR);
+    TEST_ASSERT(opts.error[0] != '\0');
+}
+
+static void test_cli_config_empty_equals(void) {
+    cli_options_t opts;
+    char* argv[] = { "millennium-daemon", "--config=" };
+    cli_parse_args(2, argv, &opts);
+    TEST_ASSERT_EQ_INT(opts.mode, CLI_MODE_ERROR);
+}
+
+static void test_cli_help(void) {
+    cli_options_t opts;
+    char* argv[] = { "millennium-daemon", "--help" };
+    cli_parse_args(2, argv, &opts);
+    TEST_ASSERT_EQ_INT(opts.mode, CLI_MODE_HELP);
+}
+
+static void test_cli_version(void) {
+    cli_options_t opts;
+    char* argv[] = { "millennium-daemon", "-v" };
+    cli_parse_args(2, argv, &opts);
+    TEST_ASSERT_EQ_INT(opts.mode, CLI_MODE_VERSION);
+}
+
+static void test_cli_unknown_arg(void) {
+    cli_options_t opts;
+    char* argv[] = { "millennium-daemon", "--bogus" };
+    cli_parse_args(2, argv, &opts);
+    TEST_ASSERT_EQ_INT(opts.mode, CLI_MODE_ERROR);
+    TEST_ASSERT(opts.error[0] != '\0');
+}
+
+/* --config no longer has to be the first argument (the old parser only looked
+   at argv[1]); a flag before it must still be honored. */
+static void test_cli_config_not_first(void) {
+    cli_options_t opts;
+    char* argv[] = { "millennium-daemon", "-c", "/a.conf", "--bogus" };
+    cli_parse_args(4, argv, &opts);
+    TEST_ASSERT_EQ_INT(opts.mode, CLI_MODE_ERROR);  /* the trailing bad flag wins */
+}
+
+/* --version/--help short-circuit even when other (valid) args follow. */
+static void test_cli_version_short_circuits(void) {
+    cli_options_t opts;
+    char* argv[] = { "millennium-daemon", "--version", "--config", "/x.conf" };
+    cli_parse_args(4, argv, &opts);
+    TEST_ASSERT_EQ_INT(opts.mode, CLI_MODE_VERSION);
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -1017,6 +1106,19 @@ int main(void) {
     TEST_SUITE_BEGIN("Logger");
     TEST_SUITE_RUN(test_logger_async_file_write);
     TEST_SUITE_RUN(test_logger_queue_stats);
+
+    TEST_SUITE_BEGIN("CLI");
+    TEST_SUITE_RUN(test_cli_no_args_runs);
+    TEST_SUITE_RUN(test_cli_config_long);
+    TEST_SUITE_RUN(test_cli_config_short);
+    TEST_SUITE_RUN(test_cli_config_equals);
+    TEST_SUITE_RUN(test_cli_config_missing_value);
+    TEST_SUITE_RUN(test_cli_config_empty_equals);
+    TEST_SUITE_RUN(test_cli_help);
+    TEST_SUITE_RUN(test_cli_version);
+    TEST_SUITE_RUN(test_cli_unknown_arg);
+    TEST_SUITE_RUN(test_cli_config_not_first);
+    TEST_SUITE_RUN(test_cli_version_short_circuits);
 
     TEST_REPORT();
 }


### PR DESCRIPTION
## What

Gives the daemon proper command-line handling. Previously the only flag was an ad-hoc `--config` that:

- only worked when `--config` was **argv[1]** (`daemon --foo --config x` dropped it),
- **silently ignored** unknown flags, and
- offered no way to query the build version or usage.

## Changes

A small, dependency-free CLI module (`cli.c`/`cli.h`) parses the command line into a `cli_options_t`; `main()` acts on the result:

```
Usage: millennium-daemon [options]

Options:
  -c, --config <path>   Read configuration from <path>
                        (default: /etc/millennium/daemon.conf)
  -v, --version         Print version and build info, then exit
  -h, --help            Print this help, then exit
```

- `--config` is now **position-independent** and also accepts `--config=<path>`.
- Unknown flags / a `--config` with no value print a usage message and exit **2**.
- `--version` prints `millennium-daemon <ver> (git <hash>, built <time>)` using the same `version_get_*` info the updater already tracks — so a deploy can confirm *which* build is installed.
- `--help`/`--version` run before any hardware, state, or stdin handling, so they're cheap and side-effect-free anywhere.

The systemd unit's `--config /etc/millennium/daemon.conf` invocation is unchanged and still works.

## Testing

The parser is its own translation unit so it's unit-testable on the Mac (the full `daemon` binary needs PJSIP/ALSA and only builds on the Pi). Added **11 unit tests** covering each flag form, `--config=`/empty cases, unknown args, position independence, and `--version`/`--help` short-circuiting.

- `make test` → all 70 unit tests + all scenario tests pass.
- `daemon.o` and `cli.o` compile clean under `-Wall -Wextra -Wdeclaration-after-statement -Werror -std=gnu89`.
- End-to-end behavior verified via a throwaway harness linking `cli.o` + `version.o` (correct output and exit codes for every flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)