### PR TITLE
metrics: fix heap overflow in Prometheus/JSON exporters

### DIFF
--- a/host/metrics.c
+++ b/host/metrics.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdarg.h>
 #include <math.h>
 #include <limits.h>
 #include <ctype.h>
@@ -529,153 +530,198 @@ int metrics_reset_all(void) {
 #define METRICS_EXPORT_INITIAL_SIZE 8192
 #define METRICS_EXPORT_MAX_SIZE (256 * 1024)
 
+/*
+ * Safely append printf-style text to a heap buffer that grows on demand.
+ *
+ * *buf / *cap / *pos track the allocation, its capacity, and the bytes used
+ * so far (excluding the terminating NUL). The exporters historically did
+ *   pos += snprintf(buf + pos, cap - pos, ...);
+ * which is unsafe: snprintf returns the length it *would* have written, so
+ * once the buffer fills, pos runs past cap, the `cap - pos` argument
+ * underflows the size_t to a huge value, and the next snprintf writes
+ * outside the allocation — a heap overflow reachable from the unauthenticated
+ * /api/metrics and :8080 endpoints. This helper measures the fragment first,
+ * grows the buffer geometrically (capped at METRICS_EXPORT_MAX_SIZE), and
+ * never advances pos past what actually fit, so vsnprintf always has a valid
+ * length and the buffer stays NUL-terminated.
+ *
+ * Returns 0 on success (including a clean truncation at the cap); -1 if a
+ * reallocation failed, in which case *buf is freed and set to NULL. Once
+ * *buf is NULL every further call is a safe no-op, so callers can append a
+ * whole document and check for NULL once at the end.
+ */
+static int buf_appendf(char **buf, size_t *cap, size_t *pos,
+                       const char *fmt, ...) {
+    va_list ap;
+    int needed;
+    size_t want, avail;
+
+    if (!buf || !*buf) return -1;
+
+    va_start(ap, fmt);
+    needed = vsnprintf(NULL, 0, fmt, ap);
+    va_end(ap);
+    if (needed < 0) return 0; /* formatting error: skip this fragment */
+
+    /* Grow so the fragment plus its NUL fits, up to the hard cap. */
+    want = *pos + (size_t)needed + 1;
+    if (want > *cap && *cap < METRICS_EXPORT_MAX_SIZE) {
+        size_t new_cap = *cap ? *cap : METRICS_EXPORT_INITIAL_SIZE;
+        char *tmp;
+        while (new_cap < want && new_cap < METRICS_EXPORT_MAX_SIZE) {
+            new_cap *= 2;
+        }
+        if (new_cap > METRICS_EXPORT_MAX_SIZE) new_cap = METRICS_EXPORT_MAX_SIZE;
+        tmp = realloc(*buf, new_cap);
+        if (!tmp) { free(*buf); *buf = NULL; return -1; }
+        *buf = tmp;
+        *cap = new_cap;
+    }
+
+    /* Invariant: *pos < *cap, so avail >= 1 and vsnprintf always terminates. */
+    avail = *cap - *pos;
+    va_start(ap, fmt);
+    vsnprintf(*buf + *pos, avail, fmt, ap);
+    va_end(ap);
+
+    /* Advance only by what actually fit, never past the end of the buffer. */
+    if ((size_t)needed >= avail) {
+        *pos += avail - 1; /* truncated at the cap */
+    } else {
+        *pos += (size_t)needed;
+    }
+    return 0;
+}
+
 char *metrics_export_prometheus(void) {
     char *result = NULL;
     int i;
     size_t len = METRICS_EXPORT_INITIAL_SIZE;
     size_t pos = 0;
-    
+
     if (!g_metrics) return NULL;
-    
+
     pthread_mutex_lock(&metrics_mutex);
-    
+
     result = malloc(len);
     if (!result) {
         pthread_mutex_unlock(&metrics_mutex);
         return NULL;
     }
-    
-    /* Helper: grow buffer when low on space (#121) */
-    #define GROW_IF_NEEDED() do { \
-        if (pos + 512 >= len && len < METRICS_EXPORT_MAX_SIZE) { \
-            size_t new_len = len * 2; \
-            char *tmp; \
-            if (new_len > METRICS_EXPORT_MAX_SIZE) new_len = METRICS_EXPORT_MAX_SIZE; \
-            tmp = realloc(result, new_len); \
-            if (tmp) { result = tmp; len = new_len; } \
-        } \
-    } while (0)
-    
+
     /* Add timestamp */
-    GROW_IF_NEEDED();
-    pos += snprintf(result + pos, len - pos,
+    buf_appendf(&result, &len, &pos,
         "# HELP millennium_metrics_start_time Start time of the metrics collection\n");
-    pos += snprintf(result + pos, len - pos,
+    buf_appendf(&result, &len, &pos,
         "# TYPE millennium_metrics_start_time counter\n");
-    pos += snprintf(result + pos, len - pos,
+    buf_appendf(&result, &len, &pos,
         "millennium_metrics_start_time %ld\n\n", (long)g_metrics->start_time);
-    
+
     /* Export counters */
     for (i = 0; i < (int)g_metrics->counter_count; i++) {
-        char *sanitized_name;
-        GROW_IF_NEEDED();
-        sanitized_name = metrics_sanitize_name(g_metrics->counter_names[i]);
+        char *sanitized_name = metrics_sanitize_name(g_metrics->counter_names[i]);
         if (sanitized_name) {
-            pos += snprintf(result + pos, len - pos,
+            buf_appendf(&result, &len, &pos,
                 "# HELP %s Counter metric\n", sanitized_name);
-            pos += snprintf(result + pos, len - pos,
+            buf_appendf(&result, &len, &pos,
                 "# TYPE %s counter\n", sanitized_name);
-            pos += snprintf(result + pos, len - pos,
+            buf_appendf(&result, &len, &pos,
                 "%s %llu\n", sanitized_name, (unsigned long long)g_metrics->counters[i].value);
             free(sanitized_name);
         }
     }
-    
+
     if (g_metrics->counter_count > 0) {
-        pos += snprintf(result + pos, len - pos, "\n");
+        buf_appendf(&result, &len, &pos, "\n");
     }
-    
+
     /* Export gauges */
     for (i = 0; i < (int)g_metrics->gauge_count; i++) {
-        char *sanitized_name;
-        GROW_IF_NEEDED();
-        sanitized_name = metrics_sanitize_name(g_metrics->gauge_names[i]);
+        char *sanitized_name = metrics_sanitize_name(g_metrics->gauge_names[i]);
         if (sanitized_name) {
-            pos += snprintf(result + pos, len - pos,
+            buf_appendf(&result, &len, &pos,
                 "# HELP %s Gauge metric\n", sanitized_name);
-            pos += snprintf(result + pos, len - pos,
+            buf_appendf(&result, &len, &pos,
                 "# TYPE %s gauge\n", sanitized_name);
-            pos += snprintf(result + pos, len - pos,
+            buf_appendf(&result, &len, &pos,
                 "%s %.2f\n", sanitized_name, g_metrics->gauges[i].value);
             free(sanitized_name);
         }
     }
-    
+
     if (g_metrics->gauge_count > 0) {
-        pos += snprintf(result + pos, len - pos, "\n");
+        buf_appendf(&result, &len, &pos, "\n");
     }
-    
+
     /* Export histograms */
     for (i = 0; i < (int)g_metrics->histogram_count; i++) {
         metrics_histogram_stats_t stats;
         char *sanitized_name;
-        
+
         if (metrics_get_histogram_stats_unlocked(g_metrics->histogram_names[i], &stats) == 0) {
-            GROW_IF_NEEDED();
             sanitized_name = metrics_sanitize_name(g_metrics->histogram_names[i]);
             if (sanitized_name) {
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "# HELP %s_count Histogram count\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "# TYPE %s_count counter\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "%s_count %llu\n", sanitized_name, (unsigned long long)stats.count);
-                
-                pos += snprintf(result + pos, len - pos,
+
+                buf_appendf(&result, &len, &pos,
                     "# HELP %s_sum Histogram sum\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "# TYPE %s_sum counter\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "%s_sum %.2f\n", sanitized_name, stats.sum);
-                
-                pos += snprintf(result + pos, len - pos,
+
+                buf_appendf(&result, &len, &pos,
                     "# HELP %s_min Histogram minimum\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "# TYPE %s_min gauge\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "%s_min %.2f\n", sanitized_name, stats.min);
-                
-                pos += snprintf(result + pos, len - pos,
+
+                buf_appendf(&result, &len, &pos,
                     "# HELP %s_max Histogram maximum\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "# TYPE %s_max gauge\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "%s_max %.2f\n", sanitized_name, stats.max);
-                
-                pos += snprintf(result + pos, len - pos,
+
+                buf_appendf(&result, &len, &pos,
                     "# HELP %s_mean Histogram mean\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "# TYPE %s_mean gauge\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "%s_mean %.2f\n", sanitized_name, stats.mean);
-                
-                pos += snprintf(result + pos, len - pos,
+
+                buf_appendf(&result, &len, &pos,
                     "# HELP %s_median Histogram median\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "# TYPE %s_median gauge\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "%s_median %.2f\n", sanitized_name, stats.median);
-                
-                pos += snprintf(result + pos, len - pos,
+
+                buf_appendf(&result, &len, &pos,
                     "# HELP %s_p95 Histogram 95th percentile\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "# TYPE %s_p95 gauge\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "%s_p95 %.2f\n", sanitized_name, stats.p95);
-                
-                pos += snprintf(result + pos, len - pos,
+
+                buf_appendf(&result, &len, &pos,
                     "# HELP %s_p99 Histogram 99th percentile\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "# TYPE %s_p99 gauge\n", sanitized_name);
-                pos += snprintf(result + pos, len - pos,
+                buf_appendf(&result, &len, &pos,
                     "%s_p99 %.2f\n\n", sanitized_name, stats.p99);
-                
+
                 free(sanitized_name);
             }
         }
     }
-    
-    #undef GROW_IF_NEEDED
+
     pthread_mutex_unlock(&metrics_mutex);
     return result;
 }
@@ -697,75 +743,71 @@ char *metrics_export_json(void) {
         return NULL;
     }
     
-    /* Calculate approximate size needed */
-    len = 1024; /* Base size */
-    len += g_metrics->counter_count * 100;
-    len += g_metrics->gauge_count * 100;
-    len += g_metrics->histogram_count * 500;
-    len += strlen(timestamp);
-    
+    /* Start with a reasonable buffer; buf_appendf grows it as needed so a
+     * long metric name or a full registry can never overflow the allocation. */
+    len = METRICS_EXPORT_INITIAL_SIZE;
     result = malloc(len);
     if (!result) {
         free(timestamp);
         pthread_mutex_unlock(&metrics_mutex);
         return NULL;
     }
-    
-                pos += snprintf(result + pos, len - pos, "{\n");
-                pos += snprintf(result + pos, len - pos, "  \"timestamp\": \"%s\",\n", timestamp);
-                pos += snprintf(result + pos, len - pos, "  \"counters\": {\n");
-    
+
+    buf_appendf(&result, &len, &pos, "{\n");
+    buf_appendf(&result, &len, &pos, "  \"timestamp\": \"%s\",\n", timestamp);
+    buf_appendf(&result, &len, &pos, "  \"counters\": {\n");
+
     /* Export counters */
     for (i = 0; i < (int)g_metrics->counter_count; i++) {
-        if (i > 0) pos += snprintf(result + pos, len - pos, ",\n");
-                pos += snprintf(result + pos, len - pos, "    \"%s\": %llu",
+        if (i > 0) buf_appendf(&result, &len, &pos, ",\n");
+        buf_appendf(&result, &len, &pos, "    \"%s\": %llu",
             g_metrics->counter_names[i], (unsigned long long)g_metrics->counters[i].value);
     }
-    
-                pos += snprintf(result + pos, len - pos, "\n  },\n");
-                pos += snprintf(result + pos, len - pos, "  \"gauges\": {\n");
-    
+
+    buf_appendf(&result, &len, &pos, "\n  },\n");
+    buf_appendf(&result, &len, &pos, "  \"gauges\": {\n");
+
     /* Export gauges */
     for (i = 0; i < (int)g_metrics->gauge_count; i++) {
-        if (i > 0) pos += snprintf(result + pos, len - pos, ",\n");
-                pos += snprintf(result + pos, len - pos, "    \"%s\": %.2f",
+        if (i > 0) buf_appendf(&result, &len, &pos, ",\n");
+        buf_appendf(&result, &len, &pos, "    \"%s\": %.2f",
             g_metrics->gauge_names[i], g_metrics->gauges[i].value);
     }
-    
-                pos += snprintf(result + pos, len - pos, "\n  },\n");
-                pos += snprintf(result + pos, len - pos, "  \"histograms\": {\n");
-    
+
+    buf_appendf(&result, &len, &pos, "\n  },\n");
+    buf_appendf(&result, &len, &pos, "  \"histograms\": {\n");
+
     /* Export histograms */
     for (i = 0; i < (int)g_metrics->histogram_count; i++) {
         metrics_histogram_stats_t stats;
-        
+
         if (metrics_get_histogram_stats_unlocked(g_metrics->histogram_names[i], &stats) == 0) {
-            if (i > 0) pos += snprintf(result + pos, len - pos, ",\n");
-            pos += snprintf(result + pos, len - pos, "    \"%s\": {\n",
+            if (i > 0) buf_appendf(&result, &len, &pos, ",\n");
+            buf_appendf(&result, &len, &pos, "    \"%s\": {\n",
                 g_metrics->histogram_names[i]);
-            pos += snprintf(result + pos, len - pos,
+            buf_appendf(&result, &len, &pos,
                 "      \"count\": %llu,\n", (unsigned long long)stats.count);
-            pos += snprintf(result + pos, len - pos,
+            buf_appendf(&result, &len, &pos,
                 "      \"sum\": %.2f,\n", stats.sum);
-            pos += snprintf(result + pos, len - pos,
+            buf_appendf(&result, &len, &pos,
                 "      \"min\": %.2f,\n", stats.min);
-            pos += snprintf(result + pos, len - pos,
+            buf_appendf(&result, &len, &pos,
                 "      \"max\": %.2f,\n", stats.max);
-            pos += snprintf(result + pos, len - pos,
+            buf_appendf(&result, &len, &pos,
                 "      \"mean\": %.2f,\n", stats.mean);
-            pos += snprintf(result + pos, len - pos,
+            buf_appendf(&result, &len, &pos,
                 "      \"median\": %.2f,\n", stats.median);
-            pos += snprintf(result + pos, len - pos,
+            buf_appendf(&result, &len, &pos,
                 "      \"p95\": %.2f,\n", stats.p95);
-            pos += snprintf(result + pos, len - pos,
+            buf_appendf(&result, &len, &pos,
                 "      \"p99\": %.2f\n", stats.p99);
-            pos += snprintf(result + pos, len - pos, "    }");
+            buf_appendf(&result, &len, &pos, "    }");
         }
     }
-    
-                pos += snprintf(result + pos, len - pos, "\n  }\n");
-                pos += snprintf(result + pos, len - pos, "}\n");
-    
+
+    buf_appendf(&result, &len, &pos, "\n  }\n");
+    buf_appendf(&result, &len, &pos, "}\n");
+
     free(timestamp);
     pthread_mutex_unlock(&metrics_mutex);
     return result;

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -936,6 +936,78 @@ static void test_logger_queue_stats(void) {
     remove(path);
 }
 
+/* ── Metrics export ─────────────────────────────────────────────── */
+
+static void test_metrics_export_prometheus_basic(void) {
+    char *out;
+    TEST_ASSERT_EQ_INT(metrics_init(), 0);
+    metrics_increment_counter("calls_total", 3);
+    metrics_set_gauge("balance_cents", 50.0);
+    metrics_observe_histogram("call_duration", 12.5);
+    out = metrics_export_prometheus();
+    TEST_ASSERT_NOT_NULL(out);
+    TEST_ASSERT(strstr(out, "calls_total 3") != NULL);
+    TEST_ASSERT(strstr(out, "call_duration_count 1") != NULL);
+    free(out);
+    metrics_cleanup();
+}
+
+static void test_metrics_export_json_basic(void) {
+    char *out;
+    TEST_ASSERT_EQ_INT(metrics_init(), 0);
+    metrics_increment_counter("coins", 7);
+    out = metrics_export_json();
+    TEST_ASSERT_NOT_NULL(out);
+    TEST_ASSERT(out[0] == '{');
+    TEST_ASSERT(strstr(out, "\"coins\": 7") != NULL);
+    free(out);
+    metrics_cleanup();
+}
+
+/* Regression for the export buffer-overflow fix (buf_appendf). The JSON
+ * exporter sized its buffer from an *average* budget (100 bytes per counter),
+ * so a registry of many long-named counters whose lines each exceed that
+ * budget overran the total allocation: `pos` ran past `len`, `len - pos`
+ * underflowed the size_t, and the next snprintf wrote off the end of the heap
+ * block. A registry full of 160-char names blows past the estimate decisively.
+ * Under ASan this aborts on the old code; the fixed exporters grow on demand,
+ * so it passes and the output stays well-formed and NUL-terminated. */
+static void test_metrics_export_no_overflow(void) {
+    char name[200];
+    char prefix[200];
+    char *p, *j;
+    int i;
+
+    TEST_ASSERT_EQ_INT(metrics_init(), 0);
+
+    /* A 160-char name template; each emitted line is far larger than the old
+     * 100-bytes-per-counter JSON budget. */
+    memset(prefix, 'a', 160);
+    prefix[160] = '\0';
+
+    for (i = 0; i < 200; i++) {
+        snprintf(name, sizeof(name), "%s%d", prefix, i);
+        metrics_increment_counter(name, (uint64_t)i);
+    }
+    for (i = 0; i < 50; i++) {
+        snprintf(name, sizeof(name), "%shist%d", prefix, i);
+        metrics_observe_histogram(name, (double)i);
+    }
+
+    p = metrics_export_prometheus();
+    TEST_ASSERT_NOT_NULL(p);
+    TEST_ASSERT(p[strlen(p)] == '\0');
+    free(p);
+
+    j = metrics_export_json();
+    TEST_ASSERT_NOT_NULL(j);
+    TEST_ASSERT(j[0] == '{');
+    TEST_ASSERT(j[strlen(j)] == '\0');
+    free(j);
+
+    metrics_cleanup();
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -1017,6 +1089,11 @@ int main(void) {
     TEST_SUITE_BEGIN("Logger");
     TEST_SUITE_RUN(test_logger_async_file_write);
     TEST_SUITE_RUN(test_logger_queue_stats);
+
+    TEST_SUITE_BEGIN("Metrics Export");
+    TEST_SUITE_RUN(test_metrics_export_prometheus_basic);
+    TEST_SUITE_RUN(test_metrics_export_json_basic);
+    TEST_SUITE_RUN(test_metrics_export_no_overflow);
 
     TEST_REPORT();
 }


### PR DESCRIPTION
## Summary

Both `metrics_export_prometheus()` and `metrics_export_json()` built their output with the unsafe idiom:

```c
pos += snprintf(buf + pos, len - pos, ...);
```

`snprintf` returns the length it *would* have written, not what it actually wrote. Once the buffer fills, `pos` runs past `len`, the `len - pos` argument **underflows** the `size_t` to a huge value, and the next `snprintf` writes off the end of the heap allocation.

The JSON exporter was the most exposed: it sized its buffer from an *average* budget (`counter_count * 100`, etc.) and had **no growth path at all**, so a registry of long-named metrics overruns the allocation outright. The Prometheus exporter grew geometrically but only reserved 512 bytes of slack before a histogram block that emits ~960 bytes.

Both surfaces are unauthenticated — `/api/metrics` on port 80 and the standalone metrics server on `:8080` — so this is a **remotely reachable heap-buffer-overflow**.

## Fix

Replace the hand-rolled accumulation (and the broken JSON size estimate / undersized Prometheus reserve) with a single `buf_appendf()` helper that:

- measures each fragment with `vsnprintf(NULL, 0, ...)` first,
- grows the buffer geometrically up to the existing 256 KiB cap,
- never advances `pos` past what actually fit, so the buffer stays in-bounds and NUL-terminated even when truncating at the cap.

The exporter bodies are otherwise unchanged — same output format, same metrics.

## Testing

- `make test` — all unit + scenario tests pass (62 unit tests).
- New regression test `test_metrics_export_no_overflow` builds a registry of 200 long-named counters + 50 histograms and exports both formats.
- **Under AddressSanitizer the regression test aborts with `heap-buffer-overflow` on the pre-fix code, and passes cleanly after** (verified by compiling the new test against `main`'s `metrics.c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)