### PR TITLE
metrics: count outbound dial failures as calls_failed

### DIFF
--- a/host/call_metrics.c
+++ b/host/call_metrics.c
@@ -5,9 +5,10 @@
 /* Name of the histogram populated by call_metrics_ended(). */
 #define CALL_DURATION_HISTOGRAM "call_duration_seconds"
 
-/* Histogram and counter populated by the ring functions. */
+/* Histogram and counters populated by the ring / incoming-ended functions. */
 #define CALL_RING_HISTOGRAM "call_ring_seconds"
 #define CALLS_MISSED_COUNTER "calls_missed"
+#define CALLS_FAILED_COUNTER "calls_failed"
 
 /* In-progress call/ring timing. Accessed only from the daemon's main event-loop
  * thread (and the single-threaded simulator / unit tests), each under the same
@@ -77,9 +78,18 @@ void call_metrics_ringing_answered(void) {
     (void)call_metrics_ringing_observe();
 }
 
-void call_metrics_ringing_missed(void) {
+void call_metrics_incoming_ended(void) {
+    /* The CALL_INCOMING phase ended before the call became active. Exactly one
+     * of two things happened, told apart by whether a genuine inbound ring was
+     * in progress: */
     if (call_metrics_ringing_observe()) {
+        /* A real inbound ring went unanswered — the caller gave up. */
         metrics_increment_counter(CALLS_MISSED_COUNTER, 1);
+    } else {
+        /* No ring was ever armed, so the phone was placing an OUTBOUND call
+         * that never connected (callee busy, no answer, rejected, or a SIP /
+         * network error). This is the #91 "Call failed during dial" path. */
+        metrics_increment_counter(CALLS_FAILED_COUNTER, 1);
     }
 }
 

--- a/host/call_metrics.h
+++ b/host/call_metrics.h
@@ -14,22 +14,34 @@
  * The ring functions cover the phase *before* a call connects. An incoming call
  * "rings" from the moment it arrives (CALL_INCOMING) until it is either answered
  * (handset lifted / SIP answer) or ends unanswered (caller gives up, timeout).
- * call_metrics_ringing_started() stamps the ring; _answered()/_missed() observe
- * the ring-to-resolution seconds into the `call_ring_seconds` histogram, and
- * _missed() additionally bumps the `calls_missed` counter. Together they expose
- * how long the phone rings and how often a ring goes unanswered — neither of
- * which the existing calls_incoming/calls_answered counters can reveal.
+ * call_metrics_ringing_started() stamps the ring; _answered() and
+ * _incoming_ended() observe the ring-to-resolution seconds into the
+ * `call_ring_seconds` histogram. Together they expose how long the phone rings
+ * and how often a ring goes unanswered — neither of which the existing
+ * calls_incoming/calls_answered counters can reveal.
+ *
+ * call_metrics_incoming_ended() resolves the single daemon transition where a
+ * CALL_INCOMING phase ends *without* the call ever becoming active, and counts
+ * exactly one of two mutually exclusive outcomes:
+ *   - a genuine inbound ring was in progress -> the caller gave up: records the
+ *     ring time and bumps the `calls_missed` counter;
+ *   - no ring was armed -> the phone was placing an OUTBOUND call that never
+ *     connected (busy / no answer / rejected / SIP or network error), so it
+ *     bumps the `calls_failed` counter instead. Outbound dial failures were
+ *     previously invisible to monitoring; for a payphone that bills by the
+ *     call, the connect-failure rate (the gap between calls_initiated and
+ *     calls_established) is the headline reliability signal.
  *
  * Timestamps are read through mclock_now() (clock_source.h), so the scenario
  * simulator's advanceable clock measures duration with no real waiting and the
  * same code path runs on the Pi, in the simulator, and in unit tests.
  *
- * Every pair is order-tolerant: an end/resolution without a matching start is a
- * no-op, and a second start simply restamps. Handlers can therefore call them
- * defensively without tracking prior state. Crucially, because the ring timer is
- * only armed by call_metrics_ringing_started() on a genuine inbound ring, the
- * web-initiated outbound "start_call" path (which reuses the CALL_INCOMING state
- * but never starts a ring) is never miscounted as a missed call.
+ * The ring start/answer pair is order-tolerant: a resolution without a matching
+ * start records nothing into the histogram, and a second start simply restamps.
+ * Because the ring timer is only armed by call_metrics_ringing_started() on a
+ * genuine inbound ring, the web-initiated outbound "start_call" path (which
+ * reuses the CALL_INCOMING state but never starts a ring) is never miscounted as
+ * a missed call — call_metrics_incoming_ended() attributes it to calls_failed.
  */
 
 /* Mark the start of a connected call (entry into CALL_ACTIVE). */
@@ -46,10 +58,13 @@ void call_metrics_ringing_started(void);
  * call_ring_seconds histogram. No-op if no ring was in progress. */
 void call_metrics_ringing_answered(void);
 
-/* Mark a ringing call as missed (it rang but ended before being answered);
- * records the ring duration into call_ring_seconds and increments the
- * calls_missed counter. No-op if no ring was in progress. */
-void call_metrics_ringing_missed(void);
+/* Resolve a CALL_INCOMING phase that ended before the call became active.
+ * If an inbound ring was in progress, records the ring duration into
+ * call_ring_seconds and increments calls_missed (the caller gave up); otherwise
+ * the phone was dialing out and the attempt never connected, so it increments
+ * calls_failed instead. Exactly one counter moves, so a transition is never
+ * double-counted as both a miss and a failure. */
+void call_metrics_incoming_ended(void);
 
 /* Discard any in-progress call/ring timing without recording it (test seam). */
 void call_metrics_reset(void);

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -386,11 +386,11 @@ void handle_call_state_event(call_state_event_t *call_state_event) {
         } else if (daemon_state->current_state == DAEMON_STATE_CALL_INCOMING) {
             /* #91: Call failed during dial - don't clear coins (refund via plugin) */
             logger_info_with_category("Call", "Call failed during dial");
-            /* A genuine inbound ring that ended here was never answered: record
-             * the ring time and count the miss. No-op for the web-initiated
-             * outbound start_call path, which reuses CALL_INCOMING without a
-             * ring, so outbound dial failures are not counted as missed. */
-            call_metrics_ringing_missed();
+            /* Resolve the ended CALL_INCOMING phase: a genuine inbound ring that
+             * was never answered counts a miss (call_ring_seconds + calls_missed),
+             * while the web-initiated outbound start_call path (CALL_INCOMING
+             * without a ring) counts an outbound dial failure (calls_failed). */
+            call_metrics_incoming_ended();
             daemon_state_clear_keypad(daemon_state);
             daemon_state->current_state = DAEMON_STATE_IDLE_UP;
             daemon_state_update_activity(daemon_state);

--- a/host/simulator.c
+++ b/host/simulator.c
@@ -383,12 +383,13 @@ static void sim_handle_call_state(call_state_event_t *ev) {
         /* #90: Remote hung up */
         if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE ||
             daemon_state->current_state == DAEMON_STATE_CALL_INCOMING) {
-            /* A connected (CALL_ACTIVE) call has a duration to record; a call
-             * still ringing (CALL_INCOMING) ended unanswered — a missed call. */
+            /* A connected (CALL_ACTIVE) call has a duration to record; a
+             * CALL_INCOMING phase that ended before connecting is resolved as
+             * either a missed inbound ring or a failed outbound dial. */
             if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE) {
                 call_metrics_ended();
             } else {
-                call_metrics_ringing_missed();
+                call_metrics_incoming_ended();
             }
             daemon_state_clear_keypad(daemon_state);
             daemon_state->inserted_cents = 0;
@@ -587,6 +588,16 @@ static int run_scenario(const char *path) {
                 "CALL_CLOSED", NULL, EVENT_CALL_STATE_INVALID);
             if (ev) { sim_process_event((event_t *)ev); event_destroy((event_t *)ev); }
             sim_call_active = 0;
+            sim_drain_events();
+        }
+        /* start_call: mirror daemon.c's web "start_call" control action — place
+         * an OUTBOUND call by entering CALL_INCOMING WITHOUT arming a ring, so a
+         * subsequent call_ended is counted as a dial failure (calls_failed),
+         * never as a missed inbound call. */
+        else if (strcmp(cmd, "start_call") == 0) {
+            daemon_state->current_state = DAEMON_STATE_CALL_INCOMING;
+            metrics_increment_counter("calls_initiated", 1);
+            daemon_state_update_activity(daemon_state);
             sim_drain_events();
         }
 

--- a/host/tests/test_failed_call_metrics.scenario
+++ b/host/tests/test_failed_call_metrics.scenario
@@ -1,0 +1,49 @@
+# Test: Outbound dial-failure counter (calls_failed)
+# When the phone places an outbound call (the web "start_call" control action),
+# it enters CALL_INCOMING WITHOUT arming a ring — unlike a genuine inbound call.
+# If that call never connects (callee busy, no answer, rejected, or a SIP /
+# network error) it ends straight from CALL_INCOMING, and the daemon counts it
+# as a dial failure in `calls_failed`, NOT as a missed inbound call. For a
+# payphone that bills by the call, the connect-failure rate — the gap between
+# calls_initiated and calls_established — is the headline reliability signal,
+# and it must never be conflated with the calls_missed counter that tracks
+# unanswered inbound rings.
+#
+# Run under a plugin with no call-time limit so timing is driven only by us.
+activate_plugin Number Guess
+
+# 1) Place an outbound call. start_call enters CALL_INCOMING but arms no ring.
+start_call
+assert_state CALL_INCOMING
+
+# It rings out for 12 seconds (from the caller's side) and never connects.
+wait 12
+call_ended
+assert_state IDLE_UP
+
+# The attempt is counted as a failure, not a miss. (That no ring time is
+# recorded is proven in step 3: only the one genuine inbound ring lands in the
+# call_ring_seconds histogram — these outbound failures never touch it.)
+assert_counter calls_failed 1
+assert_counter calls_missed 0
+
+# 2) A second outbound attempt that also fails: the failure counter climbs.
+start_call
+assert_state CALL_INCOMING
+call_ended
+assert_state IDLE_UP
+
+assert_counter calls_failed 2
+assert_counter calls_missed 0
+
+# 3) A genuine inbound ring that goes unanswered is still a miss, not a failure:
+#    the two counters stay cleanly separated.
+call_incoming
+assert_state CALL_INCOMING
+wait 5
+call_ended
+assert_state IDLE_UP
+
+assert_counter calls_missed 1
+assert_counter calls_failed 2
+assert_histogram call_ring_seconds 1 5

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -1000,13 +1000,14 @@ static void test_call_duration_histogram(void) {
     metrics_cleanup();
 }
 
-/* The ring functions time the pre-connect phase of an incoming call and record
- * the seconds into call_ring_seconds. _missed() also bumps the calls_missed
- * counter, while _answered() does not — that is how a missed ring is told from
- * an answered one. Crucially, both are no-ops without a started ring, so the
- * web-initiated outbound start_call path (which reuses CALL_INCOMING but never
- * rings) is never miscounted as a miss. */
-static void test_call_ring_metrics(void) {
+/* call_metrics_ringing_started()/_answered() time the pre-connect phase of an
+ * incoming call into call_ring_seconds. call_metrics_incoming_ended() resolves a
+ * CALL_INCOMING phase that ended before connecting: with a ring in progress it
+ * counts a missed inbound call (calls_missed), and with no ring it counts a
+ * failed outbound dial (calls_failed) — the two are mutually exclusive, so the
+ * web-initiated outbound start_call path (CALL_INCOMING without a ring) is never
+ * miscounted as a miss. */
+static void test_call_ring_and_failure_metrics(void) {
     metrics_histogram_stats_t stats;
 
     TEST_ASSERT_EQ_INT(metrics_init(), 0);
@@ -1025,48 +1026,54 @@ static void test_call_ring_metrics(void) {
     TEST_ASSERT(stats.sum == 8.0);
     TEST_ASSERT(stats.max == 8.0);
     TEST_ASSERT_EQ_INT((int)metrics_get_counter("calls_missed"), 0);
+    TEST_ASSERT_EQ_INT((int)metrics_get_counter("calls_failed"), 0);
 
     /* An incoming call that rang 30 seconds and was abandoned: ring time is
      * recorded into the same histogram, and the miss is counted. */
     g_fake_clock = 6000;
     call_metrics_ringing_started();
     g_fake_clock = 6030;
-    call_metrics_ringing_missed();
+    call_metrics_incoming_ended();
 
     TEST_ASSERT_EQ_INT(metrics_get_histogram_stats("call_ring_seconds", &stats), 0);
     TEST_ASSERT_EQ_INT((int)stats.count, 2);
     TEST_ASSERT(stats.sum == 38.0);
     TEST_ASSERT(stats.max == 30.0);
     TEST_ASSERT_EQ_INT((int)metrics_get_counter("calls_missed"), 1);
+    TEST_ASSERT_EQ_INT((int)metrics_get_counter("calls_failed"), 0);
 
-    /* A resolution with no ring in progress records nothing and counts no miss:
-     * this is the outbound start_call (CALL_INCOMING without a ring) path. */
-    call_metrics_ringing_missed();
-    call_metrics_ringing_answered();
+    /* incoming_ended() with no ring in progress is the outbound start_call path:
+     * the dial never connected, so it counts a failure and not a miss, and
+     * records nothing into the ring histogram. */
+    call_metrics_incoming_ended();
     TEST_ASSERT_EQ_INT(metrics_get_histogram_stats("call_ring_seconds", &stats), 0);
     TEST_ASSERT_EQ_INT((int)stats.count, 2);
     TEST_ASSERT_EQ_INT((int)metrics_get_counter("calls_missed"), 1);
+    TEST_ASSERT_EQ_INT((int)metrics_get_counter("calls_failed"), 1);
 
-    /* reset() discards an in-progress ring so it is never recorded. */
+    /* reset() discards an in-progress ring so it is never recorded; the ended
+     * phase then looks like an outbound dial and is counted as a failure. */
     g_fake_clock = 7000;
     call_metrics_ringing_started();
     call_metrics_reset();
     g_fake_clock = 7100;
-    call_metrics_ringing_missed();
+    call_metrics_incoming_ended();
     TEST_ASSERT_EQ_INT(metrics_get_histogram_stats("call_ring_seconds", &stats), 0);
     TEST_ASSERT_EQ_INT((int)stats.count, 2);
     TEST_ASSERT_EQ_INT((int)metrics_get_counter("calls_missed"), 1);
+    TEST_ASSERT_EQ_INT((int)metrics_get_counter("calls_failed"), 2);
 
     /* A clock that steps backwards clamps the ring duration to 0, never
      * negative, and still counts the miss. */
     g_fake_clock = 8000;
     call_metrics_ringing_started();
     g_fake_clock = 7950;
-    call_metrics_ringing_missed();
+    call_metrics_incoming_ended();
     TEST_ASSERT_EQ_INT(metrics_get_histogram_stats("call_ring_seconds", &stats), 0);
     TEST_ASSERT_EQ_INT((int)stats.count, 3);
     TEST_ASSERT(stats.sum == 38.0);   /* the clamped 0 added nothing */
     TEST_ASSERT_EQ_INT((int)metrics_get_counter("calls_missed"), 2);
+    TEST_ASSERT_EQ_INT((int)metrics_get_counter("calls_failed"), 2);
 
     mclock_set_source(NULL);
     metrics_cleanup();
@@ -1156,7 +1163,7 @@ int main(void) {
 
     TEST_SUITE_BEGIN("Call Metrics");
     TEST_SUITE_RUN(test_call_duration_histogram);
-    TEST_SUITE_RUN(test_call_ring_metrics);
+    TEST_SUITE_RUN(test_call_ring_and_failure_metrics);
 
     TEST_REPORT();
 }


### PR DESCRIPTION
## Summary

Adds a **`calls_failed`** counter for outbound calls that never connect — the one call outcome that was previously invisible to monitoring.

When the phone places an outbound call (the web `start_call` action) and it never connects — callee busy, no answer, rejected, or a SIP/network error — the call goes `CALL_INCOMING → INVALID` without ever reaching `CALL_ACTIVE`. The daemon already handles this (#91: refund coins, show "Call failed"), but **no metric recorded it**: the old `call_metrics_ringing_missed()` was deliberately a no-op on this path because no inbound ring had been armed. So the outbound connect-failure rate — for a payphone, the headline reliability signal, i.e. the gap between `calls_initiated` and `calls_established` — could not be observed.

## What changed

- The single `CALL_INCOMING`-ended transition is now resolved by one function, **`call_metrics_incoming_ended()`** (replacing `call_metrics_ringing_missed()`), which counts exactly one outcome:
  - a genuine inbound ring was in progress → records ring time + **`calls_missed`** (caller gave up);
  - no ring was armed (outbound dial) → **`calls_failed`** (dial never connected).
- Because the two are mutually exclusive, a transition is never double-counted as both a miss and a failure, and outbound failures are still never miscounted as missed inbound calls. The decision lives entirely inside `call_metrics`, mirrored identically in `daemon.c` and `simulator.c`.

## Tests (`make test`, runs on the Mac)

- **Unit** — `test_call_ring_and_failure_metrics` now exercises both branches, asserting `calls_failed` for the no-ring (outbound) case alongside the existing ring/miss coverage. 61 passed, 0 failed.
- **Scenario** — new `test_failed_call_metrics.scenario` drives the outbound path via a new simulator `start_call` command (mirrors the daemon's web `start_call`: enters `CALL_INCOMING` without arming a ring) and verifies `calls_failed` climbs while `calls_missed` stays separate, and that the inbound-ring histogram is untouched by failures.

## Notes

Stacks on `feature/ring-duration-missed-call-metrics`, which introduced `call_metrics.c`; this PR is based on that branch so the diff shows only the new work. Re-target to `main` once the base merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)