### PR TITLE
metrics: count placed calls by payment type (emergency/card/coin)

### DIFF
--- a/host/plugins/classic_phone.c
+++ b/host/plugins/classic_phone.c
@@ -355,6 +355,21 @@ static void classic_phone_start_call(void) {
 
     millennium_client_call(client, classic_phone_data.current_number);
 
+    /* Record the payment type of the call we just placed. `calls_established`
+     * counts connected calls but can't reveal the usage mix; for a payphone the
+     * split between free emergency calls (911/311/0), calling-card calls, and
+     * coin-paid calls is the headline business + compliance signal. The three
+     * counters are mutually exclusive — exactly one moves per placed call, in
+     * the same priority order as classic_phone_check_and_call() selects the
+     * type (free number first, then card, then coin). */
+    if (classic_phone_data.is_emergency_call) {
+        metrics_increment_counter("calls_emergency", 1);
+    } else if (classic_phone_data.is_card_call) {
+        metrics_increment_counter("calls_card", 1);
+    } else {
+        metrics_increment_counter("calls_coin", 1);
+    }
+
     snprintf(log_msg, sizeof(log_msg), "%s call to %s",
              classic_phone_data.is_emergency_call ? "Emergency" : "Starting",
              classic_phone_data.current_number);

--- a/host/simulator.c
+++ b/host/simulator.c
@@ -630,6 +630,30 @@ static int run_scenario(const char *path) {
             }
         }
 
+        /* ── assert_counter <name> <value> ───────────────────────── */
+        else if (strncmp(cmd, "assert_counter ", 15) == 0) {
+            char name[128];
+            const char *p = trim(cmd + 15);
+            int ni = 0;
+            while (*p && *p != ' ' && ni < 127) { name[ni++] = *p++; }
+            name[ni] = '\0';
+            while (*p == ' ') p++;
+            if (name[0] == '\0' || *p == '\0') {
+                fprintf(stderr, "  ERROR: assert_counter needs <name> <value>\n");
+                failures++;
+            } else {
+                unsigned long long expected = strtoull(p, NULL, 10);
+                unsigned long long actual = (unsigned long long)metrics_get_counter(name);
+                if (actual == expected) {
+                    fprintf(stderr, "  PASS: counter %s == %llu\n", name, actual);
+                } else {
+                    fprintf(stderr, "  FAIL: counter %s expected %llu, got %llu\n",
+                            name, expected, actual);
+                    failures++;
+                }
+            }
+        }
+
         /* ── print (debug) ───────────────────────────────────────── */
         else if (strcmp(cmd, "print") == 0) {
             fprintf(stderr, "  state=%s  coins=%d  display=\"%s\" | \"%s\"\n",
@@ -799,6 +823,7 @@ int main(int argc, char *argv[]) {
 
         /* Reset state between scenarios */
         daemon_state_init(daemon_state);
+        metrics_reset_all();  /* zero counters/gauges so metric asserts are per-scenario */
         sim_display_line1[0] = '\0';
         sim_display_line2[0] = '\0';
         sim_display_count    = 0;

--- a/host/tests/test_call_payment_type_metrics.scenario
+++ b/host/tests/test_call_payment_type_metrics.scenario
@@ -1,0 +1,62 @@
+# Test: Call payment-type counters (calls_emergency / calls_card / calls_coin)
+# `calls_established` counts connected calls but throws away HOW each was paid
+# for. At the moment a call is placed, the Classic Phone plugin knows whether it
+# is a free emergency-number call (911/311/0), a calling-card call, or a
+# coin-paid call, and records exactly one of three mutually-exclusive counters.
+# For a payphone the free-vs-paid usage mix — and free-911 usage in particular —
+# is a headline business and compliance signal the undifferentiated call
+# counters can't show. This drives all three paths through the real plugin and
+# proves precisely one counter moves per placed call.
+#
+# Default config: call.cost_cents=50, call.free_numbers includes 911, and card
+# support is enabled, so each path is reachable without extra setup beyond a
+# registered free calling card.
+config card.free_cards 1234567890123456
+
+# ── 1) Emergency / free-number call: dial 911 with no coins ───────────────
+hook_up
+assert_state IDLE_UP
+keys 911
+# A free number connects immediately with no money inserted.
+call_active
+assert_state CALL_ACTIVE
+assert_counter calls_emergency 1
+assert_counter calls_coin 0
+assert_counter calls_card 0
+hook_down
+assert_state IDLE_DOWN
+
+# ── 2) Coin-paid call: insert 50c, dial a 10-digit number ─────────────────
+hook_up
+assert_state IDLE_UP
+coin 25
+coin 25
+assert_display Have: 50c
+keys 2125551234
+# 10 digits with enough money — call starts and is billed as a coin call.
+call_active
+assert_state CALL_ACTIVE
+assert_counter calls_coin 1
+assert_counter calls_emergency 1
+assert_counter calls_card 0
+hook_down
+assert_state IDLE_DOWN
+
+# ── 3) Calling-card call: swipe a free card, dial without coins ───────────
+hook_up
+assert_state IDLE_UP
+card 1234567890123456
+assert_display Card accepted
+keys 2125559876
+call_active
+assert_state CALL_ACTIVE
+assert_counter calls_card 1
+assert_counter calls_coin 1
+assert_counter calls_emergency 1
+hook_down
+assert_state IDLE_DOWN
+
+# Final tally: one of each, never double-counted.
+assert_counter calls_emergency 1
+assert_counter calls_card 1
+assert_counter calls_coin 1


### PR DESCRIPTION
## What

The phone records *that* calls connect (`calls_established`) but not *how they were paid for*. At the moment a call is placed, the **Classic Phone** plugin already knows whether it's a free **emergency**-number call (911/311/0), a calling-**card** call, or a **coin**-paid call — but that distinction was thrown away.

This emits one of three mutually-exclusive counters at the single point a call is dialed:

| Counter | Incremented when |
|---|---|
| `calls_emergency` | a free/emergency number is dialed (no money required) |
| `calls_card` | a registered calling card paid for the call |
| `calls_coin` | coins paid for the call |

Exactly one moves per placed call, in the same priority order `classic_phone_check_and_call()` already uses to select the type (free number → card → coin). Counting happens at dial time alongside the existing coin deduction, so a call refused because SIP is down (paid path only) is correctly *not* counted.

## Why

For a payphone the free-vs-paid usage **mix** — and free-911 usage in particular — is a headline business and compliance signal that the undifferentiated call counters (`calls_initiated` / `calls_established`) can't reveal.

## Tests

- New `host/tests/test_call_payment_type_metrics.scenario` drives all three payment paths through the **real** plugin (dial 911; insert 50¢ + dial 10 digits; swipe a free card + dial) and asserts precisely one counter moves per call, never double-counted.
- To support it, the simulator gains an `assert_counter <name> <value>` scenario command and now `metrics_reset_all()` between scenario files so metric assertions are per-scenario (scenarios share one process).
- `make test`: all 59 unit tests pass; all scenarios pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)