### PR TITLE
systemd: add the daemon-dev.service unit referenced by SETUP.md

### DIFF
--- a/host/systemd/daemon-dev.service
+++ b/host/systemd/daemon-dev.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Millennium Tools Daemon (development)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Development: run from repo build (no make install). %h = your home directory
+ExecStart=%h/millennium/host/daemon --config /etc/millennium/daemon.conf
+ExecStartPre=/bin/bash -c 'until /bin/ping -c1 -W1 8.8.8.8 >/dev/null 2>/dev/null; do sleep 1; done'
+Restart=on-failure
+RestartSec=2
+WorkingDirectory=%h/millennium/host
+StandardInput=null
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Problem

`host/SETUP.md` documents a development workflow and a troubleshooting step that both tell the user to copy a `daemon-dev.service` unit:

```bash
cp systemd/daemon-dev.service ~/.config/systemd/user/daemon.service
```

…but `host/systemd/daemon-dev.service` was never committed — only the production `daemon.service` exists. Following the docs today fails with *No such file or directory*.

## Fix

Add the missing unit. It's a minimal `systemctl --user` service that:
- runs the in-repo build at `%h/millennium/host/daemon` (no `make install`),
- waits for the network before starting,
- redirects stdin to `/dev/null` (also belt-and-suspenders with the daemon's own startup redirect).

Unlike the production `daemon.service`, it intentionally omits the ambient capabilities (`CAP_NET_BIND_SERVICE`, RT-audio caps) and `LimitRTPRIO`/`LimitMEMLOCK`: a `--user` service can't be granted those anyway, so the production unit remains the path for a real deployment (port-80 dashboard, real-time audio). The dev unit is for iterating on the binary from a checkout.

## Provenance

Recovered from a stale, local-only branch (commit `1b5dcef`, ~4 months old) found during branch cleanup. The SETUP.md half of that original change had already landed via another PR, so this reintroduces **only** the missing file — no doc churn.

## Testing

Docs-only/ops change; nothing in `make test`'s scope. Verified the unit references the correct binary path and config location that current `main`'s SETUP.md expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)