### PR TITLE
metrics: tally coin inserts by denomination for coin-box reconciliation

### DIFF
--- a/host/daemon.c
+++ b/host/daemon.c
@@ -276,6 +276,18 @@ static void daemon_broadcast_state(const char *event_type) {
     web_server_broadcast_to_websockets(web_server, msg);
 }
 
+/* Prometheus counter name for a coin of the given cent value. Used to tally
+ * the coin-box denomination mix. Falls back to a catch-all bucket for any
+ * future/unknown coin so no accepted coin goes uncounted. */
+static const char *coin_denomination_metric(int coin_value) {
+    switch (coin_value) {
+        case 5:  return "coins_5c";
+        case 10: return "coins_10c";
+        case 25: return "coins_25c";
+        default: return "coins_other";
+    }
+}
+
 void handle_coin_event(coin_event_t *coin_event) {
     char *coin_code_str;
     int coin_value = 0;
@@ -309,8 +321,13 @@ void handle_coin_event(coin_event_t *coin_event) {
             
             metrics_increment_counter("coins_inserted", 1);
             metrics_increment_counter("coins_value_cents", coin_value);
-            
-            logger_infof_with_category("Coin", 
+            /* Per-denomination tally so the coin box can be reconciled by coin
+             * (capacity is per-coin, not per-dollar): a $5.00 take is 20
+             * quarters or 100 nickels, and only this breakdown tells them
+             * apart. coins_inserted/coins_value_cents stay the aggregate view. */
+            metrics_increment_counter(coin_denomination_metric(coin_value), 1);
+
+            logger_infof_with_category("Coin",
                     "Coin inserted: %s, value: %d cents, total: %d cents",
                     coin_code_str, coin_value, daemon_state->inserted_cents);
             

--- a/host/simulator.c
+++ b/host/simulator.c
@@ -299,10 +299,14 @@ static void sim_handle_coin(coin_event_t *ev) {
     else if (strcmp(code, "COIN_8") == 0) val = 25;
 
     if (val > 0 && daemon_state->current_state == DAEMON_STATE_IDLE_UP) {
+        const char *denom = (val == 5)  ? "coins_5c"  :
+                            (val == 10) ? "coins_10c" :
+                            (val == 25) ? "coins_25c" : "coins_other";
         daemon_state->inserted_cents += val;
         daemon_state_update_activity(daemon_state);
         metrics_increment_counter("coins_inserted", 1);
         metrics_increment_counter("coins_value_cents", val);
+        metrics_increment_counter(denom, 1);  /* mirror daemon.c per-denomination tally */
         plugins_handle_coin(val, code);
     }
     free(code);
@@ -630,6 +634,26 @@ static int run_scenario(const char *path) {
             }
         }
 
+        /* ── assert_metric <counter_name> <expected> ─────────────── */
+        else if (strncmp(cmd, "assert_metric ", 14) == 0) {
+            char name[128];
+            unsigned long long expected;
+            if (sscanf(cmd + 14, "%127s %llu", name, &expected) == 2) {
+                unsigned long long actual =
+                    (unsigned long long)metrics_get_counter(name);
+                if (actual == expected) {
+                    fprintf(stderr, "  PASS: metric %s == %llu\n", name, expected);
+                } else {
+                    fprintf(stderr, "  FAIL: metric %s expected %llu, got %llu\n",
+                            name, expected, actual);
+                    failures++;
+                }
+            } else {
+                fprintf(stderr, "  ERROR: assert_metric needs <name> <expected>\n");
+                failures++;
+            }
+        }
+
         /* ── print (debug) ───────────────────────────────────────── */
         else if (strcmp(cmd, "print") == 0) {
             fprintf(stderr, "  state=%s  coins=%d  display=\"%s\" | \"%s\"\n",
@@ -799,6 +823,7 @@ int main(int argc, char *argv[]) {
 
         /* Reset state between scenarios */
         daemon_state_init(daemon_state);
+        metrics_reset_all();   /* keep per-scenario assert_metric independent */
         sim_display_line1[0] = '\0';
         sim_display_line2[0] = '\0';
         sim_display_count    = 0;

--- a/host/tests/test_coin_denomination_metrics.scenario
+++ b/host/tests/test_coin_denomination_metrics.scenario
@@ -1,0 +1,34 @@
+# Test: Per-denomination coin metrics
+# Verifies that each accepted coin is tallied into a denomination-specific
+# counter (coins_5c / coins_10c / coins_25c) in addition to the aggregate
+# coins_inserted (count) and coins_value_cents (total). The breakdown lets an
+# operator reconcile the coin box by coin, not just by dollar value.
+
+hook_up
+assert_state IDLE_UP
+
+# Insert a mix: two quarters, one dime, three nickels.
+coin 25
+coin 25
+coin 10
+coin 5
+coin 5
+coin 5
+assert_display Have: 75c
+
+# Aggregate counters: 6 coins worth 75c total.
+assert_metric coins_inserted 6
+assert_metric coins_value_cents 75
+
+# Per-denomination breakdown sums back to the same coins and value.
+assert_metric coins_25c 2
+assert_metric coins_10c 1
+assert_metric coins_5c 3
+
+# Coins arriving while the handset is down are not accepted (validator off),
+# so none of the denomination counters move.
+hook_down
+assert_state IDLE_DOWN
+coin 25
+assert_metric coins_25c 2
+assert_metric coins_inserted 6


### PR DESCRIPTION
## What

Adds per-denomination coin counters so the coin box can be reconciled by coin, not just by dollar value.

The daemon already exposes:
- `coins_inserted` — how many coins were accepted
- `coins_value_cents` — their total value

…but nothing about the **mix**. A `$5.00` take could be 20 quarters or 100 nickels, and coin-box capacity is per-coin (per tube/bin), not per-dollar — only the breakdown distinguishes them. This is exactly the data an operator needs when emptying/restocking the box.

## Change

- New counters incremented on the existing coin-accept path: `coins_5c`, `coins_10c`, `coins_25c`, plus a `coins_other` catch-all so no accepted coin ever goes uncounted if the validator gains a new denomination.
- Because they share the accept path with `coins_inserted`, the breakdown always reconciles with the aggregate (count and value).
- No new endpoint or wiring: the dynamic Prometheus/JSON exporters pick the counters up automatically.

## Testing

`make test` passes. Adds `tests/test_coin_denomination_metrics.scenario`, which:
- inserts a known mix (2× 25¢, 1× 10¢, 3× 5¢) and asserts each denomination counter plus the aggregates sum back consistently, and
- confirms a coin arriving while on-hook (validator disabled) is counted nowhere.

To make the scenario testable, this also adds two test-harness primitives that aren't on `main` yet: the `assert_metric` scenario command and a per-scenario `metrics_reset_all()`. These overlap trivially (identical additions) with the independent test-harness changes in #194 — whichever lands first, the other rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)