### PR TITLE
display: scrub control characters from plugin text before it reaches the VFD

### DIFF
--- a/host/display_manager.c
+++ b/host/display_manager.c
@@ -16,6 +16,26 @@ static int dm_scroll2_pos;
 static int dm_line1_scrolling;
 static int dm_line2_scrolling;
 
+/*
+ * Replace C0 control characters (bytes below 0x20) and DEL (0x7F) with spaces,
+ * in place. The Beta firmware forwards every display byte straight to the VFD
+ * module, which interprets these low bytes as commands (cursor moves, scroll
+ * mode, display on/off) and treats 0x0A as a line break. The display manager
+ * inserts its own single 0x0A line separator when packing the two lines, so any
+ * control byte arriving in plugin-supplied text could only corrupt the layout
+ * or issue an unintended VFD command. Printable ASCII and high-bit bytes (which
+ * may map to the VFD's extended glyphs) are left untouched.
+ */
+static void dm_sanitize(char *s) {
+    size_t i;
+    for (i = 0; s[i] != '\0'; i++) {
+        unsigned char c = (unsigned char)s[i];
+        if (c < 0x20 || c == 0x7F) {
+            s[i] = ' ';
+        }
+    }
+}
+
 static void dm_send_display(void) {
     char display_bytes[100];
     char visible1[DISPLAY_WIDTH + 1];
@@ -90,6 +110,7 @@ void display_manager_set_text(const char *line1, const char *line2) {
     if (line1) {
         strncpy(dm_line1_full, line1, MAX_TEXT_LEN - 1);
         dm_line1_full[MAX_TEXT_LEN - 1] = '\0';
+        dm_sanitize(dm_line1_full);
         dm_line1_len = (int)strlen(dm_line1_full);
     } else {
         dm_line1_full[0] = '\0';
@@ -101,6 +122,7 @@ void display_manager_set_text(const char *line1, const char *line2) {
     if (line2) {
         strncpy(dm_line2_full, line2, MAX_TEXT_LEN - 1);
         dm_line2_full[MAX_TEXT_LEN - 1] = '\0';
+        dm_sanitize(dm_line2_full);
         dm_line2_len = (int)strlen(dm_line2_full);
     } else {
         dm_line2_full[0] = '\0';

--- a/host/display_manager.h
+++ b/host/display_manager.h
@@ -16,6 +16,11 @@ void display_manager_init(millennium_client_t *client);
  * Set display text. Lines longer than 20 characters will scroll
  * automatically on each tick. Short lines are displayed statically.
  * Passing NULL for a line clears that line.
+ *
+ * Control characters (bytes below 0x20, plus DEL 0x7F) in the supplied text
+ * are replaced with spaces before storage: the VFD treats those bytes as
+ * commands or line breaks, so they would otherwise corrupt the display. Plugin
+ * authors can therefore pass arbitrary text without sanitizing it themselves.
  */
 void display_manager_set_text(const char *line1, const char *line2);
 

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -9,6 +9,7 @@
 #include "../updater.h"
 #include "../plugin_sdk.h"
 #include "../clock_source.h"
+#include "../display_manager.h"
 #include <stdlib.h>
 
 /* ── Stubs for linker (plugins.c references these) ──────────────── */
@@ -856,6 +857,52 @@ static void test_card_empty_list(void) {
     TEST_ASSERT_EQ_INT(0, config_is_admin_card(&cfg, "1234567890123456"));
 }
 
+/* ── Display manager ────────────────────────────────────────────── */
+
+/* Control bytes in plugin-supplied text would otherwise reach the VFD as
+ * commands or stray line breaks. They must be replaced with spaces while
+ * ordinary printable text passes through unchanged. */
+static void test_display_sanitizes_control_chars(void) {
+    char line1[64];
+    char line2[64];
+
+    display_manager_init(NULL);
+
+    /* Embedded newline, tab, carriage return, escape, and DEL all become
+     * spaces; the surrounding printable characters are preserved. */
+    display_manager_set_text("AB\nCD\tEF", "G\rH\x1bI\x7fJ");
+    display_manager_get_text(line1, sizeof(line1), line2, sizeof(line2));
+    TEST_ASSERT_EQ_STR(line1, "AB CD EF");
+    TEST_ASSERT_EQ_STR(line2, "G H I J");
+}
+
+static void test_display_preserves_printable(void) {
+    char line1[64];
+    char line2[64];
+
+    display_manager_init(NULL);
+
+    /* Plain text (including spaces and punctuation) is untouched. */
+    display_manager_set_text("Hello, World!", "Coins: $0.50");
+    display_manager_get_text(line1, sizeof(line1), line2, sizeof(line2));
+    TEST_ASSERT_EQ_STR(line1, "Hello, World!");
+    TEST_ASSERT_EQ_STR(line2, "Coins: $0.50");
+}
+
+static void test_display_high_bit_bytes_untouched(void) {
+    char line1[64];
+    char line2[64];
+
+    display_manager_init(NULL);
+
+    /* Bytes >= 0x80 may map to the VFD's extended glyph set, so they are left
+     * alone — only the C0 control range and DEL are scrubbed. */
+    display_manager_set_text("X\xa9Y", NULL);
+    display_manager_get_text(line1, sizeof(line1), line2, sizeof(line2));
+    TEST_ASSERT_EQ_STR(line1, "X\xa9Y");
+    TEST_ASSERT_EQ_STR(line2, "");
+}
+
 /* ── Logger (async file writer, issue #123) ─────────────────────── */
 
 /* File logging is drained to disk by a background writer thread so a slow disk
@@ -1013,6 +1060,11 @@ int main(void) {
     TEST_SUITE_RUN(test_version_no_update_initially);
     TEST_SUITE_RUN(test_updater_apply_null_dir);
     TEST_SUITE_RUN(test_updater_apply_bad_dir);
+
+    TEST_SUITE_BEGIN("Display Manager");
+    TEST_SUITE_RUN(test_display_sanitizes_control_chars);
+    TEST_SUITE_RUN(test_display_preserves_printable);
+    TEST_SUITE_RUN(test_display_high_bit_bytes_untouched);
 
     TEST_SUITE_BEGIN("Logger");
     TEST_SUITE_RUN(test_logger_async_file_write);


### PR DESCRIPTION
## Summary

`display_manager_set_text()` stored plugin-supplied text verbatim. The Beta firmware (`Arduino/sketches/display/display.ino`) forwards **every** display byte straight to the VFD module, translating only `0x0A` into a line break:

```c
writeCharacter(buf[i] == 0x0A ? 13 : buf[i]);
```

So any C0 control byte (newline, tab, CR, ESC) or DEL embedded in plugin text reaches the VFD as a **command** — moving the cursor, toggling scroll mode (`18`), turning the display on/off (`20`) — or, for a stray `0x0A`, injects an extra line break and corrupts the two-line layout that the display manager carefully packs with its own single `0x0A` separator.

The plugin SDK explicitly invites third-party authors to paint arbitrary text (`sdk_display`, `sdk_displayf`), so this is a real footgun: one accidental `"\n"` in a status string silently mangles the display.

## Change

- Replace bytes below `0x20` (and DEL `0x7F`) with spaces when text is stored, so the only control byte ever sent is the intentional line separator.
- Spaces preserve column positions rather than shifting text.
- Printable ASCII and high-bit bytes (`>= 0x80`, which may map to the VFD's extended glyph set) pass through untouched.
- Sanitizing at store time keeps the `/api/state` and dashboard views — which read back through `display_manager_get_text()` — consistent with what the VFD shows.

## Testing

- New unit tests: control-char scrubbing, printable passthrough, high-bit preservation.
- `make test` — all 62 unit tests and all scenarios pass under `-Wall -Wextra -Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)