### PR TITLE
classic_phone: add '*' correct key to erase the last dialed digit

### DIFF
--- a/host/plugins/classic_phone.c
+++ b/host/plugins/classic_phone.c
@@ -90,6 +90,18 @@ static int classic_phone_handle_keypad(char key) {
         classic_phone_update_display();
         classic_phone_check_and_call();
     }
+    /* '*' is the "correct" key: erase the last dialed digit so a misdial can be
+     * fixed without hanging up. Only meaningful while building a number with the
+     * handset up (handset DTMF is handled above); ignored with an empty buffer. */
+    else if (key == '*' && daemon_state &&
+             daemon_state->current_state == DAEMON_STATE_IDLE_UP &&
+             !classic_phone_data.is_dialing && !classic_phone_data.is_in_call &&
+             classic_phone_data.keypad_length > 0) {
+        audio_tones_play_dtmf(key);
+        classic_phone_remove_last_key();
+        classic_phone_data.last_activity = sdk_now();
+        classic_phone_update_display();
+    }
     return 0;
 }
 
@@ -281,16 +293,13 @@ static void classic_phone_add_key(char key) {
     }
 }
 
-/* Helper function for future keypad functionality - kept for extensibility */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
+/* Erase the last dialed digit (the '*' "correct" key). */
 static void classic_phone_remove_last_key(void) {
     if (classic_phone_data.keypad_length > 0) {
         classic_phone_data.keypad_length--;
         classic_phone_data.keypad_buffer[classic_phone_data.keypad_length] = '\0';
     }
 }
-#pragma GCC diagnostic pop
 
 static int classic_phone_has_enough_money(void) {
     return classic_phone_data.inserted_cents >= classic_phone_data.call_cost_cents;

--- a/host/tests/test_correct_key.scenario
+++ b/host/tests/test_correct_key.scenario
@@ -1,0 +1,46 @@
+# Test: '*' correct key erases the last dialed digit
+# Verifies that pressing '*' deletes the most recently dialed digit so a
+# misdial can be fixed without hanging up, that it bottoms out cleanly on an
+# empty buffer, and that a corrected number still places a call normally.
+
+# Phone starts with receiver down
+assert_state IDLE_DOWN
+
+# Pick up handset
+hook_up
+assert_state IDLE_UP
+assert_display Insert 50c
+
+# Dial a 4-digit prefix, then notice the last digit is wrong
+keys 5551
+assert_display (555) 1__-____
+
+# Press '*' to erase the last digit
+key *
+assert_display (555) ___-____
+assert_no_display (555) 1__-____
+
+# Erase the remaining digits one at a time
+key *
+assert_display (55_) ___-____
+key *
+assert_display (5__) ___-____
+key *
+assert_display (___) ___-____
+
+# '*' on an empty buffer is a clean no-op
+key *
+assert_display (___) ___-____
+
+# Correction left coins untouched: pay, then dial the right number and connect
+coin 25
+coin 25
+assert_display Have: 50c
+keys 5551234567
+assert_display Call active
+assert_state CALL_ACTIVE
+
+# Hang up
+hook_down
+assert_state IDLE_DOWN
+assert_display Lift receiver


### PR DESCRIPTION
## Summary

Adds a **`*` "correct" key** to the Classic Phone plugin so a caller can fix a misdial without hanging up and starting over.

While building a number with the handset up (`IDLE_UP`), pressing `*` erases the most recently dialed digit — a natural backspace that mirrors the dialing UX. Behavior:

- **No-op on an empty buffer** — nothing to erase.
- **Ignored during/placing a call** — there, `*` is still sent as DTMF for IVR/voicemail menus (existing `#95` path, untouched).
- Plays DTMF feedback, refreshes the idle-timeout activity timer, and re-renders the display.

This wires up `classic_phone_remove_last_key()`, which previously existed only as **dead code behind a `-Wunused-function` suppression** labelled "kept for extensibility." The pragma is removed now that the function has a real caller.

## Why

Before this change the only way to back out of a wrong digit was to drop the handset, which resets coins and the keypad buffer. A backspace key is the standard fix and the helper for it was already (almost) in place.

## Testing

- New `host/tests/test_correct_key.scenario` covers: single-digit erase, erasing down to empty, the empty-buffer no-op, and successfully placing a call after a correction.
- `make test` — all 59 unit tests and all scenarios pass; clean `-Wall -Wextra -Werror` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)