### PR TITLE
config: strict range-checked validation with descriptive diagnostics

### DIFF
--- a/host/config.c
+++ b/host/config.c
@@ -168,17 +168,124 @@ int config_get_bool(const config_data_t* config, const char* key, int default_va
     return 0;
 }
 
-int config_validate(const config_data_t* config) {
-    /* Validate numeric values */
+/* Case-insensitive string compare for small config tokens. */
+static int config_str_eq_ci(const char* a, const char* b) {
+    if (a == NULL || b == NULL) {
+        return 0;
+    }
+    while (*a != '\0' && *b != '\0') {
+        if (tolower((unsigned char)*a) != tolower((unsigned char)*b)) {
+            return 0;
+        }
+        a++;
+        b++;
+    }
+    return *a == '\0' && *b == '\0';
+}
+
+static int config_is_valid_log_level(const char* level) {
+    return config_str_eq_ci(level, "VERBOSE") ||
+           config_str_eq_ci(level, "DEBUG") ||
+           config_str_eq_ci(level, "INFO") ||
+           config_str_eq_ci(level, "WARN") ||
+           config_str_eq_ci(level, "ERROR");
+}
+
+/* Record a failure reason into the caller's buffer (if any) and return 0. */
+#define CONFIG_FAIL(...)                                  \
+    do {                                                  \
+        if (err != NULL && err_size > 0) {                \
+            snprintf(err, err_size, __VA_ARGS__);         \
+        }                                                 \
+        return 0;                                         \
+    } while (0)
+
+int config_validate_ex(const config_data_t* config, char* err, size_t err_size) {
+    int web_enabled, metrics_enabled, web_port, metrics_port;
+    const char* transport;
+
+    if (err != NULL && err_size > 0) {
+        err[0] = '\0';
+    }
+
+    /* Call economics */
     if (config_get_call_cost_cents(config) <= 0) {
-        return 0;
+        CONFIG_FAIL("call.cost_cents must be > 0 (got %d)",
+                    config_get_call_cost_cents(config));
     }
-    
+    if (config_get_call_timeout_seconds(config) <= 0) {
+        CONFIG_FAIL("call.timeout_seconds must be > 0 (got %d)",
+                    config_get_call_timeout_seconds(config));
+    }
+    if (config_get_idle_timeout_seconds(config) <= 0) {
+        CONFIG_FAIL("call.idle_timeout_seconds must be > 0 (got %d)",
+                    config_get_idle_timeout_seconds(config));
+    }
+
+    /* Hardware */
+    if (config_get_baud_rate(config) <= 0) {
+        CONFIG_FAIL("hardware.baud_rate must be > 0 (got %d)",
+                    config_get_baud_rate(config));
+    }
+
+    /* System loop */
     if (config_get_update_interval_ms(config) <= 0) {
-        return 0;
+        CONFIG_FAIL("system.update_interval_ms must be > 0 (got %d)",
+                    config_get_update_interval_ms(config));
     }
-    
+    if (config_get_max_retries(config) < 0) {
+        CONFIG_FAIL("system.max_retries must be >= 0 (got %d)",
+                    config_get_max_retries(config));
+    }
+
+    /* Logging */
+    if (!config_is_valid_log_level(config_get_log_level(config))) {
+        CONFIG_FAIL("logging.level '%s' is not one of "
+                    "VERBOSE/DEBUG/INFO/WARN/ERROR",
+                    config_get_log_level(config));
+    }
+    if (config_get_log_max_size_bytes(config) <= 0) {
+        CONFIG_FAIL("logging.max_size_bytes must be > 0 (got %d)",
+                    config_get_log_max_size_bytes(config));
+    }
+    if (config_get_log_max_files(config) < 1) {
+        CONFIG_FAIL("logging.max_files must be >= 1 (got %d)",
+                    config_get_log_max_files(config));
+    }
+
+    /* Network ports */
+    web_port = config_get_web_server_port(config);
+    metrics_port = config_get_metrics_server_port(config);
+    if (web_port < 1 || web_port > 65535) {
+        CONFIG_FAIL("web_server.port %d out of range 1..65535", web_port);
+    }
+    if (metrics_port < 1 || metrics_port > 65535) {
+        CONFIG_FAIL("metrics_server.port %d out of range 1..65535",
+                    metrics_port);
+    }
+    web_enabled = config_get_web_server_enabled(config);
+    metrics_enabled = config_get_metrics_server_enabled(config);
+    if (web_enabled && metrics_enabled && web_port == metrics_port) {
+        CONFIG_FAIL("web_server.port and metrics_server.port both set to %d "
+                    "while both servers are enabled", web_port);
+    }
+
+    /* SIP transport (only when explicitly configured) */
+    transport = config_get_string(config, "sip.transport", "");
+    if (transport[0] != '\0' &&
+        !config_str_eq_ci(transport, "udp") &&
+        !config_str_eq_ci(transport, "tcp") &&
+        !config_str_eq_ci(transport, "tls")) {
+        CONFIG_FAIL("sip.transport '%s' is not one of udp/tcp/tls", transport);
+    }
+
     return 1;
+}
+
+#undef CONFIG_FAIL
+
+int config_validate(const config_data_t* config) {
+    return config_validate_ex(config, NULL, 0);
 }
 
 void config_set_default_values(config_data_t* config) {

--- a/host/config.h
+++ b/host/config.h
@@ -18,6 +18,10 @@ config_data_t* config_get_instance(void);
 int config_load_from_file(config_data_t* config, const char* config_path);
 int config_load_from_environment(config_data_t* config);
 int config_validate(const config_data_t* config);
+/* Like config_validate(), but on failure writes a human-readable reason
+   (e.g. "web_server.port 99999 out of range 1..65535") into err, which may
+   be NULL. Returns 1 on success, 0 on the first validation failure. */
+int config_validate_ex(const config_data_t* config, char* err, size_t err_size);
 
 /* Configuration getters */
 const char* config_get_string(const config_data_t* config, const char* key, const char* default_value);

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -897,9 +897,13 @@ int main(int argc, char *argv[]) {
         logger_infof_with_category("Config", "Config loaded from %s", config_file);
     }
     
-    if (!config_validate(config)) {
-        logger_error_with_category("Config", "Configuration validation failed");
-        return 1;
+    {
+        char validate_err[256];
+        if (!config_validate_ex(config, validate_err, sizeof(validate_err))) {
+            logger_errorf_with_category("Config",
+                "Configuration validation failed: %s", validate_err);
+            return 1;
+        }
     }
     
     /* Setup logging */

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -146,6 +146,126 @@ static void test_config_validate_bad_cost(void) {
     TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
 }
 
+/* config_validate_ex fills a descriptive reason on failure and clears it on
+   success, so the operator learns which setting is wrong. */
+static void test_config_validate_ex_reports_reason(void) {
+    config_data_t cfg;
+    char err[256];
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    err[0] = 'x';
+    TEST_ASSERT_EQ_INT(config_validate_ex(&cfg, err, sizeof(err)), 1);
+    TEST_ASSERT_EQ_STR(err, "");
+
+    config_set_value(&cfg, "call.cost_cents", "-5");
+    TEST_ASSERT_EQ_INT(config_validate_ex(&cfg, err, sizeof(err)), 0);
+    TEST_ASSERT_NOT_NULL(strstr(err, "call.cost_cents"));
+}
+
+/* A NULL error buffer must be tolerated (config_validate() relies on this). */
+static void test_config_validate_ex_null_buffer(void) {
+    config_data_t cfg;
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    TEST_ASSERT_EQ_INT(config_validate_ex(&cfg, NULL, 0), 1);
+
+    config_set_value(&cfg, "call.cost_cents", "0");
+    TEST_ASSERT_EQ_INT(config_validate_ex(&cfg, NULL, 0), 0);
+}
+
+/* Out-of-range / nonsensical numeric settings are rejected. */
+static void test_config_validate_ranges(void) {
+    config_data_t cfg;
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "call.timeout_seconds", "0");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "call.idle_timeout_seconds", "-1");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "hardware.baud_rate", "0");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "logging.max_files", "0");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+}
+
+/* Web and metrics ports must be in range. */
+static void test_config_validate_ports(void) {
+    config_data_t cfg;
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "web_server.port", "99999");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "metrics_server.port", "0");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "web_server.port", "8080");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 1);
+}
+
+/* Both servers enabled on the same port is a misconfiguration. */
+static void test_config_validate_port_conflict(void) {
+    config_data_t cfg;
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+
+    config_set_value(&cfg, "web_server.enabled", "true");
+    config_set_value(&cfg, "metrics_server.enabled", "true");
+    config_set_value(&cfg, "web_server.port", "9000");
+    config_set_value(&cfg, "metrics_server.port", "9000");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+
+    /* Same port but metrics disabled: no conflict. */
+    config_set_value(&cfg, "metrics_server.enabled", "false");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 1);
+}
+
+/* Logging level and SIP transport accept only known tokens. */
+static void test_config_validate_enums(void) {
+    config_data_t cfg;
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "logging.level", "INF");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "logging.level", "warn"); /* case-insensitive */
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 1);
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "sip.transport", "sctp");
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 0);
+
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    config_set_value(&cfg, "sip.transport", "TLS"); /* case-insensitive */
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 1);
+
+    /* Unset sip.transport must not fail validation. */
+    cfg.count = 0;
+    config_set_default_values(&cfg);
+    TEST_ASSERT_EQ_INT(config_validate(&cfg), 1);
+}
+
 static void test_config_trim(void) {
     char result[64];
 
@@ -949,6 +1069,12 @@ int main(void) {
     TEST_SUITE_RUN(test_config_get_bool_variants);
     TEST_SUITE_RUN(test_config_validate_good);
     TEST_SUITE_RUN(test_config_validate_bad_cost);
+    TEST_SUITE_RUN(test_config_validate_ex_reports_reason);
+    TEST_SUITE_RUN(test_config_validate_ex_null_buffer);
+    TEST_SUITE_RUN(test_config_validate_ranges);
+    TEST_SUITE_RUN(test_config_validate_ports);
+    TEST_SUITE_RUN(test_config_validate_port_conflict);
+    TEST_SUITE_RUN(test_config_validate_enums);
     TEST_SUITE_RUN(test_config_trim);
     TEST_SUITE_RUN(test_config_null_safety);
     TEST_SUITE_RUN(test_config_overwrite_value);


### PR DESCRIPTION
## Summary

`config_validate()` previously checked only `call.cost_cents` and `system.update_interval_ms`, and returned a bare pass/fail. A typo or out-of-range value would either start the daemon misconfigured (silently falling back to a default) or abort with only `Configuration validation failed` and no indication of which setting was wrong.

This PR makes config validation strict and diagnostic:

- **`config_validate_ex(config, err, err_size)`** — new entry point that range-checks every numeric setting and validates enum-style settings:
  - `call.cost_cents`, `call.timeout_seconds`, `call.idle_timeout_seconds` must be `> 0`
  - `hardware.baud_rate`, `system.update_interval_ms` must be `> 0`; `system.max_retries` `>= 0`
  - `logging.level` ∈ {VERBOSE, DEBUG, INFO, WARN, ERROR} (case-insensitive); `logging.max_size_bytes > 0`; `logging.max_files >= 1`
  - `web_server.port` and `metrics_server.port` bounded to `1..65535`
  - rejects a **port collision** when both the web and metrics servers are enabled on the same port
  - `sip.transport` (only when explicitly set) ∈ {udp, tcp, tls} (case-insensitive)
- On the first failure it writes a human-readable reason into the caller's buffer (e.g. `web_server.port 99999 out of range 1..65535`).
- **`config_validate()`** now wraps `config_validate_ex(config, NULL, 0)`, preserving the existing signature and behaviour for all current callers.
- **Daemon startup** logs the specific reason instead of the generic message, so an operator sees exactly what to fix.

The validator stays pure (no logger/hardware dependency), so it remains fully unit-testable on the Mac. It deliberately does **not** enumerate plugin-owned keys, keeping in line with the project's dynamic-plugin design.

## Testing

- `make test` — all unit + scenario tests pass (unit suite 59 → 65 with 6 new tests).
- New unit tests cover each range/enum check, the port-conflict case, the descriptive-reason path, and the NULL-buffer path.
- Compiles clean under `-Wall -Wextra -Wdeclaration-after-statement -Werror -std=gnu89`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)