### PR TITLE
config: parse integer settings strictly instead of atoi()-ing garbage to 0

### DIFF
--- a/host/config.c
+++ b/host/config.c
@@ -1,9 +1,11 @@
 #define _POSIX_C_SOURCE 200112L
 #include "config.h"
+#include "logger.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <errno.h>
 
 /* Global config instance */
 config_data_t* g_config = NULL;
@@ -132,15 +134,44 @@ const char* config_get_string(const config_data_t* config, const char* key, cons
 
 int config_get_int(const config_data_t* config, const char* key, int default_value) {
     const char* value_str;
-    int value;
-    
+    const char* s;
+    char* end;
+    long value;
+
     value_str = config_get_string(config, key, NULL);
     if (value_str == NULL) {
         return default_value;
     }
-    
-    value = atoi(value_str);
-    return value;
+
+    /*
+     * Strict parse: reject empty, non-numeric, trailing junk, or out-of-int-range
+     * input rather than letting atoi() silently coerce garbage to 0. A typo in
+     * the config file then falls back to the documented default (and is logged)
+     * instead of, say, zeroing a port or disabling a timeout. Mirrors the strict
+     * parsing the state file already uses for the same reason.
+     */
+    s = value_str;
+    while (*s == ' ' || *s == '\t') s++;
+    if (*s == '\0') {
+        logger_warnf_with_category("Config",
+            "%s is empty; using default %d", key, default_value);
+        return default_value;
+    }
+
+    errno = 0;
+    value = strtol(s, &end, 10);
+    while (*end == ' ' || *end == '\t' || *end == '\r' || *end == '\n') end++;
+    /* value != (long)(int)value catches int overflow portably: on a 32-bit
+     * long (the Pi) it can never fire, so it avoids a -Wtype-limits warning. */
+    if (end == s || *end != '\0' || errno == ERANGE ||
+        value != (long)(int)value) {
+        logger_warnf_with_category("Config",
+            "%s='%s' is not a valid integer; using default %d",
+            key, value_str, default_value);
+        return default_value;
+    }
+
+    return (int)value;
 }
 
 int config_get_bool(const config_data_t* config, const char* key, int default_value) {

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -112,6 +112,29 @@ static void test_config_get_int_default(void) {
     TEST_ASSERT_EQ_INT(config_get_int(&cfg, "nonexistent", 42), 42);
 }
 
+static void test_config_get_int_strict(void) {
+    config_data_t cfg;
+    cfg.count = 0;
+
+    /* Well-formed values parse, including sign and surrounding whitespace. */
+    config_set_value(&cfg, "good", "8080");
+    TEST_ASSERT_EQ_INT(config_get_int(&cfg, "good", -1), 8080);
+    config_set_value(&cfg, "neg", "-42");
+    TEST_ASSERT_EQ_INT(config_get_int(&cfg, "neg", 0), -42);
+    config_set_value(&cfg, "padded", "  17  ");
+    TEST_ASSERT_EQ_INT(config_get_int(&cfg, "padded", 0), 17);
+
+    /* Malformed values fall back to the default instead of atoi()'s silent 0. */
+    config_set_value(&cfg, "garbage", "abc");
+    TEST_ASSERT_EQ_INT(config_get_int(&cfg, "garbage", 9600), 9600);
+    config_set_value(&cfg, "trailing", "96O0");        /* letter O, not zero */
+    TEST_ASSERT_EQ_INT(config_get_int(&cfg, "trailing", 9600), 9600);
+    config_set_value(&cfg, "empty", "   ");
+    TEST_ASSERT_EQ_INT(config_get_int(&cfg, "empty", 33), 33);
+    config_set_value(&cfg, "huge", "99999999999999999999");
+    TEST_ASSERT_EQ_INT(config_get_int(&cfg, "huge", 50), 50);
+}
+
 static void test_config_get_bool_variants(void) {
     config_data_t cfg;
     cfg.count = 0;
@@ -946,6 +969,7 @@ int main(void) {
     TEST_SUITE_RUN(test_config_set_and_get);
     TEST_SUITE_RUN(test_config_get_string_default);
     TEST_SUITE_RUN(test_config_get_int_default);
+    TEST_SUITE_RUN(test_config_get_int_strict);
     TEST_SUITE_RUN(test_config_get_bool_variants);
     TEST_SUITE_RUN(test_config_validate_good);
     TEST_SUITE_RUN(test_config_validate_bad_cost);


### PR DESCRIPTION
## Problem

`config_get_int()` parsed every integer setting with `atoi()`, which silently coerces any malformed value to `0`. A typo in `/etc/millennium/daemon.conf` such as:

- `hardware.baud_rate=96O0` (letter O instead of zero)
- `call.timeout_seconds=` (empty)
- `metrics_server.port=off`

would quietly zero the setting with no warning — disabling a timeout, zeroing a port, etc. This is the same silent-coercion bug class that `077fb52` just fixed in the state-file parser (`atoi` → strict `strtol`).

## Fix

Parse with `strtol()` and reject empty, non-numeric, trailing-junk, or out-of-`int`-range input. On malformed input, log a warning under the `Config` category and fall back to the caller's documented default. Well-formed values — including a leading sign and surrounding whitespace — are unaffected, so this is behavior-preserving for any valid config.

The overflow guard is written as `value != (long)(int)value` so it compiles warning-free under `-Werror` on both the 64-bit Mac and the 32-bit Pi (a direct `INT_MAX` comparison would trip `-Wtype-limits` where `long == int`).

`logger_get_instance()` lazily initializes, so the warning is safe to emit even during early config load before `logger_init()`.

## Testing

- `make test` — all unit + scenario tests pass (60/60 unit).
- Added `test_config_get_int_strict` covering valid (signed, whitespace-padded), garbage, trailing-junk, empty, and overflow cases.
- Verified `config.c` compiles clean under the project's `-std=gnu89 -Wall -Wextra -Wdeclaration-after-statement -Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)