### PR TITLE
metrics: track returned-coin value so net revenue is observable

### DIFF
--- a/host/daemon.c
+++ b/host/daemon.c
@@ -713,12 +713,21 @@ int send_control_command(const char* action) {
         return 1;
         
     } else if (strcmp(command, "coin_return") == 0) {
+        int returned_cents;
         pthread_mutex_lock(&daemon_state_mutex);
+        returned_cents = daemon_state->inserted_cents;
         daemon_state->inserted_cents = 0;
         daemon_state_update_activity(daemon_state);
         metrics_set_gauge("inserted_cents", 0.0);
         metrics_increment_counter("coin_returns", 1);
-        logger_info_with_category("Control", "Coins returned via web portal");
+        /* Track the value handed back so net revenue is observable:
+         * net = coins_value_cents - coins_returned_cents */
+        if (returned_cents > 0) {
+            metrics_increment_counter("coins_returned_cents",
+                                      (uint64_t)returned_cents);
+        }
+        logger_infof_with_category("Control",
+                "Coins returned via web portal: %d cents", returned_cents);
         
         /* Let plugins handle display updates */
         

--- a/host/simulator.c
+++ b/host/simulator.c
@@ -514,6 +514,18 @@ static int run_scenario(const char *path) {
             sim_drain_events();
         }
 
+        /* ── coin_return — return inserted coins to the customer ─────── */
+        else if (strcmp(cmd, "coin_return") == 0) {
+            int returned_cents = daemon_state->inserted_cents;
+            daemon_state->inserted_cents = 0;
+            daemon_state_update_activity(daemon_state);
+            metrics_increment_counter("coin_returns", 1);
+            if (returned_cents > 0) {
+                metrics_increment_counter("coins_returned_cents",
+                                          (uint64_t)returned_cents);
+            }
+        }
+
         /* ── key <char> — any keypad key: 0-9, *, #, A-D ─────────────── */
         else if (strncmp(cmd, "key ", 4) == 0) {
             char key = cmd[4];
@@ -626,6 +638,26 @@ static int run_scenario(const char *path) {
             } else {
                 fprintf(stderr, "  FAIL: expected state containing \"%s\", got \"%s\"\n",
                         arg, actual);
+                failures++;
+            }
+        }
+
+        /* ── assert_metric <counter_name> <expected> ─────────────── */
+        else if (strncmp(cmd, "assert_metric ", 14) == 0) {
+            char name[128];
+            unsigned long long expected;
+            if (sscanf(cmd + 14, "%127s %llu", name, &expected) == 2) {
+                unsigned long long actual =
+                    (unsigned long long)metrics_get_counter(name);
+                if (actual == expected) {
+                    fprintf(stderr, "  PASS: metric %s == %llu\n", name, expected);
+                } else {
+                    fprintf(stderr, "  FAIL: metric %s expected %llu, got %llu\n",
+                            name, expected, actual);
+                    failures++;
+                }
+            } else {
+                fprintf(stderr, "  ERROR: assert_metric needs <name> <expected>\n");
                 failures++;
             }
         }
@@ -799,6 +831,7 @@ int main(int argc, char *argv[]) {
 
         /* Reset state between scenarios */
         daemon_state_init(daemon_state);
+        metrics_reset_all();   /* keep per-scenario assert_metric independent */
         sim_display_line1[0] = '\0';
         sim_display_line2[0] = '\0';
         sim_display_count    = 0;

--- a/host/tests/test_coin_return_revenue.scenario
+++ b/host/tests/test_coin_return_revenue.scenario
@@ -1,0 +1,34 @@
+# Test: Coin-return revenue accounting
+# Verifies that returning inserted coins records their value in the
+# coins_returned_cents counter, so net revenue (inserted - returned)
+# is observable in the metrics endpoint.
+
+hook_up
+assert_state IDLE_UP
+
+# Insert 25 + 10 = 35 cents
+coin 25
+coin 10
+assert_display Have: 35c
+
+# Everything inserted so far is counted as revenue-in
+assert_metric coins_value_cents 35
+assert_metric coins_returned_cents 0
+
+# Return the coins to the customer
+coin_return
+assert_metric coin_returns 1
+assert_metric coins_returned_cents 35
+
+# Insert again and return only part of the session, twice over,
+# to confirm the counter accumulates across returns.
+coin 25
+assert_metric coins_value_cents 60
+coin_return
+assert_metric coin_returns 2
+assert_metric coins_returned_cents 60
+
+# A coin_return with nothing inserted must NOT change the cents counter
+coin_return
+assert_metric coin_returns 3
+assert_metric coins_returned_cents 60


### PR DESCRIPTION
## Problem

The daemon counts every cent **inserted** (`coins_value_cents`), but the `coin_return` control action zeroed `inserted_cents` and only bumped `coin_returns` — a count of return *events*. The actual value handed back to the customer was discarded, so **net revenue (inserted − returned) could not be computed** from `/api/metrics`.

## Change

- **`daemon.c`** — in the `coin_return` handler, capture `inserted_cents` before zeroing and add it to a new **`coins_returned_cents`** counter (guarded so a return with nothing inserted is a no-op). The log line now reports the amount returned.
  - Net revenue is now `coins_value_cents - coins_returned_cents`, both already exported in Prometheus and JSON formats automatically.

## Testing

No scenario could assert on metrics before, so this adds the harness plumbing too:

- **`simulator.c`** — new `coin_return` scenario command mirroring the daemon; new reusable **`assert_metric <name> <expected>`** assertion; metrics are now reset between scenario files so those assertions are per-scenario and independent.
- **`tests/test_coin_return_revenue.scenario`** — covers accumulation across multiple returns and the no-op (return with zero inserted) case.

Full suite green locally (`make test`): 59/59 unit tests pass, all scenarios pass.

> Note: `make daemon` requires PJSIP/ALSA (Pi-only), so `daemon.c` was not full-compiled here; the change is C89, declaration-first, and uses the existing `metrics_increment_counter` / `logger_infof_with_category` patterns already in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)