### PR TITLE
display: preserve scroll position when text is repainted unchanged

### DIFF
--- a/host/display_manager.c
+++ b/host/display_manager.c
@@ -87,27 +87,42 @@ void display_manager_init(millennium_client_t *client) {
 }
 
 void display_manager_set_text(const char *line1, const char *line2) {
-    if (line1) {
-        strncpy(dm_line1_full, line1, MAX_TEXT_LEN - 1);
-        dm_line1_full[MAX_TEXT_LEN - 1] = '\0';
-        dm_line1_len = (int)strlen(dm_line1_full);
-    } else {
-        dm_line1_full[0] = '\0';
-        dm_line1_len = 0;
-    }
-    dm_scroll1_pos = 0;
-    dm_line1_scrolling = (dm_line1_len > DISPLAY_WIDTH);
+    char new1[MAX_TEXT_LEN];
+    char new2[MAX_TEXT_LEN];
 
-    if (line2) {
-        strncpy(dm_line2_full, line2, MAX_TEXT_LEN - 1);
-        dm_line2_full[MAX_TEXT_LEN - 1] = '\0';
-        dm_line2_len = (int)strlen(dm_line2_full);
+    /* Normalize NULL (clear) to an empty string so comparison is uniform. */
+    if (line1) {
+        strncpy(new1, line1, MAX_TEXT_LEN - 1);
+        new1[MAX_TEXT_LEN - 1] = '\0';
     } else {
-        dm_line2_full[0] = '\0';
-        dm_line2_len = 0;
+        new1[0] = '\0';
     }
-    dm_scroll2_pos = 0;
-    dm_line2_scrolling = (dm_line2_len > DISPLAY_WIDTH);
+    if (line2) {
+        strncpy(new2, line2, MAX_TEXT_LEN - 1);
+        new2[MAX_TEXT_LEN - 1] = '\0';
+    } else {
+        new2[0] = '\0';
+    }
+
+    /*
+     * Only reset the scroll position when a line's content actually changes.
+     * A plugin that idempotently repaints its current state on every tick (the
+     * canonical pattern) would otherwise snap a long, scrolling line back to
+     * its start on each repaint and never advance. Re-sending identical text
+     * now preserves the in-progress scroll animation.
+     */
+    if (strcmp(new1, dm_line1_full) != 0) {
+        strcpy(dm_line1_full, new1);
+        dm_line1_len = (int)strlen(dm_line1_full);
+        dm_scroll1_pos = 0;
+        dm_line1_scrolling = (dm_line1_len > DISPLAY_WIDTH);
+    }
+    if (strcmp(new2, dm_line2_full) != 0) {
+        strcpy(dm_line2_full, new2);
+        dm_line2_len = (int)strlen(dm_line2_full);
+        dm_scroll2_pos = 0;
+        dm_line2_scrolling = (dm_line2_len > DISPLAY_WIDTH);
+    }
 
     dm_send_display();
 }

--- a/host/display_manager.h
+++ b/host/display_manager.h
@@ -16,6 +16,10 @@ void display_manager_init(millennium_client_t *client);
  * Set display text. Lines longer than 20 characters will scroll
  * automatically on each tick. Short lines are displayed statically.
  * Passing NULL for a line clears that line.
+ *
+ * Re-setting a line to text identical to what it already shows preserves the
+ * in-progress scroll position, so a plugin may safely repaint its current
+ * state every tick without freezing a scrolling line at its start.
  */
 void display_manager_set_text(const char *line1, const char *line2);
 

--- a/host/tests/test_display_scrolling.scenario
+++ b/host/tests/test_display_scrolling.scenario
@@ -31,3 +31,18 @@ set_display Static|Text
 tick_display 20
 assert_display Static
 assert_display Text
+
+# Repainting identical text must preserve the scroll position.
+# A plugin that repaints its current state every tick should keep scrolling
+# instead of snapping the line back to its start on each repaint.
+set_display Header|This is a very long fortune message that scrolls
+tick_display 6
+assert_display s a very long fortun
+# Repaint byte-for-byte identical content...
+set_display Header|This is a very long fortune message that scrolls
+# ...the scroll position is preserved (not reset to the start of the line)
+assert_display s a very long fortun
+assert_no_display This is a very long
+# ...and ticking keeps advancing from where it left off
+tick_display 1
+assert_display a very long fortune


### PR DESCRIPTION
## Problem

`display_manager_set_text()` unconditionally reset the scroll position to `0` on every call. The plugin SDK invites authors to repaint their current state on each tick (`handle_tick`) — the canonical UI pattern — and the header docs say long lines "scroll automatically on each tick." But a plugin following that pattern would re-call `set_text` with the same long string every tick, snapping the line back to its start each time, so the text would **never scroll past the first 20 characters** on the VFD.

None of the current built-in plugins repaint on tick (they only set text on state transitions), so this is a latent trap rather than a live regression — but it's exactly the bug a new plugin author would hit by writing the obvious code.

## Fix

Compare each incoming line against what's already displayed and only reset the scroll position (and recompute the scrolling flag) when the content **actually changes**:

- Re-sending byte-for-byte identical text preserves the in-progress scroll animation.
- Genuine content changes still restart the scroll from the beginning, exactly as before.

NULL (clear) is normalized to an empty string so the comparison is uniform. The frame is still pushed to the display on every call.

## Tests

Extended `tests/test_display_scrolling.scenario`: scroll a long line partway, repaint identical text, and assert the scroll position is preserved (`s a very long fortun`) rather than reset to the start (`assert_no_display This is a very long`), then confirm ticking continues advancing.

- `make test` — all scenarios pass
- `./unit_tests` — 59 passed, 0 failed
- Clean build under `-Wall -Wextra -Wdeclaration-after-statement -Werror`

🤖 Generated with [Claude Code](https://claude.com/claude-code)