### PR TITLE
state_persistence: validate restored state so a corrupt file can't restore a bogus balance

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -124,7 +124,7 @@ all: daemon
 # Unit test binary
 UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o updater.o
 
-tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h millennium_sdk.h updater.h
+tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h millennium_sdk.h updater.h state_persistence.h
 	gcc tests/unit_tests.c -o tests/unit_tests.o -c $(CFLAGS) -I.
 
 # Unit tests don't use time wrapping; link ALSA on Linux for jukebox

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -997,7 +997,9 @@ int main(int argc, char *argv[]) {
     /* Restore persisted state */
     {
         persisted_state_t ps;
-        if (state_persistence_load(&ps, state_file_path) == 0) {
+        char load_err[160];
+        if (state_persistence_load_ex(&ps, state_file_path,
+                                      load_err, sizeof(load_err)) == 0) {
             logger_infof_with_category("Daemon",
                 "Restored state: coins=%d, plugin=%s, last_state=%d",
                 ps.inserted_cents, ps.active_plugin, ps.last_state);
@@ -1021,6 +1023,12 @@ int main(int argc, char *argv[]) {
                 daemon_state_update_activity(daemon_state);
                 pthread_mutex_unlock(&daemon_state_mutex);
             }
+        } else if (load_err[0] != '\0') {
+            /* File existed but was corrupt: start fresh, but say why. */
+            logger_warnf_with_category("Daemon",
+                "Ignoring corrupt state file %s: %s (starting fresh)",
+                state_file_path, load_err);
+            metrics_increment_counter("corrupt_state_loads", 1);
         }
     }
 

--- a/host/state_persistence.c
+++ b/host/state_persistence.c
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <ctype.h>
+#include <errno.h>
 
 int state_persistence_save(const persisted_state_t *state, const char *filepath) {
     FILE *f;
@@ -42,9 +44,62 @@ int state_persistence_save(const persisted_state_t *state, const char *filepath)
     return 0;
 }
 
-int state_persistence_load(persisted_state_t *state, const char *filepath) {
+/* Record a corruption reason into the caller's buffer (if any). */
+#define STATE_FAIL(...)                                   \
+    do {                                                  \
+        if (err != NULL && err_size > 0) {                \
+            snprintf(err, err_size, __VA_ARGS__);         \
+        }                                                 \
+    } while (0)
+
+/*
+ * Parse a base-10 integer that occupies the entire (whitespace-trimmed)
+ * string. Returns 0 and stores the value in *out on success; -1 for any
+ * malformed input: empty, non-numeric, trailing junk, or out of long range.
+ * Unlike atoi(), garbage does not silently become 0.
+ */
+static int parse_strict_long(const char *s, long *out) {
+    char *end;
+    long v;
+
+    while (*s == ' ' || *s == '\t' || *s == '\r') s++;
+    if (*s == '\0') return -1;
+
+    errno = 0;
+    v = strtol(s, &end, 10);
+    if (end == s) return -1;          /* no digits consumed */
+    if (errno == ERANGE) return -1;   /* overflowed long */
+
+    while (*end == ' ' || *end == '\t' || *end == '\r') end++;
+    if (*end != '\0') return -1;      /* trailing junk after the number */
+
+    *out = v;
+    return 0;
+}
+
+/*
+ * A persisted plugin name is trusted only if it fits the field and contains
+ * nothing but printable characters. The empty string is valid and means "no
+ * active plugin". This rejects control bytes and truncated/oversized names
+ * that a torn write or hand-edit could leave behind.
+ */
+static int plugin_name_is_valid(const char *s) {
+    size_t i;
+    size_t len = strlen(s);
+
+    if (len >= 64) return 0;          /* would not fit persisted_state_t.active_plugin */
+    for (i = 0; i < len; i++) {
+        if (!isprint((unsigned char)s[i])) return 0;
+    }
+    return 1;
+}
+
+int state_persistence_load_ex(persisted_state_t *state, const char *filepath,
+                              char *err, size_t err_size) {
     FILE *f;
     char line[256];
+
+    if (err != NULL && err_size > 0) err[0] = '\0';
 
     if (!state || !filepath) return -1;
 
@@ -52,30 +107,65 @@ int state_persistence_load(persisted_state_t *state, const char *filepath) {
 
     f = fopen(filepath, "r");
     if (!f) {
+        /* Absent file is normal first-boot, not corruption: leave err empty. */
         return -1;
     }
 
     while (fgets(line, sizeof(line), f)) {
         char *eq = strchr(line, '=');
+        char *key;
+        char *val;
         char *newline;
         if (!eq) continue;
 
         *eq = '\0';
-        eq++;
+        key = line;
+        val = eq + 1;
 
-        newline = strchr(eq, '\n');
+        newline = strchr(val, '\n');
         if (newline) *newline = '\0';
 
-        if (strcmp(line, "inserted_cents") == 0) {
-            state->inserted_cents = atoi(eq);
-        } else if (strcmp(line, "last_state") == 0) {
-            state->last_state = atoi(eq);
-        } else if (strcmp(line, "active_plugin") == 0) {
-            strncpy(state->active_plugin, eq, sizeof(state->active_plugin) - 1);
+        if (strcmp(key, "inserted_cents") == 0) {
+            long v;
+            if (parse_strict_long(val, &v) != 0 ||
+                v < 0 || v > STATE_MAX_INSERTED_CENTS) {
+                STATE_FAIL("inserted_cents out of range 0..%d (got '%s')",
+                           STATE_MAX_INSERTED_CENTS, val);
+                fclose(f);
+                memset(state, 0, sizeof(persisted_state_t));
+                return -1;
+            }
+            state->inserted_cents = (int)v;
+        } else if (strcmp(key, "last_state") == 0) {
+            long v;
+            if (parse_strict_long(val, &v) != 0 ||
+                v < (long)DAEMON_STATE_INVALID ||
+                v > (long)DAEMON_STATE_CALL_ACTIVE) {
+                STATE_FAIL("last_state out of range %d..%d (got '%s')",
+                           (int)DAEMON_STATE_INVALID,
+                           (int)DAEMON_STATE_CALL_ACTIVE, val);
+                fclose(f);
+                memset(state, 0, sizeof(persisted_state_t));
+                return -1;
+            }
+            state->last_state = (int)v;
+        } else if (strcmp(key, "active_plugin") == 0) {
+            if (!plugin_name_is_valid(val)) {
+                STATE_FAIL("active_plugin is not a valid name");
+                fclose(f);
+                memset(state, 0, sizeof(persisted_state_t));
+                return -1;
+            }
+            strncpy(state->active_plugin, val, sizeof(state->active_plugin) - 1);
             state->active_plugin[sizeof(state->active_plugin) - 1] = '\0';
         }
+        /* Unknown keys are ignored for forward compatibility. */
     }
 
     fclose(f);
     return 0;
+}
+
+int state_persistence_load(persisted_state_t *state, const char *filepath) {
+    return state_persistence_load_ex(state, filepath, NULL, 0);
 }

--- a/host/state_persistence.h
+++ b/host/state_persistence.h
@@ -1,6 +1,7 @@
 #ifndef STATE_PERSISTENCE_H
 #define STATE_PERSISTENCE_H
 
+#include <stddef.h>
 #include "daemon_state.h"
 
 typedef struct {
@@ -8,6 +9,13 @@ typedef struct {
     int last_state;         /* daemon_state_t enum value */
     char active_plugin[64];
 } persisted_state_t;
+
+/*
+ * Upper bound on a restorable coin balance. A real payphone session never
+ * holds anywhere near $1000; a value above this in the state file indicates
+ * corruption (overflow, a hand-edit, or a torn write), not a real balance.
+ */
+#define STATE_MAX_INSERTED_CENTS 100000
 
 /*
  * Save current state to disk. Uses fsync for durability.
@@ -21,5 +29,22 @@ int state_persistence_save(const persisted_state_t *state, const char *filepath)
  * On failure, *state is zeroed out.
  */
 int state_persistence_load(persisted_state_t *state, const char *filepath);
+
+/*
+ * Like state_persistence_load(), but every value read from disk is
+ * range-checked before it is trusted: inserted_cents must be a non-negative
+ * integer in 0..STATE_MAX_INSERTED_CENTS, last_state must be a valid
+ * daemon_state_t enum value, and active_plugin must be a printable,
+ * length-bounded name. Any malformed or out-of-range field fails the load
+ * (returning -1 with *state zeroed) so a corrupt file can never restore a
+ * bogus coin balance or state.
+ *
+ * On a corrupt file, a human-readable reason is written to err (if non-NULL
+ * and err_size > 0). When the file is simply absent, the load fails but err
+ * is left empty, so callers can distinguish "no saved state" (normal first
+ * boot) from "corrupt saved state" (worth warning about).
+ */
+int state_persistence_load_ex(persisted_state_t *state, const char *filepath,
+                              char *err, size_t err_size);
 
 #endif /* STATE_PERSISTENCE_H */

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -9,7 +9,9 @@
 #include "../updater.h"
 #include "../plugin_sdk.h"
 #include "../clock_source.h"
+#include "../state_persistence.h"
 #include <stdlib.h>
+#include <stdio.h>
 
 /* ── Stubs for linker (plugins.c references these) ──────────────── */
 
@@ -936,6 +938,136 @@ static void test_logger_queue_stats(void) {
     remove(path);
 }
 
+/* ── State persistence (load validation) ────────────────────────── */
+
+/* Write contents to a temp file so the loader has something to parse. */
+static void sp_write_file(const char *path, const char *contents) {
+    FILE *f = fopen(path, "w");
+    if (f) {
+        fputs(contents, f);
+        fclose(f);
+    }
+}
+
+static void test_state_load_round_trip(void) {
+    const char *path = "/tmp/millennium_state_good.test";
+    persisted_state_t saved;
+    persisted_state_t loaded;
+
+    saved.inserted_cents = 75;
+    saved.last_state = (int)DAEMON_STATE_IDLE_UP;
+    strcpy(saved.active_plugin, "Classic Phone");
+
+    TEST_ASSERT_EQ_INT(state_persistence_save(&saved, path), 0);
+    TEST_ASSERT_EQ_INT(state_persistence_load(&loaded, path), 0);
+    TEST_ASSERT_EQ_INT(loaded.inserted_cents, 75);
+    TEST_ASSERT_EQ_INT(loaded.last_state, (int)DAEMON_STATE_IDLE_UP);
+    TEST_ASSERT_EQ_STR(loaded.active_plugin, "Classic Phone");
+    remove(path);
+}
+
+static void test_state_load_absent_file_is_silent(void) {
+    const char *path = "/tmp/millennium_state_absent.test";
+    persisted_state_t ps;
+    char err[128];
+
+    remove(path);
+    /* Missing file fails the load but is NOT flagged as corruption. */
+    TEST_ASSERT_EQ_INT(state_persistence_load_ex(&ps, path, err, sizeof(err)), -1);
+    TEST_ASSERT_EQ_STR(err, "");
+    TEST_ASSERT_EQ_INT(ps.inserted_cents, 0);
+}
+
+static void test_state_load_rejects_negative_cents(void) {
+    const char *path = "/tmp/millennium_state_neg.test";
+    persisted_state_t ps;
+    char err[128];
+
+    sp_write_file(path, "inserted_cents=-50\nactive_plugin=Classic Phone\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load_ex(&ps, path, err, sizeof(err)), -1);
+    TEST_ASSERT(err[0] != '\0');                 /* corruption is reported */
+    TEST_ASSERT_EQ_INT(ps.inserted_cents, 0);    /* and the state is zeroed */
+    TEST_ASSERT_EQ_STR(ps.active_plugin, "");
+    remove(path);
+}
+
+static void test_state_load_rejects_huge_cents(void) {
+    const char *path = "/tmp/millennium_state_huge.test";
+    persisted_state_t ps;
+    char err[128];
+
+    sp_write_file(path, "inserted_cents=999999999\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load_ex(&ps, path, err, sizeof(err)), -1);
+    TEST_ASSERT(err[0] != '\0');
+    TEST_ASSERT_EQ_INT(ps.inserted_cents, 0);
+    remove(path);
+}
+
+static void test_state_load_rejects_nonnumeric_cents(void) {
+    const char *path = "/tmp/millennium_state_junk.test";
+    persisted_state_t ps;
+    char err[128];
+
+    /* atoi() would silently turn this into 0; strict parsing must reject it. */
+    sp_write_file(path, "inserted_cents=12abc\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load_ex(&ps, path, err, sizeof(err)), -1);
+    TEST_ASSERT(err[0] != '\0');
+    remove(path);
+}
+
+static void test_state_load_accepts_boundary_cents(void) {
+    const char *path = "/tmp/millennium_state_max.test";
+    persisted_state_t ps;
+    char buf[64];
+
+    snprintf(buf, sizeof(buf), "inserted_cents=%d\n", STATE_MAX_INSERTED_CENTS);
+    sp_write_file(path, buf);
+    TEST_ASSERT_EQ_INT(state_persistence_load(&ps, path), 0);
+    TEST_ASSERT_EQ_INT(ps.inserted_cents, STATE_MAX_INSERTED_CENTS);
+    remove(path);
+}
+
+static void test_state_load_rejects_bad_last_state(void) {
+    const char *path = "/tmp/millennium_state_badstate.test";
+    persisted_state_t ps;
+    char err[128];
+
+    sp_write_file(path, "last_state=99\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load_ex(&ps, path, err, sizeof(err)), -1);
+    TEST_ASSERT(err[0] != '\0');
+    remove(path);
+}
+
+static void test_state_load_rejects_control_chars_in_plugin(void) {
+    const char *path = "/tmp/millennium_state_ctrl.test";
+    persisted_state_t ps;
+    char err[128];
+
+    /* A bell/control byte in the name signals a torn write or tampering. */
+    sp_write_file(path, "active_plugin=Class\x07ic\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load_ex(&ps, path, err, sizeof(err)), -1);
+    TEST_ASSERT(err[0] != '\0');
+    remove(path);
+}
+
+static void test_state_load_ignores_unknown_keys(void) {
+    const char *path = "/tmp/millennium_state_unknown.test";
+    persisted_state_t ps;
+
+    /* Forward compatibility: an unrecognized key must not fail the load. */
+    sp_write_file(path, "inserted_cents=25\nfuture_field=whatever\n");
+    TEST_ASSERT_EQ_INT(state_persistence_load(&ps, path), 0);
+    TEST_ASSERT_EQ_INT(ps.inserted_cents, 25);
+    remove(path);
+}
+
+static void test_state_load_null_safety(void) {
+    persisted_state_t ps;
+    /* NULL arguments must fail cleanly rather than crash. */
+    TEST_ASSERT_EQ_INT(state_persistence_load(NULL, "/tmp/x"), -1);
+    TEST_ASSERT_EQ_INT(state_persistence_load(&ps, NULL), -1);
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -1017,6 +1149,18 @@ int main(void) {
     TEST_SUITE_BEGIN("Logger");
     TEST_SUITE_RUN(test_logger_async_file_write);
     TEST_SUITE_RUN(test_logger_queue_stats);
+
+    TEST_SUITE_BEGIN("State Persistence");
+    TEST_SUITE_RUN(test_state_load_round_trip);
+    TEST_SUITE_RUN(test_state_load_absent_file_is_silent);
+    TEST_SUITE_RUN(test_state_load_rejects_negative_cents);
+    TEST_SUITE_RUN(test_state_load_rejects_huge_cents);
+    TEST_SUITE_RUN(test_state_load_rejects_nonnumeric_cents);
+    TEST_SUITE_RUN(test_state_load_accepts_boundary_cents);
+    TEST_SUITE_RUN(test_state_load_rejects_bad_last_state);
+    TEST_SUITE_RUN(test_state_load_rejects_control_chars_in_plugin);
+    TEST_SUITE_RUN(test_state_load_ignores_unknown_keys);
+    TEST_SUITE_RUN(test_state_load_null_safety);
 
     TEST_REPORT();
 }


### PR DESCRIPTION
## Problem

`state_persistence_load()` trusted `/etc/millennium`'s persisted state file completely. Every field went through bare `atoi()` — which silently turns garbage into `0` — and nothing was range-checked. A torn write (the atomic-rename in `save()` post-dates this load path), disk corruption, or a hand-edit could restore:

- a **negative or absurd `inserted_cents`** — this is real credit toward a paid call (money),
- an **out-of-range `last_state`** enum, or
- a **control-byte / oversized `active_plugin`** name,

and the daemon would happily log `Restored state: …` and run with it.

## Change

Add `state_persistence_load_ex(state, filepath, err, err_size)`:

- **Strict parsing** — `strtol` with no trailing junk and `ERANGE` checks, instead of `atoi` (so `"12abc"` and `"999999999"` are rejected, not silently accepted).
- **Range checks** — `inserted_cents` in `0..STATE_MAX_INSERTED_CENTS` ($1000 cap), `last_state` a valid `daemon_state_t`, `active_plugin` printable and length-bounded.
- **Fail safe** — any bad field fails the load with `*state` zeroed, so a corrupt file starts the daemon **fresh** rather than misconfigured.
- **Diagnostics** — the reason is written to the caller's buffer; an *absent* file (normal first boot) leaves it empty, so callers distinguish "no state" from "corrupt state". Unknown keys are ignored for forward compatibility.

`state_persistence_load()` now wraps `_ex` (NULL buffer), preserving its signature. Daemon startup logs the specific reason on corruption and bumps a `corrupt_state_loads` metric.

This extends the same "strict, range-checked validation with descriptive diagnostics" treatment recently applied to the config parser to the *other* piece of untrusted input the daemon ingests at startup.

## Tests

10 new unit tests (round trip, absent-vs-corrupt distinction, and each rejection path — negative/huge/non-numeric cents, boundary value, bad enum, control chars, unknown keys, NULL safety). Full suite: **69 passed, 0 failed**; all scenario tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)