### PR TITLE
metrics: record connected-call duration as a histogram

### DIFF
--- a/host/plugins/classic_phone.c
+++ b/host/plugins/classic_phone.c
@@ -362,6 +362,16 @@ static void classic_phone_start_call(void) {
 }
 
 static void classic_phone_end_call(void) {
+    /* Record how long the connected call lasted so operators get a duration
+     * distribution (mean/median/p95/p99) via the metrics histogram. Only a
+     * call that actually connected has a non-zero start time. */
+    if (classic_phone_data.is_in_call && classic_phone_data.call_start_time > 0) {
+        double duration = (double)(sdk_now() - classic_phone_data.call_start_time);
+        if (duration < 0) duration = 0;
+        metrics_observe_histogram("call_duration_seconds", duration);
+    }
+    classic_phone_data.call_start_time = 0;
+
     classic_phone_data.is_dialing = 0;
     classic_phone_data.is_in_call = 0;
     classic_phone_data.is_emergency_call = 0;

--- a/host/simulator.c
+++ b/host/simulator.c
@@ -430,6 +430,10 @@ static void sim_check_pending_call(void) {
     if (!sim_call_pending) return;
     sim_call_pending = 0;
     sim_call_active  = 1;
+    /* A fresh call must not inherit a teardown flag left set by the previous
+     * call's hangup (e.g. after a local hook_down), which would otherwise fire
+     * on this call's first `wait` tick and drop it on-hook prematurely. */
+    sim_hangup_called = 0;
 
     ev = call_state_event_create("CALL_ESTABLISHED", NULL, EVENT_CALL_STATE_ACTIVE);
     if (ev) {
@@ -630,6 +634,46 @@ static int run_scenario(const char *path) {
             }
         }
 
+        /* ── assert_histogram_count <name> <expected> ───────────────
+         * Assert a metrics histogram has recorded exactly <expected>
+         * observations (e.g. the number of calls whose duration we logged). */
+        else if (strncmp(cmd, "assert_histogram_count ", 23) == 0) {
+            metrics_histogram_stats_t stats;
+            char hname[64];
+            unsigned long long expected = 0;
+            if (sscanf(cmd + 23, "%63s %llu", hname, &expected) == 2 &&
+                metrics_get_histogram_stats(hname, &stats) == 0 &&
+                (unsigned long long)stats.count == expected) {
+                fprintf(stderr, "  PASS: histogram %s count == %llu\n", hname, expected);
+            } else {
+                unsigned long long got = (metrics_get_histogram_stats(hname, &stats) == 0)
+                                       ? (unsigned long long)stats.count : 0ULL;
+                fprintf(stderr, "  FAIL: histogram %s count: expected %llu, got %llu\n",
+                        hname, expected, got);
+                failures++;
+            }
+        }
+
+        /* ── assert_histogram_sum <name> <expected> ─────────────────
+         * Assert the sum of a histogram's observations equals <expected>
+         * (e.g. total recorded call seconds). Compared with a small epsilon. */
+        else if (strncmp(cmd, "assert_histogram_sum ", 21) == 0) {
+            metrics_histogram_stats_t stats;
+            char hname[64];
+            double expected = 0.0;
+            if (sscanf(cmd + 21, "%63s %lf", hname, &expected) == 2 &&
+                metrics_get_histogram_stats(hname, &stats) == 0 &&
+                stats.sum >= expected - 0.001 && stats.sum <= expected + 0.001) {
+                fprintf(stderr, "  PASS: histogram %s sum == %.2f\n", hname, expected);
+            } else {
+                double got = (metrics_get_histogram_stats(hname, &stats) == 0)
+                           ? stats.sum : -1.0;
+                fprintf(stderr, "  FAIL: histogram %s sum: expected %.2f, got %.2f\n",
+                        hname, expected, got);
+                failures++;
+            }
+        }
+
         /* ── print (debug) ───────────────────────────────────────── */
         else if (strcmp(cmd, "print") == 0) {
             fprintf(stderr, "  state=%s  coins=%d  display=\"%s\" | \"%s\"\n",
@@ -806,6 +850,10 @@ int main(int argc, char *argv[]) {
         sim_call_active      = 0;
         sim_hangup_called    = 0;
         sim_time_init();
+        /* Give each scenario a clean metrics slate so counter/histogram
+         * assertions are isolated and don't accumulate across files. */
+        metrics_cleanup();
+        metrics_init();
         plugins_activate("Classic Phone");
 
         failures = run_scenario(argv[i]);

--- a/host/tests/test_call_duration.scenario
+++ b/host/tests/test_call_duration.scenario
@@ -1,0 +1,51 @@
+# Test: call duration is recorded as a metrics histogram
+# Verifies that every connected call contributes its length (in seconds) to the
+# `call_duration_seconds` histogram, so operators get a duration distribution
+# (mean/median/p95/p99) exported via /metrics. Covers both ways a call ends:
+# the local handset going down, and the remote party hanging up.
+
+# Phone starts with receiver down
+assert_state IDLE_DOWN
+
+# ── Call 1: ends when the local handset is hung up ──────────────────
+hook_up
+assert_state IDLE_UP
+coin 25
+coin 25
+assert_display Have: 50c
+keys 5551234567
+assert_display Call active
+assert_state CALL_ACTIVE
+
+# Stay connected for 3 seconds, then hang up locally
+wait 3
+hook_down
+assert_state IDLE_DOWN
+
+# One call recorded, totalling 3 seconds
+assert_histogram_count call_duration_seconds 1
+assert_histogram_sum call_duration_seconds 3.00
+
+# ── Call 2: ends when the remote party hangs up ─────────────────────
+hook_up
+assert_state IDLE_UP
+coin 25
+coin 25
+assert_display Have: 50c
+keys 5559876543
+assert_display Call active
+assert_state CALL_ACTIVE
+
+# Stay connected for 2 seconds, then the far end drops the call
+wait 2
+call_ended
+assert_state IDLE_UP
+
+# Two calls recorded now, totalling 3 + 2 = 5 seconds
+assert_histogram_count call_duration_seconds 2
+assert_histogram_sum call_duration_seconds 5.00
+
+# Hang up cleanly — no extra duration recorded (no call was active)
+hook_down
+assert_state IDLE_DOWN
+assert_histogram_count call_duration_seconds 2


### PR DESCRIPTION
## Summary

The metrics layer already shipped a **complete histogram implementation** — `metrics_observe_histogram`, percentile stats (mean/median/p95/p99), and both Prometheus and JSON export — but **nothing in the daemon ever observed a histogram**. The whole percentile machinery was effectively dead code.

This PR puts it to work by recording **connected-call duration** into a `call_duration_seconds` histogram, giving operators a real duration distribution from `/metrics` (port 8080) alongside the existing call counters.

## What changed

- **`classic_phone.c`** — when a call ends, observe `sdk_now() - call_start_time` into `call_duration_seconds`. The Classic Phone plugin owns the call lifecycle and already tracks `call_start_time`, and it runs unchanged on the Pi, in the simulator, and in unit tests — so this single instrumentation point covers **every** way a call ends: local hang-up, remote hang-up, and call timeout. Reads the clock via `sdk_now()` (the `mclock` seam), so it works under the simulator's advanceable clock too.

- **Scenario harness (`simulator.c`)**
  - New `assert_histogram_count` / `assert_histogram_sum` commands so metric behaviour can be asserted directly in scenario tests.
  - Reset metrics (`metrics_cleanup()` + `metrics_init()`) between scenario files, matching the existing per-scenario `daemon_state` reset — so metric assertions are isolated instead of accumulating across the `tests/*.scenario` glob run.
  - Clear the stale SIP-teardown flag (`sim_hangup_called`) when a new call connects, so a flag left set by a previous call's hang-up can't drop the next call on-hook on its first `wait` tick.

- **`test_call_duration.scenario`** — new test covering both end paths (local + remote hang-up) and accumulation across two calls (count 1→2, sum 3.00s→5.00s).

## Testing

- `make test` — all unit + scenario tests pass.
- Changed files compile clean under the project's strict flags (`-std=gnu89 -Wall -Wextra -Wdeclaration-after-statement -Werror`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)