### PR TITLE
display: hold the start of long lines in view before scrolling

### DIFF
--- a/host/display_manager.c
+++ b/host/display_manager.c
@@ -15,6 +15,8 @@ static int dm_scroll1_pos;
 static int dm_scroll2_pos;
 static int dm_line1_scrolling;
 static int dm_line2_scrolling;
+static int dm_line1_hold;  /* ticks remaining to pause at start of line 1 scroll */
+static int dm_line2_hold;  /* ticks remaining to pause at start of line 2 scroll */
 
 static void dm_send_display(void) {
     char display_bytes[100];
@@ -84,6 +86,8 @@ void display_manager_init(millennium_client_t *client) {
     dm_scroll2_pos = 0;
     dm_line1_scrolling = 0;
     dm_line2_scrolling = 0;
+    dm_line1_hold = 0;
+    dm_line2_hold = 0;
 }
 
 void display_manager_set_text(const char *line1, const char *line2) {
@@ -97,6 +101,7 @@ void display_manager_set_text(const char *line1, const char *line2) {
     }
     dm_scroll1_pos = 0;
     dm_line1_scrolling = (dm_line1_len > DISPLAY_WIDTH);
+    dm_line1_hold = dm_line1_scrolling ? DISPLAY_SCROLL_HOLD_TICKS : 0;
 
     if (line2) {
         strncpy(dm_line2_full, line2, MAX_TEXT_LEN - 1);
@@ -108,6 +113,7 @@ void display_manager_set_text(const char *line1, const char *line2) {
     }
     dm_scroll2_pos = 0;
     dm_line2_scrolling = (dm_line2_len > DISPLAY_WIDTH);
+    dm_line2_hold = dm_line2_scrolling ? DISPLAY_SCROLL_HOLD_TICKS : 0;
 
     dm_send_display();
 }
@@ -116,12 +122,28 @@ void display_manager_tick(void) {
     int changed = 0;
 
     if (dm_line1_scrolling) {
-        dm_scroll1_pos = (dm_scroll1_pos + 1) % (dm_line1_len + DISPLAY_SCROLL_GAP);
-        changed = 1;
+        if (dm_line1_hold > 0) {
+            /* Holding the start of the message in view; don't advance yet. */
+            dm_line1_hold--;
+        } else {
+            dm_scroll1_pos = (dm_scroll1_pos + 1) % (dm_line1_len + DISPLAY_SCROLL_GAP);
+            changed = 1;
+            if (dm_scroll1_pos == 0) {
+                /* Wrapped back to the start — pause again so it stays readable. */
+                dm_line1_hold = DISPLAY_SCROLL_HOLD_TICKS;
+            }
+        }
     }
     if (dm_line2_scrolling) {
-        dm_scroll2_pos = (dm_scroll2_pos + 1) % (dm_line2_len + DISPLAY_SCROLL_GAP);
-        changed = 1;
+        if (dm_line2_hold > 0) {
+            dm_line2_hold--;
+        } else {
+            dm_scroll2_pos = (dm_scroll2_pos + 1) % (dm_line2_len + DISPLAY_SCROLL_GAP);
+            changed = 1;
+            if (dm_scroll2_pos == 0) {
+                dm_line2_hold = DISPLAY_SCROLL_HOLD_TICKS;
+            }
+        }
     }
 
     if (changed) {

--- a/host/display_manager.h
+++ b/host/display_manager.h
@@ -5,6 +5,14 @@
 
 #define DISPLAY_WIDTH 20
 #define DISPLAY_SCROLL_GAP 3  /* spaces between end and start during scroll */
+/*
+ * Ticks to pause with the start of a long line held in view before the line
+ * begins scrolling. The hold is re-armed every time the scroll wraps back to
+ * the beginning, so on each loop the reader gets a readable beat at the start
+ * of the message instead of it sliding away immediately. At the ~300ms tick
+ * cadence, 4 ticks is a ~1.2s pause.
+ */
+#define DISPLAY_SCROLL_HOLD_TICKS 4
 
 /*
  * Initialize the display manager with the SDK client handle.
@@ -13,9 +21,10 @@
 void display_manager_init(millennium_client_t *client);
 
 /*
- * Set display text. Lines longer than 20 characters will scroll
- * automatically on each tick. Short lines are displayed statically.
- * Passing NULL for a line clears that line.
+ * Set display text. Lines longer than 20 characters scroll automatically on
+ * each tick, pausing briefly (DISPLAY_SCROLL_HOLD_TICKS) with the start of the
+ * line in view at the beginning of every loop so it stays readable. Short
+ * lines are displayed statically. Passing NULL for a line clears that line.
  */
 void display_manager_set_text(const char *line1, const char *line2);
 

--- a/host/tests/test_display_scrolling.scenario
+++ b/host/tests/test_display_scrolling.scenario
@@ -10,21 +10,27 @@ set_display Header|This is a very long fortune message that scrolls
 assert_display Header
 assert_display This is a very long
 
-# After ticking, line2 should scroll left — "his is a very long f"
-tick_display 1
+# A long line first HOLDS (DISPLAY_SCROLL_HOLD_TICKS=4) so the start of the
+# message stays readable instead of sliding away on the very first tick.
+tick_display 3
+assert_display This is a very long
+
+# Once the hold elapses, the next tick starts scrolling left
+tick_display 2
 assert_display his is a very long f
 
-# Tick 5 more (6 total from start) — text continues scrolling
+# Continue scrolling now that the hold is spent
 tick_display 5
 assert_display s a very long fortun
 
-# Long text on line1 should also scroll
+# Long text on line1 should also hold then scroll
 set_display Extremely Long Title That Exceeds Display|Short
 assert_display Extremely Long Title
 assert_display Short
 
+# Held during the first 4 ticks, scrolls one step on the 5th
 tick_display 5
-assert_display ely Long Title That
+assert_display xtremely Long Title
 
 # Short text should never scroll even after many ticks
 set_display Static|Text

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -9,7 +9,9 @@
 #include "../updater.h"
 #include "../plugin_sdk.h"
 #include "../clock_source.h"
+#include "../display_manager.h"
 #include <stdlib.h>
+#include <string.h>
 
 /* ── Stubs for linker (plugins.c references these) ──────────────── */
 
@@ -22,7 +24,19 @@ millennium_client_t *millennium_client_create(void) {
 }
 void millennium_client_destroy(millennium_client_t *c) { free(c); }
 void millennium_client_close(millennium_client_t *c) { (void)c; }
-void millennium_client_set_display(millennium_client_t *c, const char *m) { (void)c; (void)m; }
+/* Capture the most recent display payload so display_manager tests can assert
+ * on what would actually be shown on the VFD. */
+static char g_last_display[128];
+void millennium_client_set_display(millennium_client_t *c, const char *m) {
+    (void)c;
+    if (m) {
+        strncpy(g_last_display, m, sizeof(g_last_display) - 1);
+        g_last_display[sizeof(g_last_display) - 1] = '\0';
+    }
+}
+static int display_shows(const char *needle) {
+    return strstr(g_last_display, needle) != NULL;
+}
 void millennium_client_call(millennium_client_t *c, const char *n) { (void)c; (void)n; }
 void millennium_client_answer_call(millennium_client_t *c) { (void)c; }
 void millennium_client_hangup(millennium_client_t *c) { (void)c; }
@@ -197,6 +211,64 @@ static void test_config_load_from_file(void) {
     TEST_ASSERT_EQ_INT(config_get_call_timeout_seconds(&cfg), 120);
 
     remove("/tmp/millennium_test.cfg");
+}
+
+/* ── Display manager tests ──────────────────────────────────────── */
+
+static void test_display_short_line_static(void) {
+    millennium_client_t *c = millennium_client_create();
+    int i;
+    display_manager_init(c);
+
+    /* A line that fits never scrolls, even after many ticks. */
+    display_manager_set_text("Short", "Also short");
+    for (i = 0; i < 20; i++) display_manager_tick();
+    TEST_ASSERT_EQ_INT(display_shows("Short"), 1);
+    TEST_ASSERT_EQ_INT(display_shows("Also short"), 1);
+
+    millennium_client_destroy(c);
+}
+
+static void test_display_scroll_holds_at_start(void) {
+    millennium_client_t *c = millennium_client_create();
+    int i;
+    display_manager_init(c);
+
+    /* A line longer than the 20-char display starts held at the beginning. */
+    display_manager_set_text("Header", "This is a very long fortune message");
+    TEST_ASSERT_EQ_INT(display_shows("This is a very long"), 1);
+
+    /* During the hold window the start stays in view; it does not scroll. */
+    for (i = 0; i < DISPLAY_SCROLL_HOLD_TICKS - 1; i++) display_manager_tick();
+    TEST_ASSERT_EQ_INT(display_shows("This is a very long"), 1);
+
+    /* The tick that spends the last hold doesn't move; the next one scrolls. */
+    display_manager_tick();  /* hold 1 -> 0 */
+    display_manager_tick();  /* first real scroll step */
+    TEST_ASSERT_EQ_INT(display_shows("his is a very long"), 1);
+
+    millennium_client_destroy(c);
+}
+
+static void test_display_scroll_rearms_hold_on_wrap(void) {
+    millennium_client_t *c = millennium_client_create();
+    int i;
+    /* 21-char line: one column too wide, so its scroll period is short. */
+    const char *line = "123456789012345678901";
+    int period = (int)strlen(line) + DISPLAY_SCROLL_GAP;
+    display_manager_init(c);
+
+    display_manager_set_text(line, NULL);
+    /* Spend the initial hold, then a full lap back to column 0, which re-arms
+     * the hold so the start is readable again on the next loop. */
+    for (i = 0; i < DISPLAY_SCROLL_HOLD_TICKS + period; i++) display_manager_tick();
+    TEST_ASSERT_EQ_INT(display_shows("12345678901234567890"), 1);
+
+    /* Re-armed: this tick holds rather than advancing past the start. */
+    display_manager_tick();
+    TEST_ASSERT_EQ_INT(display_shows("12345678901234567890"), 1);
+
+    millennium_client_destroy(c);
 }
 
 /* ── Daemon state tests ─────────────────────────────────────────── */
@@ -953,6 +1025,11 @@ int main(void) {
     TEST_SUITE_RUN(test_config_null_safety);
     TEST_SUITE_RUN(test_config_overwrite_value);
     TEST_SUITE_RUN(test_config_load_from_file);
+
+    TEST_SUITE_BEGIN("Display Manager");
+    TEST_SUITE_RUN(test_display_short_line_static);
+    TEST_SUITE_RUN(test_display_scroll_holds_at_start);
+    TEST_SUITE_RUN(test_display_scroll_rearms_hold_on_wrap);
 
     TEST_SUITE_BEGIN("Daemon State");
     TEST_SUITE_RUN(test_state_init);


### PR DESCRIPTION
## Problem

On the 20-character VFD, any line longer than 20 chars — trivia questions, Dial-A-Joke punchlines, fortunes, the dialed phone number — began scrolling left on the **very first** `display_manager_tick()`. The start of the message slid out of view before a reader could catch it, and on each loop it never paused at the beginning, so long messages were hard to read.

## Change

Hold the start of a scrolling line in view for `DISPLAY_SCROLL_HOLD_TICKS` (4 ticks ≈ 1.2s at the ~300ms tick cadence) before it begins scrolling. The hold is **re-armed every time the scroll wraps back to column 0**, so on every loop the reader gets a readable beat at the start of the message instead of it sliding away immediately.

- Short lines (≤ 20 chars) are unaffected — still static.
- While paused, the manager skips the scroll advance *and* the redundant re-send to the display, so it's also slightly less serial chatter.
- The pause length is a single documented constant in `display_manager.h`.

## Tests

- Three new unit tests (`Display Manager` suite) covering: short lines never scroll, long lines hold at the start before scrolling, and the hold re-arms after a full wrap. Unit count 59 → 62.
- Updated `test_display_scrolling.scenario` to assert the hold window then the subsequent scroll.
- `make test` — all unit tests and scenarios pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)