### PR TITLE
metrics: record ring duration and count missed incoming calls

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -35,6 +35,9 @@ health_monitor.o: health_monitor.c health_monitor.h logger.h
 metrics.o: metrics.c metrics.h
 	gcc metrics.c -o metrics.o -c $(CFLAGS)
 
+call_metrics.o: call_metrics.c call_metrics.h metrics.h clock_source.h
+	gcc call_metrics.c -o call_metrics.o -c $(CFLAGS)
+
 metrics_server.o: metrics_server.c metrics_server.h metrics.h logger.h
 	gcc metrics_server.c -o metrics_server.o -c $(CFLAGS)
 
@@ -74,7 +77,7 @@ audio_tones.o: audio_tones.c audio_tones.h logger.h
 updater.o: updater.c updater.h version.h logger.h
 	gcc updater.c -o updater.o -c $(CFLAGS)
 
-daemon.o: daemon.c millennium_sdk.h events.h event_processor.h config.h logger.h health_monitor.h metrics.h metrics_server.h web_server.h plugins.h state_persistence.h display_manager.h audio_tones.h
+daemon.o: daemon.c millennium_sdk.h events.h event_processor.h config.h logger.h health_monitor.h metrics.h metrics_server.h call_metrics.h web_server.h plugins.h state_persistence.h display_manager.h audio_tones.h
 	gcc daemon.c -o daemon.o -c $(CFLAGS)
 
 # Executables
@@ -102,15 +105,15 @@ plugins/dial_a_joke.o: plugins/dial_a_joke.c plugins.h plugin_sdk.h config.h
 plugins/trivia.o: plugins/trivia.c plugins.h plugin_sdk.h config.h
 	gcc plugins/trivia.c -o plugins/trivia.o -c $(CFLAGS)
 
-daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o
-	gcc daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o -o daemon $(LDFLAGS) -lm
+daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o
+	gcc daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o -o daemon $(LDFLAGS) -lm
 
 # Simulator object file
-simulator.o: simulator.c millennium_sdk.h events.h config.h daemon_state.h logger.h metrics.h plugins.h
+simulator.o: simulator.c millennium_sdk.h events.h config.h daemon_state.h logger.h metrics.h call_metrics.h plugins.h
 	gcc simulator.c -o simulator.o -c $(CFLAGS)
 
 # Simulator objects — no baresip, no web server, no daemon.o
-SIM_OBJS = simulator.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o
+SIM_OBJS = simulator.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o call_metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o
 
 # Simulated time is portable: the simulator installs a clock source
 # (clock_source.h) that the daemon/plugins read through, so no -Wl,--wrap hack.
@@ -122,9 +125,9 @@ simulator: $(SIM_OBJS)
 all: daemon
 
 # Unit test binary
-UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o updater.o
+UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o call_metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o updater.o
 
-tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h millennium_sdk.h updater.h
+tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h daemon_state.h plugins.h logger.h metrics.h call_metrics.h millennium_sdk.h updater.h
 	gcc tests/unit_tests.c -o tests/unit_tests.o -c $(CFLAGS) -I.
 
 # Unit tests don't use time wrapping; link ALSA on Linux for jukebox
@@ -162,7 +165,7 @@ test: simulator unit_tests
 # code on any Linux box with libasound2-dev (e.g. CI), short of a full link.
 COMPILE_CHECK_OBJS = daemon.o daemon_state.o clock_source.o millennium_sdk.o events.o \
 	event_processor.o config.o logger.o health_monitor.o metrics.o \
-	metrics_server.o web_server.o websocket.o plugins.o plugin_sdk.o \
+	metrics_server.o call_metrics.o web_server.o websocket.o plugins.o plugin_sdk.o \
 	plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o \
 	plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o \
 	plugins/trivia.o state_persistence.o display_manager.o version.o \

--- a/host/call_metrics.c
+++ b/host/call_metrics.c
@@ -1,0 +1,43 @@
+#include "call_metrics.h"
+#include "clock_source.h"
+#include "metrics.h"
+
+/* Name of the histogram populated by call_metrics_ended(). */
+#define CALL_DURATION_HISTOGRAM "call_duration_seconds"
+
+/* In-progress call timing. Accessed only from the daemon's main event-loop
+ * thread (and the single-threaded simulator / unit tests), each under the same
+ * serialization as the surrounding call/hook handlers, so no extra lock here. */
+static time_t g_call_start;
+static int    g_call_in_progress;
+
+void call_metrics_started(void) {
+    g_call_start = mclock_now();
+    g_call_in_progress = 1;
+}
+
+void call_metrics_ended(void) {
+    time_t now;
+    double elapsed;
+
+    if (!g_call_in_progress) {
+        return;
+    }
+
+    now = mclock_now();
+    elapsed = (double)(now - g_call_start);
+    /* Guard against a clock that moved backwards (NTP step, manual set). */
+    if (elapsed < 0.0) {
+        elapsed = 0.0;
+    }
+
+    metrics_observe_histogram(CALL_DURATION_HISTOGRAM, elapsed);
+
+    g_call_in_progress = 0;
+    g_call_start = 0;
+}
+
+void call_metrics_reset(void) {
+    g_call_in_progress = 0;
+    g_call_start = 0;
+}

--- a/host/call_metrics.c
+++ b/host/call_metrics.c
@@ -5,11 +5,17 @@
 /* Name of the histogram populated by call_metrics_ended(). */
 #define CALL_DURATION_HISTOGRAM "call_duration_seconds"
 
-/* In-progress call timing. Accessed only from the daemon's main event-loop
+/* Histogram and counter populated by the ring functions. */
+#define CALL_RING_HISTOGRAM "call_ring_seconds"
+#define CALLS_MISSED_COUNTER "calls_missed"
+
+/* In-progress call/ring timing. Accessed only from the daemon's main event-loop
  * thread (and the single-threaded simulator / unit tests), each under the same
  * serialization as the surrounding call/hook handlers, so no extra lock here. */
 static time_t g_call_start;
 static int    g_call_in_progress;
+static time_t g_ring_start;
+static int    g_ring_in_progress;
 
 void call_metrics_started(void) {
     g_call_start = mclock_now();
@@ -37,7 +43,49 @@ void call_metrics_ended(void) {
     g_call_start = 0;
 }
 
+void call_metrics_ringing_started(void) {
+    g_ring_start = mclock_now();
+    g_ring_in_progress = 1;
+}
+
+/* Observe the elapsed ring time into the call_ring_seconds histogram and clear
+ * the ring timer. Returns 1 if a ring was actually in progress (and therefore
+ * recorded), 0 otherwise, so callers can attribute the outcome accordingly. */
+static int call_metrics_ringing_observe(void) {
+    time_t now;
+    double elapsed;
+
+    if (!g_ring_in_progress) {
+        return 0;
+    }
+
+    now = mclock_now();
+    elapsed = (double)(now - g_ring_start);
+    /* Guard against a clock that moved backwards (NTP step, manual set). */
+    if (elapsed < 0.0) {
+        elapsed = 0.0;
+    }
+
+    metrics_observe_histogram(CALL_RING_HISTOGRAM, elapsed);
+
+    g_ring_in_progress = 0;
+    g_ring_start = 0;
+    return 1;
+}
+
+void call_metrics_ringing_answered(void) {
+    (void)call_metrics_ringing_observe();
+}
+
+void call_metrics_ringing_missed(void) {
+    if (call_metrics_ringing_observe()) {
+        metrics_increment_counter(CALLS_MISSED_COUNTER, 1);
+    }
+}
+
 void call_metrics_reset(void) {
     g_call_in_progress = 0;
     g_call_start = 0;
+    g_ring_in_progress = 0;
+    g_ring_start = 0;
 }

--- a/host/call_metrics.h
+++ b/host/call_metrics.h
@@ -2,7 +2,7 @@
 #define CALL_METRICS_H
 
 /*
- * Call-duration instrumentation.
+ * Call-duration and ring instrumentation.
  *
  * A call is "connected" from the moment audio is established (the phone enters
  * CALL_ACTIVE) until either party hangs up. call_metrics_started() stamps the
@@ -11,13 +11,25 @@
  * percentiles to Prometheus. For a payphone that bills by the call, the spread
  * of call lengths is the headline usage signal the coin counters can't show.
  *
+ * The ring functions cover the phase *before* a call connects. An incoming call
+ * "rings" from the moment it arrives (CALL_INCOMING) until it is either answered
+ * (handset lifted / SIP answer) or ends unanswered (caller gives up, timeout).
+ * call_metrics_ringing_started() stamps the ring; _answered()/_missed() observe
+ * the ring-to-resolution seconds into the `call_ring_seconds` histogram, and
+ * _missed() additionally bumps the `calls_missed` counter. Together they expose
+ * how long the phone rings and how often a ring goes unanswered — neither of
+ * which the existing calls_incoming/calls_answered counters can reveal.
+ *
  * Timestamps are read through mclock_now() (clock_source.h), so the scenario
  * simulator's advanceable clock measures duration with no real waiting and the
  * same code path runs on the Pi, in the simulator, and in unit tests.
  *
- * The pair is order-tolerant: an end without a start (e.g. hanging up while a
- * call was still only ringing) is a no-op, and a second start simply restamps.
- * Handlers can therefore call them defensively without tracking prior state.
+ * Every pair is order-tolerant: an end/resolution without a matching start is a
+ * no-op, and a second start simply restamps. Handlers can therefore call them
+ * defensively without tracking prior state. Crucially, because the ring timer is
+ * only armed by call_metrics_ringing_started() on a genuine inbound ring, the
+ * web-initiated outbound "start_call" path (which reuses the CALL_INCOMING state
+ * but never starts a ring) is never miscounted as a missed call.
  */
 
 /* Mark the start of a connected call (entry into CALL_ACTIVE). */
@@ -26,7 +38,20 @@ void call_metrics_started(void);
 /* Mark the end of a connected call; records its duration if one was started. */
 void call_metrics_ended(void);
 
-/* Discard any in-progress call timing without recording it (test seam). */
+/* Mark the start of an incoming call's ring (entry into CALL_INCOMING from a
+ * genuine inbound ring). Pairs with _answered()/_missed() below. */
+void call_metrics_ringing_started(void);
+
+/* Mark a ringing call as answered; records the ring-to-answer duration into the
+ * call_ring_seconds histogram. No-op if no ring was in progress. */
+void call_metrics_ringing_answered(void);
+
+/* Mark a ringing call as missed (it rang but ended before being answered);
+ * records the ring duration into call_ring_seconds and increments the
+ * calls_missed counter. No-op if no ring was in progress. */
+void call_metrics_ringing_missed(void);
+
+/* Discard any in-progress call/ring timing without recording it (test seam). */
 void call_metrics_reset(void);
 
 #endif /* CALL_METRICS_H */

--- a/host/call_metrics.h
+++ b/host/call_metrics.h
@@ -1,0 +1,32 @@
+#ifndef CALL_METRICS_H
+#define CALL_METRICS_H
+
+/*
+ * Call-duration instrumentation.
+ *
+ * A call is "connected" from the moment audio is established (the phone enters
+ * CALL_ACTIVE) until either party hangs up. call_metrics_started() stamps the
+ * connect time; call_metrics_ended() observes the elapsed wall-clock seconds
+ * into the `call_duration_seconds` histogram, exposing count/sum/min/max/mean/
+ * percentiles to Prometheus. For a payphone that bills by the call, the spread
+ * of call lengths is the headline usage signal the coin counters can't show.
+ *
+ * Timestamps are read through mclock_now() (clock_source.h), so the scenario
+ * simulator's advanceable clock measures duration with no real waiting and the
+ * same code path runs on the Pi, in the simulator, and in unit tests.
+ *
+ * The pair is order-tolerant: an end without a start (e.g. hanging up while a
+ * call was still only ringing) is a no-op, and a second start simply restamps.
+ * Handlers can therefore call them defensively without tracking prior state.
+ */
+
+/* Mark the start of a connected call (entry into CALL_ACTIVE). */
+void call_metrics_started(void);
+
+/* Mark the end of a connected call; records its duration if one was started. */
+void call_metrics_ended(void);
+
+/* Discard any in-progress call timing without recording it (test seam). */
+void call_metrics_reset(void);
+
+#endif /* CALL_METRICS_H */

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -352,7 +352,8 @@ void handle_call_state_event(call_state_event_t *call_state_event) {
         
         logger_info_with_category("Call", "Incoming call received");
         metrics_increment_counter("calls_incoming", 1);
-        
+        call_metrics_ringing_started();
+
         update_display_with_content("Call incoming...", line2);
         
         daemon_state->current_state = DAEMON_STATE_CALL_INCOMING;
@@ -367,6 +368,9 @@ void handle_call_state_event(call_state_event_t *call_state_event) {
 
         daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
         daemon_state_update_activity(daemon_state);
+        /* If this transition answered a ring (SIP-side answer), close it out;
+         * a no-op for outbound calls that were never ringing. */
+        call_metrics_ringing_answered();
         call_metrics_started();
     } else if (call_state_event_get_state(call_state_event) == EVENT_CALL_STATE_INVALID) {
         /* #90/#91: Call ended - remote hung up or call failed during dial */
@@ -382,6 +386,11 @@ void handle_call_state_event(call_state_event_t *call_state_event) {
         } else if (daemon_state->current_state == DAEMON_STATE_CALL_INCOMING) {
             /* #91: Call failed during dial - don't clear coins (refund via plugin) */
             logger_info_with_category("Call", "Call failed during dial");
+            /* A genuine inbound ring that ended here was never answered: record
+             * the ring time and count the miss. No-op for the web-initiated
+             * outbound start_call path, which reuses CALL_INCOMING without a
+             * ring, so outbound dial failures are not counted as missed. */
+            call_metrics_ringing_missed();
             daemon_state_clear_keypad(daemon_state);
             daemon_state->current_state = DAEMON_STATE_IDLE_UP;
             daemon_state_update_activity(daemon_state);
@@ -445,6 +454,7 @@ void handle_hook_event(hook_state_change_event_t *hook_event) {
 
             daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
             daemon_state_update_activity(daemon_state);
+            call_metrics_ringing_answered();
             call_metrics_started();
 
         } else if (phone_down) {

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -4,6 +4,7 @@
 #include "logger.h"
 #include "metrics.h"
 #include "metrics_server.h"
+#include "call_metrics.h"
 #include "health_monitor.h"
 #include "web_server.h"
 #include "millennium_sdk.h"
@@ -363,14 +364,16 @@ void handle_call_state_event(call_state_event_t *call_state_event) {
         metrics_increment_counter("calls_established", 1);
         
         update_display_with_content("Call active", "Audio connected");
-        
+
         daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
         daemon_state_update_activity(daemon_state);
+        call_metrics_started();
     } else if (call_state_event_get_state(call_state_event) == EVENT_CALL_STATE_INVALID) {
         /* #90/#91: Call ended - remote hung up or call failed during dial */
         if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE) {
             logger_info_with_category("Call", "Call ended by remote party");
             metrics_increment_counter("calls_ended", 1);
+            call_metrics_ended();
             daemon_state_clear_keypad(daemon_state);
             daemon_state->inserted_cents = 0;
             daemon_state->current_state = DAEMON_STATE_IDLE_UP;
@@ -439,10 +442,11 @@ void handle_hook_event(hook_state_change_event_t *hook_event) {
         if (call_incoming) {
             logger_info_with_category("Call", "Call answered");
             metrics_increment_counter("calls_answered", 1);
-            
+
             daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
             daemon_state_update_activity(daemon_state);
-            
+            call_metrics_started();
+
         } else if (phone_down) {
             logger_info_with_category("Hook", "Hook lifted, transitioning to IDLE_UP");
             metrics_increment_counter("hook_lifted", 1);
@@ -461,8 +465,9 @@ void handle_hook_event(hook_state_change_event_t *hook_event) {
         
         if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE) {
             metrics_increment_counter("calls_ended", 1);
+            call_metrics_ended();
         }
-        
+
         daemon_state_clear_keypad(daemon_state);
         daemon_state->inserted_cents = 0;
         

--- a/host/simulator.c
+++ b/host/simulator.c
@@ -8,6 +8,7 @@
 extern daemon_state_data_t *daemon_state;
 #include "logger.h"
 #include "metrics.h"
+#include "call_metrics.h"
 #include "event_processor.h"
 #include "plugins.h"
 #include "state_persistence.h"
@@ -318,6 +319,7 @@ static void sim_handle_hook(hook_state_change_event_t *ev) {
     if (hook_up) {
         if (daemon_state->current_state == DAEMON_STATE_CALL_INCOMING) {
             daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
+            call_metrics_started();  /* mirror daemon.c: incoming call answered */
         } else if (daemon_state->current_state == DAEMON_STATE_IDLE_DOWN) {
             daemon_state->current_state = DAEMON_STATE_IDLE_UP;
             daemon_state->inserted_cents = 0;
@@ -325,6 +327,9 @@ static void sim_handle_hook(hook_state_change_event_t *ev) {
         }
         daemon_state_update_activity(daemon_state);
     } else if (hook_down) {
+        if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE) {
+            call_metrics_ended();  /* mirror daemon.c: local hangup ends the call */
+        }
         daemon_state_clear_keypad(daemon_state);
         daemon_state->inserted_cents = 0;
         daemon_state->current_state = DAEMON_STATE_IDLE_DOWN;
@@ -370,10 +375,15 @@ static void sim_handle_call_state(call_state_event_t *ev) {
     } else if (st == EVENT_CALL_STATE_ACTIVE) {
         daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
         daemon_state_update_activity(daemon_state);
+        call_metrics_started();  /* mirror daemon.c: call established */
     } else if (st == EVENT_CALL_STATE_INVALID) {
         /* #90: Remote hung up */
         if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE ||
             daemon_state->current_state == DAEMON_STATE_CALL_INCOMING) {
+            /* Only a connected (CALL_ACTIVE) call has a duration to record. */
+            if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE) {
+                call_metrics_ended();
+            }
             daemon_state_clear_keypad(daemon_state);
             daemon_state->inserted_cents = 0;
             daemon_state->current_state = DAEMON_STATE_IDLE_UP;
@@ -586,6 +596,13 @@ static int run_scenario(const char *path) {
                 sim_drain_events();
                 if (sim_hangup_called) {
                     sim_hangup_called = 0;
+                    /* A plugin hanging up a connected call (e.g. paid time ran
+                     * out) ends it just like a remote/local hangup. On the Pi
+                     * that returns as a CALL INVALID event through
+                     * handle_call_state; mirror its duration recording here. */
+                    if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE) {
+                        call_metrics_ended();
+                    }
                     daemon_state->current_state = DAEMON_STATE_IDLE_DOWN;
                 }
             }
@@ -626,6 +643,41 @@ static int run_scenario(const char *path) {
             } else {
                 fprintf(stderr, "  FAIL: expected state containing \"%s\", got \"%s\"\n",
                         arg, actual);
+                failures++;
+            }
+        }
+
+        /* ── assert_histogram <name> <count> <sum> ───────────────── */
+        else if (strncmp(cmd, "assert_histogram ", 17) == 0) {
+            char name[128];
+            unsigned long long want_count;
+            double want_sum;
+            if (sscanf(cmd + 17, "%127s %llu %lf",
+                       name, &want_count, &want_sum) == 3) {
+                metrics_histogram_stats_t stats;
+                if (metrics_get_histogram_stats(name, &stats) != 0) {
+                    fprintf(stderr, "  FAIL: histogram %s not found\n", name);
+                    failures++;
+                } else if (stats.count != want_count) {
+                    fprintf(stderr,
+                            "  FAIL: histogram %s count expected %llu, got %llu\n",
+                            name, want_count,
+                            (unsigned long long)stats.count);
+                    failures++;
+                } else if (stats.sum < want_sum - 0.5 ||
+                           stats.sum > want_sum + 0.5) {
+                    fprintf(stderr,
+                            "  FAIL: histogram %s sum expected %.1f, got %.1f\n",
+                            name, want_sum, stats.sum);
+                    failures++;
+                } else {
+                    fprintf(stderr,
+                            "  PASS: histogram %s count=%llu sum=%.1f\n",
+                            name, want_count, stats.sum);
+                }
+            } else {
+                fprintf(stderr,
+                        "  ERROR: assert_histogram needs <name> <count> <sum>\n");
                 failures++;
             }
         }
@@ -805,6 +857,8 @@ int main(int argc, char *argv[]) {
         sim_call_pending     = 0;
         sim_call_active      = 0;
         sim_hangup_called    = 0;
+        call_metrics_reset();  /* drop any dangling call timer from prior scenario */
+        metrics_reset_all();   /* keep per-scenario metric assertions independent */
         sim_time_init();
         plugins_activate("Classic Phone");
 

--- a/host/simulator.c
+++ b/host/simulator.c
@@ -319,6 +319,7 @@ static void sim_handle_hook(hook_state_change_event_t *ev) {
     if (hook_up) {
         if (daemon_state->current_state == DAEMON_STATE_CALL_INCOMING) {
             daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
+            call_metrics_ringing_answered();  /* mirror daemon.c: ring answered */
             call_metrics_started();  /* mirror daemon.c: incoming call answered */
         } else if (daemon_state->current_state == DAEMON_STATE_IDLE_DOWN) {
             daemon_state->current_state = DAEMON_STATE_IDLE_UP;
@@ -371,18 +372,23 @@ static void sim_handle_call_state(call_state_event_t *ev) {
     if (st == EVENT_CALL_STATE_INCOMING && (phone_down || phone_up)) {
         /* #92: Accept incoming when handset down or up */
         daemon_state->current_state = DAEMON_STATE_CALL_INCOMING;
+        call_metrics_ringing_started();  /* mirror daemon.c: ring started */
         daemon_state_update_activity(daemon_state);
     } else if (st == EVENT_CALL_STATE_ACTIVE) {
         daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
         daemon_state_update_activity(daemon_state);
+        call_metrics_ringing_answered();  /* mirror daemon.c: SIP-side answer */
         call_metrics_started();  /* mirror daemon.c: call established */
     } else if (st == EVENT_CALL_STATE_INVALID) {
         /* #90: Remote hung up */
         if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE ||
             daemon_state->current_state == DAEMON_STATE_CALL_INCOMING) {
-            /* Only a connected (CALL_ACTIVE) call has a duration to record. */
+            /* A connected (CALL_ACTIVE) call has a duration to record; a call
+             * still ringing (CALL_INCOMING) ended unanswered — a missed call. */
             if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE) {
                 call_metrics_ended();
+            } else {
+                call_metrics_ringing_missed();
             }
             daemon_state_clear_keypad(daemon_state);
             daemon_state->inserted_cents = 0;
@@ -678,6 +684,28 @@ static int run_scenario(const char *path) {
             } else {
                 fprintf(stderr,
                         "  ERROR: assert_histogram needs <name> <count> <sum>\n");
+                failures++;
+            }
+        }
+
+        /* ── assert_counter <name> <value> ───────────────────────── */
+        else if (strncmp(cmd, "assert_counter ", 15) == 0) {
+            char name[128];
+            unsigned long long want;
+            if (sscanf(cmd + 15, "%127s %llu", name, &want) == 2) {
+                unsigned long long got =
+                    (unsigned long long)metrics_get_counter(name);
+                if (got != want) {
+                    fprintf(stderr,
+                            "  FAIL: counter %s expected %llu, got %llu\n",
+                            name, want, got);
+                    failures++;
+                } else {
+                    fprintf(stderr, "  PASS: counter %s = %llu\n", name, got);
+                }
+            } else {
+                fprintf(stderr,
+                        "  ERROR: assert_counter needs <name> <value>\n");
                 failures++;
             }
         }

--- a/host/tests/test_call_duration_metrics.scenario
+++ b/host/tests/test_call_duration_metrics.scenario
@@ -1,0 +1,44 @@
+# Test: Call-duration histogram metric
+# A call is "connected" only from CALL_ACTIVE until either party hangs up. The
+# daemon stamps that interval and records the elapsed seconds into the
+# call_duration_seconds histogram, so an operator can see the spread of call
+# lengths (count/sum/percentiles) the coin counters can't show. Durations are
+# measured through the clock seam, so the simulator's `wait` advances time
+# instantly and the recorded values are exact.
+#
+# Run under a game plugin that imposes no call-time limit, so a call lasts
+# exactly until we end it (the Classic Phone plugin would auto-hang-up on its
+# own timeout, which is exercised separately by the unit tests).
+activate_plugin Number Guess
+
+# 1) An incoming call that is never answered reaches CALL_INCOMING but not
+#    CALL_ACTIVE, so it contributes no duration.
+call_incoming
+assert_state CALL_INCOMING
+call_ended
+assert_state IDLE_UP
+
+# 2) An incoming call answered by lifting the handset, then ended by the far
+#    end. Connected for 30 seconds.
+call_incoming
+assert_state CALL_INCOMING
+hook_up
+assert_state CALL_ACTIVE
+wait 30
+call_ended
+assert_state IDLE_UP
+
+# Only the answered call was recorded: one observation of 30 seconds. The
+# unanswered call in step 1 added nothing.
+assert_histogram call_duration_seconds 1 30
+
+# 3) An outgoing call that connects (CALL_ESTABLISHED) and is ended by hanging
+#    up the handset locally. Connected for 45 seconds.
+call_active
+assert_state CALL_ACTIVE
+wait 45
+hook_down
+assert_state IDLE_DOWN
+
+# Two calls recorded now, totalling 30 + 45 = 75 seconds.
+assert_histogram call_duration_seconds 2 75

--- a/host/tests/test_missed_call_metrics.scenario
+++ b/host/tests/test_missed_call_metrics.scenario
@@ -1,0 +1,48 @@
+# Test: Ring-duration histogram and missed-call counter
+# Before a call connects it "rings": an incoming call sits in CALL_INCOMING from
+# the moment it arrives until it is answered (handset lifted) or ends unanswered.
+# The daemon stamps that interval through the clock seam and records the elapsed
+# seconds into the call_ring_seconds histogram; a ring that ends without an
+# answer also bumps the calls_missed counter. Together they show how long the
+# phone rings and how often a ring goes unanswered — which the existing
+# calls_incoming/calls_answered counters can't reveal. `wait` advances the
+# simulated clock instantly, so the recorded ring times are exact.
+#
+# Run under a plugin with no call-time limit so a ring lasts exactly as long as
+# we let it.
+activate_plugin Number Guess
+
+# 1) An incoming call that rings 20 seconds and is then abandoned (the caller
+#    gives up). It never reaches CALL_ACTIVE, so it is a missed call.
+call_incoming
+assert_state CALL_INCOMING
+wait 20
+call_ended
+assert_state IDLE_UP
+
+# One ring recorded (20s); one miss counted.
+assert_histogram call_ring_seconds 1 20
+assert_counter calls_missed 1
+
+# 2) A second abandoned ring (10s); the miss counter keeps climbing.
+call_incoming
+assert_state CALL_INCOMING
+wait 10
+call_ended
+assert_state IDLE_UP
+
+# Two rings recorded now (20 + 10 = 30s); two misses.
+assert_histogram call_ring_seconds 2 30
+assert_counter calls_missed 2
+
+# 3) An incoming call that rings 5 seconds and is answered by lifting the
+#    handset. The ring time is recorded, but it is NOT a miss.
+call_incoming
+assert_state CALL_INCOMING
+wait 5
+hook_up
+assert_state CALL_ACTIVE
+
+# Three rings recorded now (30 + 5 = 35s); the miss count is unchanged at 2.
+assert_histogram call_ring_seconds 3 35
+assert_counter calls_missed 2

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -5,6 +5,7 @@
 #include "../plugins.h"
 #include "../logger.h"
 #include "../metrics.h"
+#include "../call_metrics.h"
 #include "../millennium_sdk.h"
 #include "../updater.h"
 #include "../plugin_sdk.h"
@@ -936,6 +937,69 @@ static void test_logger_queue_stats(void) {
     remove(path);
 }
 
+/* ── Call-duration metric tests ────────────────────────────────── */
+
+/* call_metrics times a connected call between started()/ended() using the
+ * clock seam and records the elapsed seconds into the call_duration_seconds
+ * histogram. Drive it with the fake clock so "elapsed time" is exact and
+ * instant, then verify the histogram count/sum and the order-tolerance and
+ * backwards-clock guards. */
+static void test_call_duration_histogram(void) {
+    metrics_histogram_stats_t stats;
+
+    TEST_ASSERT_EQ_INT(metrics_init(), 0);
+    mclock_set_source(fake_clock_source);
+    call_metrics_reset();
+
+    /* A 42-second call. */
+    g_fake_clock = 5000;
+    call_metrics_started();
+    g_fake_clock = 5042;
+    call_metrics_ended();
+
+    TEST_ASSERT_EQ_INT(metrics_get_histogram_stats("call_duration_seconds", &stats), 0);
+    TEST_ASSERT_EQ_INT((int)stats.count, 1);
+    TEST_ASSERT(stats.sum == 42.0);
+    TEST_ASSERT(stats.max == 42.0);
+
+    /* A second, 60-second call accumulates into the same histogram. */
+    g_fake_clock = 5042;
+    call_metrics_started();
+    g_fake_clock = 5102;
+    call_metrics_ended();
+
+    TEST_ASSERT_EQ_INT(metrics_get_histogram_stats("call_duration_seconds", &stats), 0);
+    TEST_ASSERT_EQ_INT((int)stats.count, 2);
+    TEST_ASSERT(stats.sum == 102.0);
+    TEST_ASSERT(stats.max == 60.0);
+
+    /* ended() without a matching started() records nothing. */
+    call_metrics_ended();
+    TEST_ASSERT_EQ_INT(metrics_get_histogram_stats("call_duration_seconds", &stats), 0);
+    TEST_ASSERT_EQ_INT((int)stats.count, 2);
+
+    /* reset() discards an in-progress call so it is never recorded. */
+    g_fake_clock = 6000;
+    call_metrics_started();
+    call_metrics_reset();
+    g_fake_clock = 6100;
+    call_metrics_ended();
+    TEST_ASSERT_EQ_INT(metrics_get_histogram_stats("call_duration_seconds", &stats), 0);
+    TEST_ASSERT_EQ_INT((int)stats.count, 2);
+
+    /* A clock that steps backwards clamps the duration to 0, never negative. */
+    g_fake_clock = 7000;
+    call_metrics_started();
+    g_fake_clock = 6950;
+    call_metrics_ended();
+    TEST_ASSERT_EQ_INT(metrics_get_histogram_stats("call_duration_seconds", &stats), 0);
+    TEST_ASSERT_EQ_INT((int)stats.count, 3);
+    TEST_ASSERT(stats.sum == 102.0);   /* the clamped 0 added nothing */
+
+    mclock_set_source(NULL);
+    metrics_cleanup();
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -1017,6 +1081,9 @@ int main(void) {
     TEST_SUITE_BEGIN("Logger");
     TEST_SUITE_RUN(test_logger_async_file_write);
     TEST_SUITE_RUN(test_logger_queue_stats);
+
+    TEST_SUITE_BEGIN("Call Metrics");
+    TEST_SUITE_RUN(test_call_duration_histogram);
 
     TEST_REPORT();
 }

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -1000,6 +1000,78 @@ static void test_call_duration_histogram(void) {
     metrics_cleanup();
 }
 
+/* The ring functions time the pre-connect phase of an incoming call and record
+ * the seconds into call_ring_seconds. _missed() also bumps the calls_missed
+ * counter, while _answered() does not — that is how a missed ring is told from
+ * an answered one. Crucially, both are no-ops without a started ring, so the
+ * web-initiated outbound start_call path (which reuses CALL_INCOMING but never
+ * rings) is never miscounted as a miss. */
+static void test_call_ring_metrics(void) {
+    metrics_histogram_stats_t stats;
+
+    TEST_ASSERT_EQ_INT(metrics_init(), 0);
+    mclock_set_source(fake_clock_source);
+    call_metrics_reset();
+
+    /* An incoming call that rang 8 seconds and was then answered: the ring time
+     * is recorded, but no miss is counted. */
+    g_fake_clock = 5000;
+    call_metrics_ringing_started();
+    g_fake_clock = 5008;
+    call_metrics_ringing_answered();
+
+    TEST_ASSERT_EQ_INT(metrics_get_histogram_stats("call_ring_seconds", &stats), 0);
+    TEST_ASSERT_EQ_INT((int)stats.count, 1);
+    TEST_ASSERT(stats.sum == 8.0);
+    TEST_ASSERT(stats.max == 8.0);
+    TEST_ASSERT_EQ_INT((int)metrics_get_counter("calls_missed"), 0);
+
+    /* An incoming call that rang 30 seconds and was abandoned: ring time is
+     * recorded into the same histogram, and the miss is counted. */
+    g_fake_clock = 6000;
+    call_metrics_ringing_started();
+    g_fake_clock = 6030;
+    call_metrics_ringing_missed();
+
+    TEST_ASSERT_EQ_INT(metrics_get_histogram_stats("call_ring_seconds", &stats), 0);
+    TEST_ASSERT_EQ_INT((int)stats.count, 2);
+    TEST_ASSERT(stats.sum == 38.0);
+    TEST_ASSERT(stats.max == 30.0);
+    TEST_ASSERT_EQ_INT((int)metrics_get_counter("calls_missed"), 1);
+
+    /* A resolution with no ring in progress records nothing and counts no miss:
+     * this is the outbound start_call (CALL_INCOMING without a ring) path. */
+    call_metrics_ringing_missed();
+    call_metrics_ringing_answered();
+    TEST_ASSERT_EQ_INT(metrics_get_histogram_stats("call_ring_seconds", &stats), 0);
+    TEST_ASSERT_EQ_INT((int)stats.count, 2);
+    TEST_ASSERT_EQ_INT((int)metrics_get_counter("calls_missed"), 1);
+
+    /* reset() discards an in-progress ring so it is never recorded. */
+    g_fake_clock = 7000;
+    call_metrics_ringing_started();
+    call_metrics_reset();
+    g_fake_clock = 7100;
+    call_metrics_ringing_missed();
+    TEST_ASSERT_EQ_INT(metrics_get_histogram_stats("call_ring_seconds", &stats), 0);
+    TEST_ASSERT_EQ_INT((int)stats.count, 2);
+    TEST_ASSERT_EQ_INT((int)metrics_get_counter("calls_missed"), 1);
+
+    /* A clock that steps backwards clamps the ring duration to 0, never
+     * negative, and still counts the miss. */
+    g_fake_clock = 8000;
+    call_metrics_ringing_started();
+    g_fake_clock = 7950;
+    call_metrics_ringing_missed();
+    TEST_ASSERT_EQ_INT(metrics_get_histogram_stats("call_ring_seconds", &stats), 0);
+    TEST_ASSERT_EQ_INT((int)stats.count, 3);
+    TEST_ASSERT(stats.sum == 38.0);   /* the clamped 0 added nothing */
+    TEST_ASSERT_EQ_INT((int)metrics_get_counter("calls_missed"), 2);
+
+    mclock_set_source(NULL);
+    metrics_cleanup();
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -1084,6 +1156,7 @@ int main(void) {
 
     TEST_SUITE_BEGIN("Call Metrics");
     TEST_SUITE_RUN(test_call_duration_histogram);
+    TEST_SUITE_RUN(test_call_ring_metrics);
 
     TEST_REPORT();
 }


### PR DESCRIPTION
## Summary

The recently-added `call_duration_seconds` histogram (38a5f8a) only measures calls that **connect**. The phase *before* connect — an incoming call ringing in `CALL_INCOMING` until it's answered or the caller gives up — was completely invisible to metrics:

- `calls_incoming` counts rings and `calls_answered` counts pickups, but a ring that **ends unanswered incremented neither counter**.
- The **time spent ringing** was never recorded at all.

For a payphone, *"how long does it ring"* and *"how often does a ring go unanswered"* are real usage signals the existing counters can't reveal.

## What this adds

- **`call_ring_seconds` histogram** — ring-to-resolution duration (count/sum/min/max/mean/percentiles), mirroring the connected-call duration histogram.
- **`calls_missed` counter** — rings that ended before being answered.

`call_metrics` gains a ring timer that mirrors the existing connected-call timer:

- `call_metrics_ringing_started()` stamps the ring on entry to `CALL_INCOMING`.
- `call_metrics_ringing_answered()` / `call_metrics_ringing_missed()` observe the elapsed seconds into `call_ring_seconds`; `_missed()` also bumps `calls_missed`.

Both resolutions are **no-ops without a started ring**, so the web-initiated outbound `start_call` path (which reuses `CALL_INCOMING` but never rings) is never miscounted as a missed call. The backwards-clock guard from the duration timer is reused.

## Wiring

Four resolution points in `daemon.c`, mirrored in `simulator.c`:

| Site | Call |
|------|------|
| Incoming ring arrives | `ringing_started()` |
| Answered via hook-lift | `ringing_answered()` |
| Answered via SIP-side `CALL_ESTABLISHED` | `ringing_answered()` |
| `CALL_INCOMING → INVALID` (caller gave up / dial failed) | `ringing_missed()` |

## Tests

- New `assert_counter <name> <value>` scenario command.
- Unit test `test_call_ring_metrics` — histogram + counter, order-tolerance (resolution without a ring is a no-op), reset seam, and backwards-clock clamp.
- End-to-end `tests/test_missed_call_metrics.scenario` driving abandoned and answered rings through the simulator.

`make test` passes (62 unit assertions, all scenarios green); `daemon.c` and `call_metrics.c` compile clean under `-Wall -Wextra -Werror -std=gnu89`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)