### PR TITLE
metrics: count plugin activations so field usage is observable

### DIFF
--- a/host/plugins.c
+++ b/host/plugins.c
@@ -8,6 +8,7 @@
 #include "plugins.h"
 #include "logger.h"
 #include "millennium_sdk.h"
+#include "metrics.h"
 
 /* Maximum number of plugins. Generous headroom so experimenters can add
  * their own alongside the built-ins (7 ship by default). */
@@ -92,27 +93,49 @@ int plugins_register(const char *name, const char *description,
     return 0;
 }
 
+/* Bump the activation counters for a plugin that was just made active.
+ *
+ * Exposes which of the built-in experiences actually get used on a phone in
+ * the field: a per-plugin counter (plugin_activations_<name>) plus an
+ * aggregate (plugin_activations_total). Both are plain Prometheus counters, so
+ * they ride out through the existing dynamic metrics export with no endpoint
+ * changes. "Activation" here means "made the active plugin" — that includes the
+ * boot-time default and a restore from persistence, not only deliberate user
+ * switches, which is the honest count for a counter named this way.
+ *
+ * Called *after* releasing plugins_mutex: metrics_increment_counter takes its
+ * own lock, and keeping the two mutexes strictly un-nested avoids any lock
+ * ordering concern. Safe before metrics_init() too — the increment is a no-op
+ * until the metrics subsystem is up. */
+static void plugins_record_activation(const char *name) {
+    char counter[128];
+    metrics_increment_counter("plugin_activations_total", 1);
+    snprintf(counter, sizeof(counter), "plugin_activations_%s", name);
+    metrics_increment_counter(counter, 1);
+}
+
 int plugins_activate(const char *plugin_name) {
     int i;
     if (!plugin_name) {
         logger_error_with_category("Plugins", "Plugin name required for activation");
         return -1;
     }
-    
+
     pthread_mutex_lock(&plugins_mutex);
-    
+
     /* Find the plugin */
     for (i = 0; i < plugin_count; i++) {
         if (strcmp(plugins[i].name, plugin_name) == 0) {
             active_plugin_index = i;
-            
+
             /* Call the plugin's activation handler if it exists */
             if (plugins[i].handle_activation) {
                 plugins[i].handle_activation();
             }
-            
+
             logger_infof_with_category("Plugins", "Plugin %s activated", plugin_name);
             pthread_mutex_unlock(&plugins_mutex);
+            plugins_record_activation(plugin_name);
             return 0;
         }
     }

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -329,6 +329,41 @@ static void test_plugins_register_and_activate(void) {
     plugins_cleanup();
 }
 
+static void test_plugins_activation_metrics(void) {
+    daemon_state_data_t ds;
+    daemon_state_init(&ds);
+    daemon_state = &ds;
+    client = millennium_client_create();
+
+    /* Start from a clean metrics slate so counts are deterministic even if an
+     * earlier test already created the metrics instance. */
+    metrics_init();
+    metrics_reset_all();
+
+    /* plugins_init activates the default "Classic Phone" once. */
+    plugins_init();
+    TEST_ASSERT_EQ_INT((int)metrics_get_counter("plugin_activations_total"), 1);
+    TEST_ASSERT_EQ_INT(
+        (int)metrics_get_counter("plugin_activations_Classic Phone"), 1);
+
+    /* Each activation bumps the aggregate and the per-plugin counter. */
+    TEST_ASSERT_EQ_INT(plugins_activate("Fortune Teller"), 0);
+    TEST_ASSERT_EQ_INT(plugins_activate("Fortune Teller"), 0);
+    TEST_ASSERT_EQ_INT((int)metrics_get_counter("plugin_activations_total"), 3);
+    TEST_ASSERT_EQ_INT(
+        (int)metrics_get_counter("plugin_activations_Fortune Teller"), 2);
+
+    /* A failed activation must not move any counter. */
+    TEST_ASSERT_EQ_INT(plugins_activate("Nonexistent"), -1);
+    TEST_ASSERT_EQ_INT((int)metrics_get_counter("plugin_activations_total"), 3);
+
+    millennium_client_destroy(client);
+    client = NULL;
+    daemon_state = NULL;
+    plugins_cleanup();
+    metrics_cleanup();
+}
+
 static void test_plugins_activate_nonexistent(void) {
     daemon_state_data_t ds;
     daemon_state_init(&ds);
@@ -967,6 +1002,7 @@ int main(void) {
 
     TEST_SUITE_BEGIN("Plugins");
     TEST_SUITE_RUN(test_plugins_register_and_activate);
+    TEST_SUITE_RUN(test_plugins_activation_metrics);
     TEST_SUITE_RUN(test_plugins_activate_nonexistent);
     TEST_SUITE_RUN(test_plugins_register_custom);
     TEST_SUITE_RUN(test_plugins_list);


### PR DESCRIPTION
## What

Adds per-plugin activation metrics so we can see **which of the seven built-in experiences actually get used** on a phone deployed in the field.

The daemon already exports Prometheus/JSON counters for coins, calls, keypad presses, and card swipes — but nothing recorded plugin engagement. The most interesting question for a payphone in the wild ("is anyone playing Simon, or is it all Classic Phone?") was unanswerable.

## How

`plugins_activate()` now increments two plain counters on every successful activation:

- `plugin_activations_<name>` — per plugin (e.g. `plugin_activations_Classic_Phone` after name sanitization)
- `plugin_activations_total` — aggregate

Both ride out through the existing **dynamic** metrics export (`/api/metrics`, port 8080) — no endpoint, schema, or dashboard changes required, since the exporter already enumerates all registered counters.

Design notes:
- The increment runs **after** `plugins_mutex` is released. `metrics_increment_counter` takes its own lock, so the two mutexes stay strictly un-nested — no lock-ordering concern.
- It's a safe no-op before `metrics_init()`, so boot-time default activation and restore-from-persistence are counted honestly. "Activation" means "made the active plugin," which is the accurate semantic for a counter named this way (documented in the code).
- A failed activation moves no counter.

## Testing

- New unit test `test_plugins_activation_metrics` covers the default activation, repeated activations (per-plugin + aggregate), and that a non-existent activation increments nothing.
- `make test` — all 60 unit tests + all scenario tests pass.
- Builds clean under `-std=gnu89 -Wall -Wextra -Wdeclaration-after-statement -Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)