### PR TITLE
Add "The Operator" time-travel plugin + recorded-clip audio path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ Base URL: `http://<pi>` (port 80)
 
 ### Audio
 
-Pure ALSA (`libasound`), no PipeWire. Left channel → ringer (TDA2822M ch A), right channel → earpiece (TDA2822M ch B). Audio tone functions compile as no-ops on macOS so tests run locally.
+Pure ALSA (`libasound`), no PipeWire. Left channel → ringer (TDA2822M ch A), right channel → earpiece (TDA2822M ch B). Audio tone functions compile as no-ops on macOS so tests run locally. Plugins can also play recorded WAV clips via `sdk_play_clip()` (16-bit PCM, ideally 8 kHz mono; parsed by the platform-independent `wav.c`, streamed by `audio_tones.c`); clip files live under `audio.clip_dir` and are optional — see `host/AUDIO_CLIPS.md`.
 
 ## Coding Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ Single-process C daemon. Key files:
 | `pjsip_interface.c` / `pjsip_interface.h` | PJSIP (PJSUA C API) wrapper: register/call/answer/hangup/DTMF. Header has plain declarations only (so `millennium_sdk.c` compiles on the Mac); the `.c` is built only on the Pi |
 | `daemon_state.c` | Phone state machine (5 states), keypad buffer |
 | `event_processor.c` | Routes queued events to handlers |
-| `plugins.c` + `plugins/` | Plugin registry; built-ins: Classic Phone, Fortune Teller, Jukebox, Number Guess, Simon, Dial-A-Joke, Trivia |
+| `plugins.c` + `plugins/` | Plugin registry; built-ins: Classic Phone, Fortune Teller, Jukebox, Number Guess, Simon, Dial-A-Joke, Trivia, The Operator |
 | `plugin_sdk.c` / `plugin_sdk.h` | Friendly facade for plugin authors (display, audio, calls, state, balance, logging, RNG) — see `host/PLUGIN_AUTHORING.md` |
 | `display_manager.c` | VFD abstraction with auto-scrolling for lines >20 chars |
 | `audio_tones.c` | ALSA tone generator: dial tone, DTMF, ringback, busy, coin chime |

--- a/host/AUDIO_CLIPS.md
+++ b/host/AUDIO_CLIPS.md
@@ -1,0 +1,76 @@
+# Recorded Audio Clips (`sdk_play_clip`)
+
+Plugins can play short recorded clips — voice lines, ambience, stingers —
+through the same audio path that drives the dial/ringback/busy tones. This is
+the Phase-2 audio capability for "The Operator" (and any other plugin), built so
+that **clips are optional**: a plugin always degrades gracefully to its tones
+and on-screen text when no files are installed.
+
+## Feasibility (why this was straightforward)
+
+`audio_tones.c` already owns a single background thread that streams
+`S16_LE` PCM to a named ALSA PCM device, with one set of stop/join/`is_playing`
+controls and the rule "starting a sound stops the previous one." Clip playback
+reuses all of that: instead of synthesising sine samples, the thread streams the
+PCM payload of a WAV file. The only genuinely new, error-prone code — parsing
+the RIFF/WAVE container — lives in a pure, platform-independent module
+(`wav.c`) that is unit-tested on every platform, while the ALSA streaming stays
+in the Linux-only `audio_tones.c`.
+
+## Authoring clips
+
+- Format: **16-bit PCM WAV** (`WAVE_FORMAT_PCM`), mono or stereo.
+- Sample rate: **8 kHz mono is strongly preferred.** Call audio on this device
+  is 8 kHz narrowband and high-quality resampling crackles on the single-core
+  CPU, so author at 8 kHz to avoid on-the-fly conversion. Other rates play (ALSA
+  resamples via the `plug` device) but may not sound clean.
+- Keep them short (a few seconds). The loader refuses files over 8 MB.
+- Name them `<clip>.wav` and drop them in the clip directory
+  (`audio.clip_dir`, default `/usr/local/share/millennium/audio`).
+
+Example, producing a compliant clip with ffmpeg:
+
+```sh
+ffmpeg -i voice.mp3 -ac 1 -ar 8000 -sample_fmt s16 operator.wav
+scp operator.wav matzen@raspberrypi.local:/usr/local/share/millennium/audio/
+```
+
+## Using clips from a plugin
+
+```c
+sdk_play_clip("operator");   /* plays <clip_dir>/operator.wav */
+```
+
+- The name is restricted to letters, digits, `_` and `-` (no path separators),
+  so it can't escape the clip directory.
+- Playing a clip interrupts whatever sound is currently playing, exactly like
+  the tone functions, and `sdk_stop_audio()` stops it.
+- A **missing or unsupported file is a no-op that leaves the current sound
+  playing.** That lets you layer a clip over a fallback tone:
+
+  ```c
+  sdk_busy_tone();          /* always heard */
+  sdk_play_clip("drop");    /* replaces the busy tone only if drop.wav exists */
+  ```
+
+"The Operator" uses this for an Operator greeting on lift (`operator`), per-era
+ambience on arrival (`era_wires`, `era_golden`, `era_space`, `era_analog`,
+`era_frozen`, `era_static`, `era_sealed`), the 1999 line-drop (`drop`), and the
+paradox sting (`paradox`). None ship in the repo — add your own to bring the
+phone to life, or leave them out and the experience runs on tones + text.
+
+## Testing
+
+`wav.c` is covered by unit tests (`test_wav_parse_*`). Scenario tests assert the
+*request* for a clip with `assert_clip <substring>` (the simulator records the
+last path a plugin asked to play); actual ALSA playback is exercised on the Pi.
+
+## Not yet done (future work)
+
+- **Looping ambience.** Clips currently play once through. A loop flag on the
+  clip thread would let era ambience sustain under the dialogue.
+- **Mixing.** Only one sound plays at a time (clip *or* tone), inherited from
+  the tone subsystem. Simultaneous ambience + DTMF would need a mixer.
+- **Phase 3 (live AI Operator).** Piping handset audio to STT → LLM → TTS so the
+  Operator improvises is a separate, much larger effort (network + speech stack)
+  and is out of scope here.

--- a/host/Makefile
+++ b/host/Makefile
@@ -71,13 +71,16 @@ state_persistence.o: state_persistence.c state_persistence.h daemon_state.h logg
 display_manager.o: display_manager.c display_manager.h millennium_sdk.h
 	gcc display_manager.c -o display_manager.o -c $(CFLAGS)
 
-plugin_sdk.o: plugin_sdk.c plugin_sdk.h plugins.h display_manager.h audio_tones.h millennium_sdk.h clock_source.h logger.h daemon_state.h
+plugin_sdk.o: plugin_sdk.c plugin_sdk.h plugins.h display_manager.h audio_tones.h millennium_sdk.h clock_source.h logger.h daemon_state.h config.h
 	gcc plugin_sdk.c -o plugin_sdk.o -c $(CFLAGS)
 
 version.o: version.c version.h
 	gcc version.c -o version.o -c $(CFLAGS) $(VERSION_CFLAGS)
 
-audio_tones.o: audio_tones.c audio_tones.h logger.h
+wav.o: wav.c wav.h
+	gcc wav.c -o wav.o -c $(CFLAGS)
+
+audio_tones.o: audio_tones.c audio_tones.h wav.h logger.h
 	gcc audio_tones.c -o audio_tones.o -c $(CFLAGS)
 
 updater.o: updater.c updater.h version.h logger.h
@@ -114,8 +117,8 @@ plugins/trivia.o: plugins/trivia.c plugins.h plugin_sdk.h config.h
 plugins/time_operator.o: plugins/time_operator.c plugins.h plugin_sdk.h
 	gcc plugins/time_operator.c -o plugins/time_operator.o -c $(CFLAGS)
 
-daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o updater.o
-	gcc daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o updater.o -o daemon $(LDFLAGS) -lm
+daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o wav.o updater.o
+	gcc daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o wav.o updater.o -o daemon $(LDFLAGS) -lm
 
 # Simulator object file
 simulator.o: simulator.c millennium_sdk.h events.h config.h daemon_state.h logger.h metrics.h call_metrics.h plugins.h
@@ -134,7 +137,7 @@ simulator: $(SIM_OBJS)
 all: daemon
 
 # Unit test binary
-UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o cli.o logger.o metrics.o call_metrics.o health_monitor.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o updater.o conn_queue.o
+UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o cli.o logger.o metrics.o call_metrics.o health_monitor.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o wav.o updater.o conn_queue.o
 
 tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h cli.h daemon_state.h plugins.h logger.h metrics.h call_metrics.h millennium_sdk.h updater.h state_persistence.h conn_queue.h health_monitor.h
 	gcc tests/unit_tests.c -o tests/unit_tests.o -c $(CFLAGS) -I.
@@ -178,7 +181,7 @@ COMPILE_CHECK_OBJS = daemon.o daemon_state.o clock_source.o millennium_sdk.o eve
 	plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o \
 	plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o \
 	plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o \
-	audio_tones.o updater.o
+	audio_tones.o wav.o updater.o
 
 .PHONY: compile-check
 compile-check: $(COMPILE_CHECK_OBJS)
@@ -201,6 +204,7 @@ install: daemon
 	sudo cp asoundrc.example /etc/asound.conf
 	sudo cp daemon /usr/local/bin/millennium-daemon
 	sudo mkdir -p /usr/local/share/millennium
+	sudo mkdir -p /usr/local/share/millennium/audio
 	sudo cp web_portal.html /usr/local/share/millennium/
 	sudo cp systemd/daemon.service /etc/systemd/system/
 	sudo mkdir -p /etc/systemd/system/daemon.service.d

--- a/host/Makefile
+++ b/host/Makefile
@@ -111,15 +111,18 @@ plugins/dial_a_joke.o: plugins/dial_a_joke.c plugins.h plugin_sdk.h config.h
 plugins/trivia.o: plugins/trivia.c plugins.h plugin_sdk.h config.h
 	gcc plugins/trivia.c -o plugins/trivia.o -c $(CFLAGS)
 
-daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o
-	gcc daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o audio_tones.o updater.o -o daemon $(LDFLAGS) -lm
+plugins/time_operator.o: plugins/time_operator.c plugins.h plugin_sdk.h
+	gcc plugins/time_operator.c -o plugins/time_operator.o -c $(CFLAGS)
+
+daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o updater.o
+	gcc daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o updater.o -o daemon $(LDFLAGS) -lm
 
 # Simulator object file
 simulator.o: simulator.c millennium_sdk.h events.h config.h daemon_state.h logger.h metrics.h call_metrics.h plugins.h
 	gcc simulator.c -o simulator.o -c $(CFLAGS)
 
 # Simulator objects — no baresip, no web server, no daemon.o
-SIM_OBJS = simulator.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o call_metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o
+SIM_OBJS = simulator.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o call_metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o
 
 # Simulated time is portable: the simulator installs a clock source
 # (clock_source.h) that the daemon/plugins read through, so no -Wl,--wrap hack.
@@ -131,7 +134,7 @@ simulator: $(SIM_OBJS)
 all: daemon
 
 # Unit test binary
-UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o cli.o logger.o metrics.o call_metrics.o health_monitor.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o state_persistence.o display_manager.o version.o updater.o conn_queue.o
+UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o cli.o logger.o metrics.o call_metrics.o health_monitor.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o updater.o conn_queue.o
 
 tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h cli.h daemon_state.h plugins.h logger.h metrics.h call_metrics.h millennium_sdk.h updater.h state_persistence.h conn_queue.h health_monitor.h
 	gcc tests/unit_tests.c -o tests/unit_tests.o -c $(CFLAGS) -I.
@@ -174,7 +177,7 @@ COMPILE_CHECK_OBJS = daemon.o daemon_state.o clock_source.o millennium_sdk.o eve
 	metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o \
 	plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o \
 	plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o \
-	plugins/trivia.o state_persistence.o display_manager.o version.o \
+	plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o \
 	audio_tones.o updater.o
 
 .PHONY: compile-check

--- a/host/PLUGIN_AUTHORING.md
+++ b/host/PLUGIN_AUTHORING.md
@@ -116,6 +116,13 @@ void register_hello_plugin(void) {
   if you add a content table, expose it the way `trivia_display_strings` does
   and add it to that test.
 
+- **Recorded audio.** Beyond the synthesised tones, `sdk_play_clip("name")`
+  plays a recorded WAV clip (`<audio.clip_dir>/name.wav`) on the earpiece. It
+  shares the tone channel (one sound at a time, stopped by `sdk_stop_audio()`),
+  and a missing file is a harmless no-op — so clips are optional and can be
+  layered after a fallback tone. See [`AUDIO_CLIPS.md`](AUDIO_CLIPS.md) for the
+  format and authoring workflow.
+
 ## Testing
 
 **Scenario tests** drive a plugin end-to-end through the simulator. Create
@@ -132,6 +139,7 @@ Useful scenario commands: `activate_plugin <name>`, `hook_up`/`hook_down`,
 `coin <cents>`, `key <0-9*#A-D>`, `keys <digits>`, `card <number>`,
 `wait <seconds>` (advances time and ticks), `tick [n]` (ticks without waiting),
 `config <key> <value>`, `assert_display <text>`, `assert_state <name>`,
+`assert_clip <text>` (the last clip a plugin requested via `sdk_play_clip`),
 `print`. All `tests/*.scenario` files run under `make test`.
 
 **Unit tests** (`tests/unit_tests.c`) cover pure logic. Keep game rules in

--- a/host/audio_tones.c
+++ b/host/audio_tones.c
@@ -1,7 +1,9 @@
 #define _POSIX_C_SOURCE 200112L
 #include "audio_tones.h"
+#include "wav.h"
 #include "logger.h"
 #include <math.h>
+#include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <pthread.h>
@@ -18,6 +20,7 @@
 #define DTMF_DURATION_MS   150
 #define COIN_DURATION_MS   200
 #define COIN_AMPLITUDE     7500   /* ~4 dB below default; coin chime sits softer */
+#define MAX_CLIP_BYTES     (8 * 1024 * 1024)  /* refuse to slurp huge files */
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -231,6 +234,135 @@ void audio_tones_play_coin_tone(void) {
     logger_debug_with_category("AudioTones", "Playing coin tone");
     start_tone(&s);
 }
+
+/* ── Recorded-clip playback (WAV → ALSA) ──────────────────────────── */
+
+#if HAVE_ALSA
+
+typedef struct {
+    unsigned char *data;   /* whole file, owned by the thread */
+    wav_info_t     info;
+} clip_arg_t;
+
+static void *clip_thread_func(void *arg) {
+    clip_arg_t *c = (clip_arg_t *)arg;
+    snd_pcm_t *pcm = NULL;
+    const unsigned char *p = c->data + c->info.data_offset;
+    size_t remaining = c->info.data_len;
+    int frame_bytes = c->info.channels * (c->info.bits_per_sample / 8);
+    int err;
+
+    err = snd_pcm_open(&pcm, EARPIECE_PCM, SND_PCM_STREAM_PLAYBACK, 0);
+    if (err < 0) {
+        logger_warnf_with_category("AudioTones", "Cannot open PCM for clip: %s",
+                                   snd_strerror(err));
+        pcm = NULL;
+    } else {
+        err = snd_pcm_set_params(pcm, SND_PCM_FORMAT_S16_LE,
+                                 SND_PCM_ACCESS_RW_INTERLEAVED,
+                                 (unsigned)c->info.channels,
+                                 (unsigned)c->info.sample_rate, 1, 200000);
+        if (err < 0) {
+            logger_warnf_with_category("AudioTones", "Cannot set clip params: %s",
+                                       snd_strerror(err));
+            snd_pcm_close(pcm);
+            pcm = NULL;
+        }
+    }
+
+    while (pcm && !tone_stop_flag && frame_bytes > 0 &&
+           remaining >= (size_t)frame_bytes) {
+        snd_pcm_uframes_t want = 1024;
+        size_t avail = remaining / (size_t)frame_bytes;
+        snd_pcm_sframes_t frames;
+        if ((size_t)want > avail) want = (snd_pcm_uframes_t)avail;
+        frames = snd_pcm_writei(pcm, p, want);
+        if (frames < 0) {
+            frames = snd_pcm_recover(pcm, (int)frames, 0);
+            if (frames < 0) break;
+            continue;
+        }
+        p += (size_t)frames * (size_t)frame_bytes;
+        remaining -= (size_t)frames * (size_t)frame_bytes;
+    }
+
+    if (pcm) {
+        snd_pcm_drain(pcm);
+        snd_pcm_close(pcm);
+    }
+
+    free(c->data);
+    free(c);
+
+    pthread_mutex_lock(&tone_mutex);
+    tone_thread_running = 0;
+    pthread_mutex_unlock(&tone_mutex);
+    return NULL;
+}
+
+void audio_tones_play_clip(const char *path) {
+    FILE *f;
+    long sz;
+    size_t rd;
+    unsigned char *buf;
+    clip_arg_t *arg;
+    wav_info_t info;
+
+    if (!path) return;
+
+    f = fopen(path, "rb");
+    if (!f) {
+        logger_debugf_with_category("AudioTones", "Clip not found: %s", path);
+        return;  /* leave any current sound playing as a fallback */
+    }
+    if (fseek(f, 0, SEEK_END) != 0) { fclose(f); return; }
+    sz = ftell(f);
+    if (sz <= 0 || sz > MAX_CLIP_BYTES) { fclose(f); return; }
+    rewind(f);
+
+    buf = (unsigned char *)malloc((size_t)sz);
+    if (!buf) { fclose(f); return; }
+    rd = fread(buf, 1, (size_t)sz, f);
+    fclose(f);
+    if (rd != (size_t)sz) { free(buf); return; }
+
+    if (wav_parse(buf, (size_t)sz, &info) != 0 || info.format != 1 ||
+        info.bits_per_sample != 16 || info.channels < 1 || info.channels > 2 ||
+        info.sample_rate <= 0 || info.data_len == 0) {
+        logger_warnf_with_category("AudioTones",
+                                   "Unsupported clip (need 16-bit PCM WAV): %s",
+                                   path);
+        free(buf);
+        return;
+    }
+
+    audio_tones_stop();   /* one sound at a time */
+
+    arg = (clip_arg_t *)malloc(sizeof(clip_arg_t));
+    if (!arg) { free(buf); return; }
+    arg->data = buf;
+    arg->info = info;
+
+    pthread_mutex_lock(&tone_mutex);
+    tone_stop_flag = 0;
+    tone_thread_running = 1;
+    pthread_mutex_unlock(&tone_mutex);
+
+    if (pthread_create(&tone_thread, NULL, clip_thread_func, arg) != 0) {
+        free(buf);
+        free(arg);
+        pthread_mutex_lock(&tone_mutex);
+        tone_thread_running = 0;
+        pthread_mutex_unlock(&tone_mutex);
+        logger_warn_with_category("AudioTones", "Failed to create clip thread");
+    }
+}
+
+#else /* !HAVE_ALSA */
+
+void audio_tones_play_clip(const char *path) { (void)path; }
+
+#endif /* HAVE_ALSA */
 
 void audio_tones_stop(void) {
     pthread_mutex_lock(&tone_mutex);

--- a/host/audio_tones.h
+++ b/host/audio_tones.h
@@ -34,6 +34,13 @@ void audio_tones_play_busy_tone(void);
 /* Short coin-deposit chime (~200 ms, auto-stops). */
 void audio_tones_play_coin_tone(void);
 
+/* Play a recorded clip from a 16-bit PCM WAV file on the earpiece channel.
+ * Streams on the shared tone thread, so it interrupts any tone/clip currently
+ * playing and stops on audio_tones_stop() like every other sound. A missing or
+ * unsupported file is a no-op that leaves any current sound untouched, so it can
+ * be layered after a fallback tone. No-op entirely when built without ALSA. */
+void audio_tones_play_clip(const char *path);
+
 /* Stop whatever tone is currently playing. */
 void audio_tones_stop(void);
 

--- a/host/daemon.conf.example
+++ b/host/daemon.conf.example
@@ -41,6 +41,12 @@ sip.local_port=0
 sip.snd_capture=plughw:CARD=Device,DEV=0
 sip.snd_playback=out_right_solo
 
+# Directory of recorded audio clips played by plugins via sdk_play_clip().
+# Files are 16-bit PCM WAV named <clip>.wav (ideally 8 kHz mono to match the
+# narrowband audio hardware). See host/AUDIO_CLIPS.md. Missing files are a
+# harmless no-op, so clips are optional.
+audio.clip_dir=/usr/local/share/millennium/audio
+
 # Card Configuration (magstripe reader)
 card.enabled=true
 # Comma-separated 16-digit card numbers that grant free calling

--- a/host/plugin_sdk.c
+++ b/host/plugin_sdk.c
@@ -12,6 +12,7 @@
 #include "millennium_sdk.h"
 #include "clock_source.h"
 #include "logger.h"
+#include "config.h"
 
 /* Globals owned by the daemon / simulator / test harness. */
 extern daemon_state_data_t *daemon_state;
@@ -57,6 +58,27 @@ void sdk_ringback(void) { audio_tones_play_ringback(); }
 void sdk_busy_tone(void) { audio_tones_play_busy_tone(); }
 void sdk_stop_audio(void) { audio_tones_stop(); }
 int sdk_audio_is_playing(void) { return audio_tones_is_playing(); }
+
+void sdk_play_clip(const char *name) {
+    char path[512];
+    const char *dir;
+    size_t i;
+
+    if (!name || !name[0]) return;
+    /* Whitelist the name so it can't escape the clip directory. */
+    for (i = 0; name[i] != '\0'; i++) {
+        char ch = name[i];
+        if (!((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
+              (ch >= '0' && ch <= '9') || ch == '_' || ch == '-')) {
+            return;
+        }
+    }
+
+    dir = config_get_string(config_get_instance(), "audio.clip_dir",
+                            "/usr/local/share/millennium/audio");
+    snprintf(path, sizeof(path), "%s/%s.wav", dir, name);
+    audio_tones_play_clip(path);
+}
 
 /* ── Calls ───────────────────────────────────────────────────────────── */
 

--- a/host/plugin_sdk.h
+++ b/host/plugin_sdk.h
@@ -77,6 +77,15 @@ void sdk_busy_tone(void);         /* continuous busy cadence */
 void sdk_stop_audio(void);        /* stop any continuous tone */
 int  sdk_audio_is_playing(void);  /* 1 if a tone is currently sounding */
 
+/* Play a recorded clip by logical name (letters/digits/_/- only, no path or
+ * extension). Resolves to <audio.clip_dir>/<name>.wav (config key
+ * "audio.clip_dir", default /usr/local/share/millennium/audio). Clips should be
+ * 16-bit PCM WAV, ideally 8 kHz mono to match the narrowband audio hardware.
+ * Interrupts any sound currently playing; a missing/unsupported file is a
+ * harmless no-op that leaves the current sound untouched, so it can be layered
+ * after a fallback tone. See host/AUDIO_CLIPS.md. */
+void sdk_play_clip(const char *name);
+
 /* ── Calls (VoIP) ────────────────────────────────────────────────────────
  * Place/answer/end calls and send in-call DTMF. No-ops if SIP isn't ready. */
 

--- a/host/plugins.c
+++ b/host/plugins.c
@@ -11,7 +11,7 @@
 #include "metrics.h"
 
 /* Maximum number of plugins. Generous headroom so experimenters can add
- * their own alongside the built-ins (7 ship by default). */
+ * their own alongside the built-ins (8 ship by default). */
 #define MAX_PLUGINS 32
 
 /* Plugin registry */
@@ -36,7 +36,8 @@ void plugins_init(void) {
     register_simon_plugin();
     register_dial_a_joke_plugin();
     register_trivia_plugin();
-    
+    register_time_operator_plugin();
+
     /* Activate classic phone by default */
     plugins_activate("Classic Phone");
     

--- a/host/plugins.h
+++ b/host/plugins.h
@@ -75,5 +75,6 @@ void register_number_guess_plugin(void);
 void register_simon_plugin(void);
 void register_dial_a_joke_plugin(void);
 void register_trivia_plugin(void);
+void register_time_operator_plugin(void);
 
 #endif /* PLUGINS_H */

--- a/host/plugins/time_operator.c
+++ b/host/plugins/time_operator.c
@@ -65,6 +65,7 @@ typedef struct {
     int            frame_count;
     const char    *observe;      /* '1' branch flavor */
     const char    *interfere;    /* '2' branch flavor (arms a paradox) */
+    const char    *ambient;      /* clip name played on arrival (optional) */
 } era_t;
 
 static const frame_t era0_frames[] = {
@@ -100,13 +101,13 @@ static const frame_t era6_frames[] = {
  * 1999 is the signature dead-end (never reaches midnight) and 2000 is "home".
  * The 2050+ era is gated behind a temporal pass. */
 static const era_t eras[] = {
-    {1900, 1929, "THE WIRES",     era0_frames, 2, "a faint voice: hi",  "you change a word"},
-    {1930, 1959, "GOLDEN AIR",    era1_frames, 2, "swing fills the line","you mute the band"},
-    {1960, 1989, "SPACE LINE",    era2_frames, 2, "...three two one...", "you halt the count"},
-    {1990, 1998, "LAST ANALOG",   era3_frames, 2, "the young web sings", "you cut the modem"},
-    {2000, 2000, "FROZEN MINUTE", era4_frames, 2, "home. stay a while",  "the clock twitches"},
-    {2001, 2049, "STATIC YEARS",  era5_frames, 2, "...seven... nine...", "you read a number"},
-    {2050, 2100, "SEALED FUTURE", era6_frames, 2, "it knows your name",  "you ask it to stop"}
+    {1900, 1929, "THE WIRES",     era0_frames, 2, "a faint voice: hi",  "you change a word", "era_wires"},
+    {1930, 1959, "GOLDEN AIR",    era1_frames, 2, "swing fills the line","you mute the band", "era_golden"},
+    {1960, 1989, "SPACE LINE",    era2_frames, 2, "...three two one...", "you halt the count","era_space"},
+    {1990, 1998, "LAST ANALOG",   era3_frames, 2, "the young web sings", "you cut the modem", "era_analog"},
+    {2000, 2000, "FROZEN MINUTE", era4_frames, 2, "home. stay a while",  "the clock twitches","era_frozen"},
+    {2001, 2049, "STATIC YEARS",  era5_frames, 2, "...seven... nine...", "you read a number", "era_static"},
+    {2050, 2100, "SEALED FUTURE", era6_frames, 2, "it knows your name",  "you ask it to stop","era_sealed"}
 };
 
 #define NUM_ERAS ((int)(sizeof(eras) / sizeof(eras[0])))
@@ -224,6 +225,7 @@ static void ts_enter_era(int idx) {
     ts.visited_mask |= (1 << idx);
     sdk_logf(TS_CAT, "Arrived in era %d (%s)", idx, eras[idx].label);
     ts_render_era();
+    sdk_play_clip(eras[idx].ambient);   /* era ambience; silent if no file */
 }
 
 static void ts_enter_drop(void) {
@@ -232,6 +234,7 @@ static void ts_enter_drop(void) {
     ts.state = TS_DROP;
     ts.frame_at = sdk_now();
     sdk_display("ALMOST 2000...", "NEVER MIDNIGHT");
+    sdk_play_clip("drop");   /* Operator's line; falls back to the busy tone */
 }
 
 static void ts_enter_paradox(void) {
@@ -240,6 +243,7 @@ static void ts_enter_paradox(void) {
     ts.state = TS_PARADOX;
     sdk_logf(TS_CAT, "Paradox jammed the line (source %d)", ts.source_year);
     sdk_display("LINE FAULT 19##", "#=OPERATOR");
+    sdk_play_clip("paradox");   /* glitch sting; falls back to the busy tone */
 }
 
 static void ts_begin_connection(int year) {
@@ -385,6 +389,7 @@ static int ts_handle_keypad(char key) {
 static int ts_handle_hook(int hook_up, int hook_down) {
     if (hook_up) {
         ts_enter_operator(NULL);
+        sdk_play_clip("operator");   /* greeting voice on lift; silent if none */
     } else if (hook_down) {
         sdk_stop_audio();
         ts.state = TS_DORMANT;

--- a/host/plugins/time_operator.c
+++ b/host/plugins/time_operator.c
@@ -1,0 +1,500 @@
+#define _POSIX_C_SOURCE 200112L
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "../plugins.h"
+#include "../plugin_sdk.h"
+
+/*
+ * The Operator — an interactive time-travel narrative.
+ *
+ * The conceit: at the stroke of the year 2000 the Millennium's clock failed to
+ * roll over and the phone came unstuck in time. Lifting the handset no longer
+ * reaches a person; it reaches the Operator, a switchboard voice stranded at
+ * that frozen minute. Dial a 4-digit YEAR, pay a fare in coins that scales with
+ * how far you travel, optionally swipe a magstripe card as a temporal pass to
+ * unlock sealed eras, and listen to each era play out on the VFD. Meddling in
+ * one era and then opening another jams the line with a paradox you must repair.
+ *
+ * The whole experience runs locally with the tone palette and the two-line
+ * display — no real SIP call is placed, so the daemon stays in IDLE_UP
+ * throughout and scenario tests assert on the displayed text. All narrative
+ * content is original.
+ *
+ * Scope: this is the Phase-1 MVP. The SDK exposes no audio-file playback and no
+ * plugin-state persistence hook (only coin balance and the active plugin name
+ * survive a restart), so era ambience is tones-only and every narrative
+ * consequence — visited eras, the temporal pass, an armed paradox — lives in
+ * memory for the current power-on session and resets when the plugin is
+ * (re)activated.
+ */
+
+#define TS_CAT "Operator"
+
+#define FARE_BASE_CENTS       25
+#define FARE_PER_DECADE_CENTS 25
+#define FARE_MAX_CENTS        500
+#define YEAR_MIN              1900
+#define YEAR_MAX              2100
+#define FUTURE_SEALED_YEAR    2050
+#define FRAME_SECONDS         2
+#define DRIFT_SECONDS         30
+#define DROP_SECONDS          3
+#define CONNECT_FRAMES        2
+
+/* Internal plugin states (distinct from daemon_state_t). TS_DORMANT must be 0
+ * so a memset-zeroed session struct starts dormant. */
+enum {
+    TS_DORMANT = 0,
+    TS_OPERATOR,
+    TS_AWAIT_FARE,
+    TS_CONNECTING,
+    TS_IN_ERA,
+    TS_DROP,
+    TS_PARADOX
+};
+
+typedef struct { const char *l1; const char *l2; } frame_t;
+
+typedef struct {
+    int            lo, hi;       /* inclusive year bracket */
+    const char    *label;        /* shown on line 1 throughout the era */
+    const frame_t *frames;
+    int            frame_count;
+    const char    *observe;      /* '1' branch flavor */
+    const char    *interfere;    /* '2' branch flavor (arms a paradox) */
+} era_t;
+
+static const frame_t era0_frames[] = {
+    {"THE WIRES", "operator plugs in"},
+    {"THE WIRES", "1=listen 2=meddle"}
+};
+static const frame_t era1_frames[] = {
+    {"GOLDEN AIR", "radio crackles on"},
+    {"GOLDEN AIR", "1=listen 2=meddle"}
+};
+static const frame_t era2_frames[] = {
+    {"SPACE LINE", "a countdown ticks"},
+    {"SPACE LINE", "1=listen 2=meddle"}
+};
+static const frame_t era3_frames[] = {
+    {"LAST ANALOG", "modems screech"},
+    {"LAST ANALOG", "1=listen 2=meddle"}
+};
+static const frame_t era4_frames[] = {
+    {"FROZEN MINUTE", "11:59 forever"},
+    {"FROZEN MINUTE", "#=back home"}
+};
+static const frame_t era5_frames[] = {
+    {"STATIC YEARS", "dead air, faint"},
+    {"STATIC YEARS", "1=listen 2=meddle"}
+};
+static const frame_t era6_frames[] = {
+    {"SEALED FUTURE", "the pass glows"},
+    {"SEALED FUTURE", "1=listen 2=meddle"}
+};
+
+/* Brackets tile 1900..2100 with two gaps handled specially before lookup:
+ * 1999 is the signature dead-end (never reaches midnight) and 2000 is "home".
+ * The 2050+ era is gated behind a temporal pass. */
+static const era_t eras[] = {
+    {1900, 1929, "THE WIRES",     era0_frames, 2, "a faint voice: hi",  "you change a word"},
+    {1930, 1959, "GOLDEN AIR",    era1_frames, 2, "swing fills the line","you mute the band"},
+    {1960, 1989, "SPACE LINE",    era2_frames, 2, "...three two one...", "you halt the count"},
+    {1990, 1998, "LAST ANALOG",   era3_frames, 2, "the young web sings", "you cut the modem"},
+    {2000, 2000, "FROZEN MINUTE", era4_frames, 2, "home. stay a while",  "the clock twitches"},
+    {2001, 2049, "STATIC YEARS",  era5_frames, 2, "...seven... nine...", "you read a number"},
+    {2050, 2100, "SEALED FUTURE", era6_frames, 2, "it knows your name",  "you ask it to stop"}
+};
+
+#define NUM_ERAS ((int)(sizeof(eras) / sizeof(eras[0])))
+
+typedef struct {
+    int         state;
+    char        year_buf[5];     /* up to 4 digits + NUL */
+    int         year_len;
+    int         current_year;    /* year of the active connection */
+    int         pending_year;    /* year awaiting fare */
+    int         fare_cents;      /* fare for pending_year */
+    int         dest;            /* era index of current connection, -1 = drop */
+    int         era;             /* era index while TS_IN_ERA */
+    int         frame_index;
+    time_t      frame_at;        /* paces frame scrolling / connecting */
+    time_t      last_input_at;   /* drives temporal-drift timeout in an era */
+    int         pass_active;     /* a temporal pass was swiped this session */
+    int         armed;           /* a paradox is armed (line will jam) */
+    int         source_year;     /* year where the paradox was armed */
+    int         visited_mask;    /* eras visited this session */
+    const char *banner;          /* operator line-1 banner */
+} time_state_t;
+
+static time_state_t ts;
+
+/* ── Pure helpers (no hardware; unit-tested directly) ────────────────── */
+
+/* Parse a buffer of exactly 4 digits into a year, or -1 otherwise. */
+int parse_year(const char *buf) {
+    int i, val = 0;
+    if (!buf || strlen(buf) != 4) return -1;
+    for (i = 0; i < 4; i++) {
+        if (buf[i] < '0' || buf[i] > '9') return -1;
+        val = val * 10 + (buf[i] - '0');
+    }
+    return val;
+}
+
+/* Fare in cents for a target year; the frozen minute (2000) is free. */
+int fare_for_year(int year) {
+    int decades, fare;
+    if (year == 2000) return 0;
+    decades = abs(year - 2000) / 10;
+    fare = FARE_BASE_CENTS + FARE_PER_DECADE_CENTS * decades;
+    if (fare > FARE_MAX_CENTS) fare = FARE_MAX_CENTS;
+    return fare;
+}
+
+/* Era index whose bracket contains year, or -1 (e.g. the 1999 gap). */
+int era_index_for_year(int year) {
+    int i;
+    for (i = 0; i < NUM_ERAS; i++) {
+        if (year >= eras[i].lo && year <= eras[i].hi) return i;
+    }
+    return -1;
+}
+
+/* ── Rendering ───────────────────────────────────────────────────────── */
+
+static void ts_render_dormant(void) {
+    sdk_display("THE OPERATOR", "Lift to dial");
+}
+
+static void ts_render_operator(void) {
+    char l2[21];
+    if (ts.year_len == 0) {
+        sdk_display(ts.banner ? ts.banner : "TIME OPERATOR",
+                    "DIAL A YEAR  #=BACK");
+    } else {
+        snprintf(l2, sizeof(l2), "YEAR: %s_", ts.year_buf);
+        sdk_display("TIME OPERATOR", l2);
+    }
+}
+
+static void ts_render_need(void) {
+    char l1[21], l2[21];
+    snprintf(l1, sizeof(l1), "NEED $%d.%02d", ts.fare_cents / 100,
+             ts.fare_cents % 100);
+    snprintf(l2, sizeof(l2), "HAVE $%d.%02d", sdk_balance() / 100,
+             sdk_balance() % 100);
+    sdk_display(l1, l2);
+}
+
+static void ts_render_connecting(void) {
+    char l2[21];
+    snprintf(l2, sizeof(l2), "YEAR %d", ts.current_year);
+    sdk_display(ts.frame_index == 0 ? "CONNECTING..." : "ringing...", l2);
+}
+
+static void ts_render_era(void) {
+    const era_t *e = &eras[ts.era];
+    int i = ts.frame_index;
+    if (i >= e->frame_count) i = e->frame_count - 1;
+    sdk_display(e->frames[i].l1, e->frames[i].l2);
+}
+
+/* ── State transitions (each stops any continuous tone first) ────────── */
+
+static void ts_enter_operator(const char *banner) {
+    sdk_stop_audio();
+    ts.state = TS_OPERATOR;
+    ts.year_buf[0] = '\0';
+    ts.year_len = 0;
+    ts.banner = banner ? banner : "TIME OPERATOR";
+    ts_render_operator();
+}
+
+static void ts_enter_era(int idx) {
+    sdk_stop_audio();
+    ts.state = TS_IN_ERA;
+    ts.era = idx;
+    ts.frame_index = 0;
+    ts.frame_at = sdk_now();
+    ts.last_input_at = sdk_now();
+    ts.visited_mask |= (1 << idx);
+    sdk_logf(TS_CAT, "Arrived in era %d (%s)", idx, eras[idx].label);
+    ts_render_era();
+}
+
+static void ts_enter_drop(void) {
+    sdk_stop_audio();
+    sdk_busy_tone();
+    ts.state = TS_DROP;
+    ts.frame_at = sdk_now();
+    sdk_display("ALMOST 2000...", "NEVER MIDNIGHT");
+}
+
+static void ts_enter_paradox(void) {
+    sdk_stop_audio();
+    sdk_busy_tone();
+    ts.state = TS_PARADOX;
+    sdk_logf(TS_CAT, "Paradox jammed the line (source %d)", ts.source_year);
+    sdk_display("LINE FAULT 19##", "#=OPERATOR");
+}
+
+static void ts_begin_connection(int year) {
+    ts.current_year = year;
+    ts.dest = (year == 1999) ? -1 : era_index_for_year(year);
+    sdk_stop_audio();
+    sdk_ringback();
+    ts.state = TS_CONNECTING;
+    ts.frame_index = 0;
+    ts.frame_at = sdk_now();
+    ts_render_connecting();
+}
+
+/* Attempt to route to a year already known to be in range and unsealed. */
+static void ts_try_connect(int year) {
+    int fare = fare_for_year(year);
+    int target;
+
+    if (sdk_balance() < fare) {
+        ts.pending_year = year;
+        ts.fare_cents = fare;
+        ts.state = TS_AWAIT_FARE;
+        ts_render_need();
+        return;
+    }
+
+    target = (year == 1999) ? -1 : era_index_for_year(year);
+    if (ts.armed && target >= 0 &&
+        target != era_index_for_year(ts.source_year)) {
+        /* Opening a second era while one is meddled-with jams the line. */
+        sdk_spend_balance(fare);
+        ts_enter_paradox();
+        return;
+    }
+
+    sdk_spend_balance(fare);
+    ts_begin_connection(year);
+}
+
+static void ts_eval_year(void) {
+    int year = parse_year(ts.year_buf);
+    if (year < YEAR_MIN || year > YEAR_MAX) {
+        ts_enter_operator("NO SUCH YEAR");
+        return;
+    }
+    if (year >= FUTURE_SEALED_YEAR && !ts.pass_active) {
+        ts_enter_operator("FUTURE SEALED");
+        return;
+    }
+    ts_try_connect(year);
+}
+
+/* ── Plugin callbacks ────────────────────────────────────────────────── */
+
+static int ts_handle_coin(int coin_value, const char *coin_code) {
+    char l2[21];
+    (void)coin_value;
+    (void)coin_code;
+    sdk_coin_chime();
+    if (ts.state == TS_AWAIT_FARE) {
+        if (sdk_balance() >= ts.fare_cents) {
+            ts_try_connect(ts.pending_year);
+        } else {
+            ts_render_need();
+        }
+    } else if (ts.state == TS_OPERATOR) {
+        snprintf(l2, sizeof(l2), "CREDIT $%d.%02d", sdk_balance() / 100,
+                 sdk_balance() % 100);
+        sdk_display("TIME OPERATOR", l2);
+    }
+    return 0;
+}
+
+static int ts_handle_keypad(char key) {
+    const era_t *e;
+
+    switch (ts.state) {
+    case TS_OPERATOR:
+        if (key >= '0' && key <= '9') {
+            if (ts.year_len < 4) {
+                ts.year_buf[ts.year_len++] = key;
+                ts.year_buf[ts.year_len] = '\0';
+                sdk_beep(key);
+                ts_render_operator();
+                if (ts.year_len == 4) ts_eval_year();
+            }
+        } else if (key == '*') {
+            if (ts.year_len > 0) ts.year_buf[--ts.year_len] = '\0';
+            ts.banner = "TIME OPERATOR";
+            ts_render_operator();
+        } else if (key == '#') {
+            ts.year_buf[0] = '\0';
+            ts.year_len = 0;
+            ts.banner = "TIME OPERATOR";
+            ts_render_operator();
+        }
+        break;
+
+    case TS_AWAIT_FARE:
+        if (key == '*' || key == '#') {
+            ts_enter_operator(NULL);
+        } else {
+            sdk_beep(key);
+        }
+        break;
+
+    case TS_IN_ERA:
+        e = &eras[ts.era];
+        ts.last_input_at = sdk_now();
+        if (key == '#') {
+            ts_enter_operator(NULL);
+        } else if (key == '1') {
+            if (ts.armed && ts.current_year == ts.source_year) {
+                ts.armed = 0;
+                sdk_logf(TS_CAT, "Paradox mended at %d", ts.current_year);
+                sdk_display("TIMELINE", "MENDED");
+            } else {
+                sdk_display(e->label, e->observe);
+            }
+        } else if (key == '2') {
+            ts.armed = 1;
+            ts.source_year = ts.current_year;
+            sdk_display("TIMELINE BENT", e->interfere);
+        } else {
+            sdk_beep(key);
+        }
+        break;
+
+    case TS_PARADOX:
+        if (key == '#') {
+            ts_enter_operator(NULL);
+        } else {
+            sdk_beep(key);
+        }
+        break;
+
+    default:
+        break;
+    }
+    return 0;
+}
+
+static int ts_handle_hook(int hook_up, int hook_down) {
+    if (hook_up) {
+        ts_enter_operator(NULL);
+    } else if (hook_down) {
+        sdk_stop_audio();
+        ts.state = TS_DORMANT;
+        ts.year_buf[0] = '\0';
+        ts.year_len = 0;
+        ts_render_dormant();
+    }
+    return 0;
+}
+
+static int ts_handle_card(const char *card_number) {
+    (void)card_number;
+    ts.pass_active = 1;
+    sdk_log(TS_CAT, "Temporal pass accepted");
+    sdk_display("TEMPORAL PASS", "PASS ACCEPTED");
+    return 0;
+}
+
+static void ts_handle_activation(void) {
+    memset(&ts, 0, sizeof(ts));
+    if (sdk_receiver_is_up()) {
+        ts_enter_operator(NULL);
+    } else {
+        ts.state = TS_DORMANT;
+        ts_render_dormant();
+    }
+}
+
+static void ts_handle_tick(void) {
+    const era_t *e;
+
+    switch (ts.state) {
+    case TS_CONNECTING:
+        if (sdk_elapsed(ts.frame_at) >= FRAME_SECONDS) {
+            ts.frame_index++;
+            ts.frame_at = sdk_now();
+            if (ts.frame_index < CONNECT_FRAMES) {
+                ts_render_connecting();
+            } else if (ts.dest < 0) {
+                ts_enter_drop();
+            } else {
+                ts_enter_era(ts.dest);
+            }
+        }
+        break;
+
+    case TS_IN_ERA:
+        if (sdk_elapsed(ts.last_input_at) >= DRIFT_SECONDS) {
+            ts_enter_operator("TEMPORAL DRIFT");
+            break;
+        }
+        e = &eras[ts.era];
+        if (ts.frame_index < e->frame_count - 1 &&
+            sdk_elapsed(ts.frame_at) >= FRAME_SECONDS) {
+            ts.frame_index++;
+            ts.frame_at = sdk_now();
+            ts_render_era();
+        }
+        break;
+
+    case TS_DROP:
+        if (sdk_elapsed(ts.frame_at) >= DROP_SECONDS) {
+            ts_enter_operator("LINE DROPPED");
+        }
+        break;
+
+    default:
+        break;
+    }
+}
+
+/* Test/introspection hook (see test_plugin_display_lines_fit): expose every
+ * authored display string so the guardrail can confirm none exceeds the line
+ * budget. Returns the total count; fills up to `max` into out[]. */
+int time_operator_display_strings(const char **out, int max) {
+    static const char *const ui[] = {
+        "THE OPERATOR", "Lift to dial", "TIME OPERATOR", "DIAL A YEAR  #=BACK",
+        "CONNECTING...", "ringing...", "ALMOST 2000...", "NEVER MIDNIGHT",
+        "LINE FAULT 19##", "#=OPERATOR", "TEMPORAL PASS", "PASS ACCEPTED",
+        "TIMELINE", "MENDED", "TIMELINE BENT", "NO SUCH YEAR", "FUTURE SEALED",
+        "TEMPORAL DRIFT", "LINE DROPPED"
+    };
+    int n = 0, i, f;
+    for (i = 0; i < (int)(sizeof(ui) / sizeof(ui[0])); i++) {
+        if (out && n < max) out[n] = ui[i];
+        n++;
+    }
+    for (i = 0; i < NUM_ERAS; i++) {
+        if (out && n < max) out[n] = eras[i].label;       n++;
+        if (out && n < max) out[n] = eras[i].observe;     n++;
+        if (out && n < max) out[n] = eras[i].interfere;   n++;
+        for (f = 0; f < eras[i].frame_count; f++) {
+            if (out && n < max) out[n] = eras[i].frames[f].l1; n++;
+            if (out && n < max) out[n] = eras[i].frames[f].l2; n++;
+        }
+    }
+    return n;
+}
+
+void register_time_operator_plugin(void) {
+    memset(&ts, 0, sizeof(ts));
+    ts.state = TS_DORMANT;
+
+    plugins_register("The Operator",
+                     "Dial a year - a time-travel story line",
+                     ts_handle_coin,
+                     ts_handle_keypad,
+                     ts_handle_hook,
+                     NULL,
+                     ts_handle_card,
+                     ts_handle_activation,
+                     ts_handle_tick);
+}

--- a/host/plugins/time_operator.c
+++ b/host/plugins/time_operator.c
@@ -183,7 +183,7 @@ static void ts_render_operator(void) {
 }
 
 static void ts_render_need(void) {
-    char l1[21], l2[21];
+    char l1[32], l2[32];   /* room for a worst-case int from snprintf */
     snprintf(l1, sizeof(l1), "NEED $%d.%02d", ts.fare_cents / 100,
              ts.fare_cents % 100);
     snprintf(l2, sizeof(l2), "HAVE $%d.%02d", sdk_balance() / 100,
@@ -299,7 +299,7 @@ static void ts_eval_year(void) {
 /* ── Plugin callbacks ────────────────────────────────────────────────── */
 
 static int ts_handle_coin(int coin_value, const char *coin_code) {
-    char l2[21];
+    char l2[32];   /* room for a worst-case int from snprintf */
     (void)coin_value;
     (void)coin_code;
     sdk_coin_chime();
@@ -461,6 +461,12 @@ static void ts_handle_tick(void) {
     }
 }
 
+/* Append one string at index n (when there's room) and return n+1. */
+static int ts_collect(const char **out, int max, int n, const char *s) {
+    if (out && n < max) out[n] = s;
+    return n + 1;
+}
+
 /* Test/introspection hook (see test_plugin_display_lines_fit): expose every
  * authored display string so the guardrail can confirm none exceeds the line
  * budget. Returns the total count; fills up to `max` into out[]. */
@@ -474,16 +480,15 @@ int time_operator_display_strings(const char **out, int max) {
     };
     int n = 0, i, f;
     for (i = 0; i < (int)(sizeof(ui) / sizeof(ui[0])); i++) {
-        if (out && n < max) out[n] = ui[i];
-        n++;
+        n = ts_collect(out, max, n, ui[i]);
     }
     for (i = 0; i < NUM_ERAS; i++) {
-        if (out && n < max) out[n] = eras[i].label;       n++;
-        if (out && n < max) out[n] = eras[i].observe;     n++;
-        if (out && n < max) out[n] = eras[i].interfere;   n++;
+        n = ts_collect(out, max, n, eras[i].label);
+        n = ts_collect(out, max, n, eras[i].observe);
+        n = ts_collect(out, max, n, eras[i].interfere);
         for (f = 0; f < eras[i].frame_count; f++) {
-            if (out && n < max) out[n] = eras[i].frames[f].l1; n++;
-            if (out && n < max) out[n] = eras[i].frames[f].l2; n++;
+            n = ts_collect(out, max, n, eras[i].frames[f].l1);
+            n = ts_collect(out, max, n, eras[i].frames[f].l2);
         }
     }
     return n;

--- a/host/simulator.c
+++ b/host/simulator.c
@@ -238,6 +238,15 @@ void audio_tones_play_coin_tone(void) { fprintf(stderr, "[TONE] Coin\n"); }
 void audio_tones_stop(void) { fprintf(stderr, "[TONE] Stop\n"); }
 int audio_tones_is_playing(void) { return 0; }
 
+/* Capture the most recently requested clip path so assert_clip can verify a
+ * plugin asked for the right recording (the daemon would stream it via ALSA). */
+static char sim_last_clip[256];
+void audio_tones_play_clip(const char *path) {
+    strncpy(sim_last_clip, path ? path : "", sizeof(sim_last_clip) - 1);
+    sim_last_clip[sizeof(sim_last_clip) - 1] = '\0';
+    fprintf(stderr, "[CLIP] %s\n", sim_last_clip);
+}
+
 void millennium_client_process_event_buffer(millennium_client_t *c) { (void)c; }
 
 char *millennium_client_extract_payload(millennium_client_t *c, char t, size_t s) {
@@ -667,6 +676,18 @@ static int run_scenario(const char *path) {
             }
         }
 
+        /* ── assert_clip <text> — last clip the plugin requested ──── */
+        else if (strncmp(cmd, "assert_clip ", 12) == 0) {
+            arg = trim(cmd + 12);
+            if (strstr(sim_last_clip, arg)) {
+                fprintf(stderr, "  PASS: last clip contains \"%s\"\n", arg);
+            } else {
+                fprintf(stderr, "  FAIL: last clip (\"%s\") does NOT contain \"%s\"\n",
+                        sim_last_clip, arg);
+                failures++;
+            }
+        }
+
         /* ── assert_state <state_name> ───────────────────────────── */
         else if (strncmp(cmd, "assert_state ", 13) == 0) {
             const char *actual = daemon_state_to_string(daemon_state->current_state);
@@ -930,6 +951,7 @@ int main(int argc, char *argv[]) {
         sim_display_line1[0] = '\0';
         sim_display_line2[0] = '\0';
         sim_display_count    = 0;
+        sim_last_clip[0]     = '\0';
         sim_call_pending     = 0;
         sim_call_active      = 0;
         sim_hangup_called    = 0;

--- a/host/tests/test_operator_1999_drop.scenario
+++ b/host/tests/test_operator_1999_drop.scenario
@@ -1,0 +1,16 @@
+# The Operator: 1999 always drops right before midnight, then back to the Operator.
+activate_plugin The Operator
+hook_up
+
+# Pay the fare and dial the signature dead-end year
+coin 25
+keys 1999
+
+# The line rings, then drops before the clock can turn over
+wait 6
+assert_display MIDNIGHT
+
+# After the drop it returns to the Operator
+wait 4
+assert_display LINE DROPPED
+assert_display DIAL A YEAR

--- a/host/tests/test_operator_await_fare.scenario
+++ b/host/tests/test_operator_await_fare.scenario
@@ -1,0 +1,12 @@
+# The Operator: dialing without enough coins waits for the fare, then advances.
+activate_plugin The Operator
+hook_up
+
+# Dial 2005 with no money -> the Operator asks for the fare
+keys 2005
+assert_display NEED
+
+# Drop in the quarter -> the connection proceeds to the era
+coin 25
+wait 6
+assert_display STATIC YEARS

--- a/host/tests/test_operator_drift.scenario
+++ b/host/tests/test_operator_drift.scenario
@@ -1,0 +1,14 @@
+# The Operator: sitting idle in an era too long causes temporal drift back to
+# the Operator.
+activate_plugin The Operator
+hook_up
+
+# Travel to an era
+coin 25
+keys 2005
+wait 6
+assert_display STATIC YEARS
+
+# Touch nothing past the drift timeout -> snapped back to the Operator
+wait 40
+assert_display TEMPORAL DRIFT

--- a/host/tests/test_operator_greeting.scenario
+++ b/host/tests/test_operator_greeting.scenario
@@ -1,0 +1,10 @@
+# The Operator: lifting the handset reaches the Operator's "dial a year" prompt.
+activate_plugin The Operator
+
+# Receiver down -> dormant invitation
+assert_display Lift
+
+# Lift the handset -> the Operator greeting / dial prompt
+hook_up
+assert_state IDLE_UP
+assert_display DIAL A YEAR

--- a/host/tests/test_operator_greeting.scenario
+++ b/host/tests/test_operator_greeting.scenario
@@ -8,3 +8,6 @@ assert_display Lift
 hook_up
 assert_state IDLE_UP
 assert_display DIAL A YEAR
+
+# Lifting also requests the Operator greeting clip
+assert_clip operator.wav

--- a/host/tests/test_operator_paradox.scenario
+++ b/host/tests/test_operator_paradox.scenario
@@ -1,0 +1,29 @@
+# The Operator: meddling in one era then opening another jams the line with a
+# paradox; returning to the source era and choosing the other branch repairs it.
+activate_plugin The Operator
+hook_up
+
+# Stock up on coins (each hop here costs the 25c base fare)
+coin 25
+coin 25
+coin 25
+coin 25
+
+# Travel to 1995 and meddle (branch 2) -> arms the paradox
+keys 1995
+wait 6
+assert_display LAST ANALOG
+key 2
+assert_display BENT
+
+# Back to the Operator, then open a different era -> the line jams
+key #
+keys 2005
+assert_display LINE FAULT
+
+# Return to the source year and choose the opposite branch (1) -> mended
+key #
+keys 1995
+wait 6
+key 1
+assert_display MENDED

--- a/host/tests/test_operator_sealed_future.scenario
+++ b/host/tests/test_operator_sealed_future.scenario
@@ -1,0 +1,22 @@
+# The Operator: sealed future years are refused until a temporal pass is swiped.
+activate_plugin The Operator
+hook_up
+
+# Dialing a sealed year with no pass is refused
+keys 2080
+assert_display SEALED
+
+# Swipe any card -> it acts as a temporal pass
+card 1234567890123456
+assert_display PASS
+
+# Pay the (longer) fare and dial the gated era -> now allowed
+coin 25
+coin 25
+coin 25
+coin 25
+coin 25
+coin 25
+keys 2050
+wait 6
+assert_display SEALED FUTURE

--- a/host/tests/test_operator_travel.scenario
+++ b/host/tests/test_operator_travel.scenario
@@ -9,3 +9,6 @@ keys 2005
 # Connecting beat, then the era plays on the line
 wait 6
 assert_display STATIC YEARS
+
+# The plugin also requests that era's ambience clip on arrival
+assert_clip era_static.wav

--- a/host/tests/test_operator_travel.scenario
+++ b/host/tests/test_operator_travel.scenario
@@ -1,0 +1,11 @@
+# The Operator: paying the fare up front and dialing a year reaches that era.
+activate_plugin The Operator
+hook_up
+
+# Credit a quarter, then dial 2005 (same decade as the anchor -> 25c fare)
+coin 25
+keys 2005
+
+# Connecting beat, then the era plays on the line
+wait 6
+assert_display STATIC YEARS

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -15,6 +15,7 @@
 #include "../conn_queue.h"
 #include "../health_monitor.h"
 #include "../display_manager.h"
+#include "../wav.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <pthread.h>
@@ -88,6 +89,7 @@ void audio_tones_play_dtmf(char k) { (void)k; }
 void audio_tones_play_ringback(void) {}
 void audio_tones_play_busy_tone(void) {}
 void audio_tones_play_coin_tone(void) {}
+void audio_tones_play_clip(const char *p) { (void)p; }
 void audio_tones_stop(void) {}
 int audio_tones_is_playing(void) { return 0; }
 
@@ -911,6 +913,99 @@ static void test_operator_era_lookup(void) {
     TEST_ASSERT_EQ_INT(era_index_for_year(1850), -1);
     TEST_ASSERT_EQ_INT(era_index_for_year(2200), -1);
     TEST_ASSERT_EQ_INT(era_index_for_year(1999), -1);
+}
+
+/* ── WAV clip parser ────────────────────────────────────────────────── */
+
+static void wav_put_u16(unsigned char *p, unsigned v) {
+    p[0] = (unsigned char)(v & 0xff);
+    p[1] = (unsigned char)((v >> 8) & 0xff);
+}
+static void wav_put_u32(unsigned char *p, unsigned long v) {
+    p[0] = (unsigned char)(v & 0xff);
+    p[1] = (unsigned char)((v >> 8) & 0xff);
+    p[2] = (unsigned char)((v >> 16) & 0xff);
+    p[3] = (unsigned char)((v >> 24) & 0xff);
+}
+
+/* Build a canonical 16-bit PCM WAV (silence) into buf; returns total length. */
+static size_t make_wav(unsigned char *buf, int channels, int rate,
+                       int frames) {
+    int data_bytes = frames * channels * 2;
+    memcpy(buf + 0, "RIFF", 4);
+    wav_put_u32(buf + 4, (unsigned long)(36 + data_bytes));
+    memcpy(buf + 8, "WAVE", 4);
+    memcpy(buf + 12, "fmt ", 4);
+    wav_put_u32(buf + 16, 16);
+    wav_put_u16(buf + 20, 1);                       /* PCM */
+    wav_put_u16(buf + 22, (unsigned)channels);
+    wav_put_u32(buf + 24, (unsigned long)rate);
+    wav_put_u32(buf + 28, (unsigned long)(rate * channels * 2));
+    wav_put_u16(buf + 32, (unsigned)(channels * 2));
+    wav_put_u16(buf + 34, 16);                      /* bits per sample */
+    memcpy(buf + 36, "data", 4);
+    wav_put_u32(buf + 40, (unsigned long)data_bytes);
+    memset(buf + 44, 0, (size_t)data_bytes);
+    return (size_t)(44 + data_bytes);
+}
+
+static void test_wav_parse_valid(void) {
+    unsigned char buf[256];
+    wav_info_t info;
+    size_t len = make_wav(buf, 1, 8000, 10);
+
+    TEST_ASSERT_EQ_INT(wav_parse(buf, len, &info), 0);
+    TEST_ASSERT_EQ_INT(info.format, 1);
+    TEST_ASSERT_EQ_INT(info.channels, 1);
+    TEST_ASSERT_EQ_INT(info.sample_rate, 8000);
+    TEST_ASSERT_EQ_INT(info.bits_per_sample, 16);
+    TEST_ASSERT_EQ_INT((int)info.data_offset, 44);
+    TEST_ASSERT_EQ_INT((int)info.data_len, 20);  /* 10 mono frames * 2 bytes */
+}
+
+static void test_wav_parse_rejects_bad(void) {
+    unsigned char buf[256];
+    wav_info_t info;
+    size_t len = make_wav(buf, 1, 8000, 4);
+
+    TEST_ASSERT_EQ_INT(wav_parse((const unsigned char *)"nope", 4, &info), -1);
+    TEST_ASSERT_EQ_INT(wav_parse(buf, 8, &info), -1);    /* truncated header */
+    TEST_ASSERT_EQ_INT(wav_parse(NULL, 100, &info), -1);
+    TEST_ASSERT_EQ_INT(wav_parse(buf, len, NULL), -1);
+
+    buf[9] = 'X';                                        /* corrupt WAVE tag */
+    TEST_ASSERT_EQ_INT(wav_parse(buf, len, &info), -1);
+}
+
+static void test_wav_parse_skips_unknown_chunk(void) {
+    /* A LIST chunk (odd length -> a pad byte) before data must be skipped and
+     * the data range still located correctly. */
+    unsigned char buf[256];
+    wav_info_t info;
+    size_t n;
+
+    memcpy(buf + 0, "RIFF", 4);
+    memcpy(buf + 8, "WAVE", 4);
+    memcpy(buf + 12, "fmt ", 4);
+    wav_put_u32(buf + 16, 16);
+    wav_put_u16(buf + 20, 1);
+    wav_put_u16(buf + 22, 1);
+    wav_put_u32(buf + 24, 8000);
+    wav_put_u32(buf + 28, 16000);
+    wav_put_u16(buf + 32, 2);
+    wav_put_u16(buf + 34, 16);
+    memcpy(buf + 36, "LIST", 4);
+    wav_put_u32(buf + 40, 3);
+    buf[44] = 'a'; buf[45] = 'b'; buf[46] = 'c'; buf[47] = 0;  /* + pad byte */
+    memcpy(buf + 48, "data", 4);
+    wav_put_u32(buf + 52, 4);
+    buf[56] = 1; buf[57] = 2; buf[58] = 3; buf[59] = 4;
+    n = 60;
+    wav_put_u32(buf + 4, (unsigned long)(n - 8));
+
+    TEST_ASSERT_EQ_INT(wav_parse(buf, n, &info), 0);
+    TEST_ASSERT_EQ_INT((int)info.data_offset, 56);
+    TEST_ASSERT_EQ_INT((int)info.data_len, 4);
 }
 
 /* ── Display line budget guardrail ──────────────────────────────────── */
@@ -2106,6 +2201,9 @@ int main(void) {
     TEST_SUITE_RUN(test_operator_parse_year);
     TEST_SUITE_RUN(test_operator_fare_for_year);
     TEST_SUITE_RUN(test_operator_era_lookup);
+    TEST_SUITE_RUN(test_wav_parse_valid);
+    TEST_SUITE_RUN(test_wav_parse_rejects_bad);
+    TEST_SUITE_RUN(test_wav_parse_skips_unknown_chunk);
     TEST_SUITE_RUN(test_plugin_display_lines_fit);
 
     TEST_SUITE_BEGIN("Plugin SDK");

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -760,6 +760,11 @@ static void test_plugins_dispatch_missing_handler(void) {
 /* Pure comparison exported by plugins/number_guess.c */
 int number_guess_compare(int secret, int guess);
 
+/* Pure helpers exported by plugins/time_operator.c */
+int parse_year(const char *buf);
+int fare_for_year(int year);
+int era_index_for_year(int year);
+
 static void test_plugins_builtins_registered(void) {
     char buf[2048];
     daemon_state_data_t ds;
@@ -769,8 +774,8 @@ static void test_plugins_builtins_registered(void) {
 
     plugins_init();
 
-    /* Seven built-ins ship with the platform. */
-    TEST_ASSERT_EQ_INT(plugins_get_count(), 7);
+    /* Eight built-ins ship with the platform. */
+    TEST_ASSERT_EQ_INT(plugins_get_count(), 8);
 
     TEST_ASSERT_EQ_INT(plugins_list(buf, sizeof(buf)), 0);
     TEST_ASSERT_NOT_NULL(strstr(buf, "Classic Phone"));
@@ -780,6 +785,7 @@ static void test_plugins_builtins_registered(void) {
     TEST_ASSERT_NOT_NULL(strstr(buf, "Simon"));
     TEST_ASSERT_NOT_NULL(strstr(buf, "Dial-A-Joke"));
     TEST_ASSERT_NOT_NULL(strstr(buf, "Trivia"));
+    TEST_ASSERT_NOT_NULL(strstr(buf, "The Operator"));
 
     millennium_client_destroy(client);
     client = NULL;
@@ -868,6 +874,45 @@ static void test_number_guess_compare(void) {
     TEST_ASSERT(number_guess_compare(99, 1) < 0);
 }
 
+/* ── The Operator (time-travel plugin) pure logic ───────────────────── */
+
+static void test_operator_parse_year(void) {
+    TEST_ASSERT_EQ_INT(parse_year("1999"), 1999);
+    TEST_ASSERT_EQ_INT(parse_year("2000"), 2000);
+    TEST_ASSERT_EQ_INT(parse_year("0000"), 0);
+    TEST_ASSERT_EQ_INT(parse_year("123"), -1);   /* too short */
+    TEST_ASSERT_EQ_INT(parse_year("12345"), -1); /* too long */
+    TEST_ASSERT_EQ_INT(parse_year("19x9"), -1);  /* non-digit */
+    TEST_ASSERT_EQ_INT(parse_year(""), -1);
+    TEST_ASSERT_EQ_INT(parse_year(NULL), -1);
+}
+
+static void test_operator_fare_for_year(void) {
+    /* The anchor (2000) is free; the next-cheapest is the base fare. */
+    TEST_ASSERT_EQ_INT(fare_for_year(2000), 0);
+    TEST_ASSERT_EQ_INT(fare_for_year(2005), 25);   /* same decade as anchor */
+    /* Symmetric around the anchor. */
+    TEST_ASSERT_EQ_INT(fare_for_year(1990), fare_for_year(2010));
+    /* Non-decreasing with distance. */
+    TEST_ASSERT(fare_for_year(1980) >= fare_for_year(1990));
+    TEST_ASSERT(fare_for_year(1900) >= fare_for_year(1980));
+    /* Capped. */
+    TEST_ASSERT_EQ_INT(fare_for_year(1900), 275);  /* 25 + 25*10, under cap */
+    TEST_ASSERT(fare_for_year(2100) <= 500);
+}
+
+static void test_operator_era_lookup(void) {
+    /* A year maps to the bracket that contains it. */
+    TEST_ASSERT_EQ_INT(era_index_for_year(1915), 0);
+    TEST_ASSERT_EQ_INT(era_index_for_year(2000), 4);  /* the frozen minute */
+    TEST_ASSERT_EQ_INT(era_index_for_year(2025), 5);
+    TEST_ASSERT_EQ_INT(era_index_for_year(2075), 6);  /* sealed future */
+    /* Out of range and the 1999 dead-end gap map to none. */
+    TEST_ASSERT_EQ_INT(era_index_for_year(1850), -1);
+    TEST_ASSERT_EQ_INT(era_index_for_year(2200), -1);
+    TEST_ASSERT_EQ_INT(era_index_for_year(1999), -1);
+}
+
 /* ── Display line budget guardrail ──────────────────────────────────── */
 
 /* Each content-heavy built-in exposes its static display strings (mirroring
@@ -878,6 +923,7 @@ int dial_a_joke_display_strings(const char **out, int max);
 int trivia_display_strings(const char **out, int max);
 int jukebox_display_strings(const char **out, int max);
 int fortune_teller_display_strings(const char **out, int max);
+int time_operator_display_strings(const char **out, int max);
 
 static void check_display_strings(const char *plugin,
                                   int (*collect)(const char **, int)) {
@@ -910,6 +956,7 @@ static void test_plugin_display_lines_fit(void) {
     check_display_strings("Trivia", trivia_display_strings);
     check_display_strings("Jukebox", jukebox_display_strings);
     check_display_strings("Fortune Teller", fortune_teller_display_strings);
+    check_display_strings("The Operator", time_operator_display_strings);
 
     millennium_client_destroy(client);
     client = NULL;
@@ -2056,6 +2103,9 @@ int main(void) {
     TEST_SUITE_RUN(test_plugins_to_json);
     TEST_SUITE_RUN(test_plugins_to_json_escapes);
     TEST_SUITE_RUN(test_number_guess_compare);
+    TEST_SUITE_RUN(test_operator_parse_year);
+    TEST_SUITE_RUN(test_operator_fare_for_year);
+    TEST_SUITE_RUN(test_operator_era_lookup);
     TEST_SUITE_RUN(test_plugin_display_lines_fit);
 
     TEST_SUITE_BEGIN("Plugin SDK");

--- a/host/wav.c
+++ b/host/wav.c
@@ -1,0 +1,59 @@
+#include "wav.h"
+#include <string.h>
+
+static unsigned read_u16(const unsigned char *p) {
+    return (unsigned)p[0] | ((unsigned)p[1] << 8);
+}
+
+static unsigned long read_u32(const unsigned char *p) {
+    return (unsigned long)p[0] | ((unsigned long)p[1] << 8) |
+           ((unsigned long)p[2] << 16) | ((unsigned long)p[3] << 24);
+}
+
+int wav_parse(const unsigned char *data, size_t len, wav_info_t *out) {
+    size_t pos;
+    int have_fmt = 0;
+
+    if (!data || !out || len < 12) return -1;
+    if (memcmp(data, "RIFF", 4) != 0) return -1;
+    if (memcmp(data + 8, "WAVE", 4) != 0) return -1;
+
+    memset(out, 0, sizeof(*out));
+
+    pos = 12;
+    while (pos + 8 <= len) {
+        const unsigned char *ck = data + pos;
+        unsigned long cksize = read_u32(ck + 4);
+        size_t body = pos + 8;
+
+        if (cksize > len - body) {
+            /* A declared size past the buffer is only tolerable for the final
+             * data chunk (some writers leave it short of the real payload);
+             * clamp it there and reject anything else as malformed. */
+            if (memcmp(ck, "data", 4) == 0) {
+                cksize = (unsigned long)(len - body);
+            } else {
+                return -1;
+            }
+        }
+
+        if (memcmp(ck, "fmt ", 4) == 0) {
+            if (cksize < 16) return -1;
+            out->format          = (int)read_u16(ck + 8);
+            out->channels        = (int)read_u16(ck + 10);
+            out->sample_rate     = (int)read_u32(ck + 12);
+            out->bits_per_sample = (int)read_u16(ck + 22);
+            have_fmt = 1;
+        } else if (memcmp(ck, "data", 4) == 0) {
+            if (!have_fmt) return -1;
+            out->data_offset = body;
+            out->data_len = (size_t)cksize;
+            return 0;
+        }
+
+        /* Chunks are word-aligned: a body of odd length carries a pad byte. */
+        pos = body + cksize + (cksize & 1);
+    }
+
+    return -1;
+}

--- a/host/wav.h
+++ b/host/wav.h
@@ -1,0 +1,32 @@
+#ifndef WAV_H
+#define WAV_H
+
+#include <stddef.h>
+
+/*
+ * Minimal, dependency-free parser for canonical RIFF/WAVE (PCM) files.
+ *
+ * It validates the RIFF/WAVE container, walks the chunk list, and reports the
+ * format fields plus the byte range of the PCM "data" chunk within the supplied
+ * buffer. It does no I/O and pulls in nothing beyond <stddef.h>/<string.h>, so
+ * it compiles and is unit-tested on every platform — the ALSA streaming layer
+ * (audio_tones.c) is the only Linux-only consumer.
+ *
+ * Only the fields needed to play a clip are decoded; extension/LIST/fact chunks
+ * are skipped. All offsets/lengths are bounds-checked against `len`.
+ */
+typedef struct {
+    int    format;           /* WAVE_FORMAT tag; 1 = PCM */
+    int    channels;
+    int    sample_rate;      /* Hz */
+    int    bits_per_sample;
+    size_t data_offset;      /* byte offset of PCM samples within the buffer */
+    size_t data_len;         /* number of PCM bytes available */
+} wav_info_t;
+
+/* Parse `data` (`len` bytes) into `*out`. Returns 0 on success, -1 if the
+ * buffer is not a well-formed WAVE file with both a "fmt " and a "data" chunk.
+ * On success `data_offset`/`data_len` always lie within [0, len]. */
+int wav_parse(const unsigned char *data, size_t len, wav_info_t *out);
+
+#endif /* WAV_H */


### PR DESCRIPTION
Adds a new payphone experience plugin and the audio capability it wanted, in two commits.

## 1. The Operator — time-travel narrative plugin (`host/plugins/time_operator.c`)
Lift the handset to reach the Operator stranded at the frozen Y2K minute, dial a 4-digit **year**, pay a coin **fare** that scales with distance from 2000, optionally swipe a card as a **temporal pass** to unlock sealed eras, and hear each era play out on the VFD. Meddling in one era then opening another **jams the line with a paradox** that must be repaired; idling too long causes **temporal drift** back to the Operator.

Phase-1 MVP per the brief: no real SIP call (the daemon stays in `IDLE_UP`), and all narrative consequence is in-memory for the session (the SDK exposes no plugin-state persistence hook). Pure helpers (`parse_year`, `fare_for_year`, `era_index_for_year`) are kept side-effect-free for unit testing.

Notable design decisions (flagged where they differ from the brief):
- **Scenario tests assert on display text, not internal states** — `assert_state` only sees the 5 daemon states, and the experience runs entirely in `IDLE_UP`. Every internal state renders a distinct marker, and all lines are ≤20 chars so auto-scroll never alters the captured text.
- Coins auto-credit before `handle_coin` and only while `IDLE_UP` (balance zeroed on hook-up), so the flow is lift → insert → dial; the plugin never re-adds coins.

## 2. Recorded-clip audio path (`sdk_play_clip`)
Phase-2 audio: plugins can play recorded WAV clips through the existing tone subsystem, with clips **entirely optional** (graceful fallback to tones + text).
- New pure, unit-tested `wav.c` parser; ALSA streaming added to `audio_tones.c` (no-op without ALSA).
- `sdk_play_clip(name)` resolves `<audio.clip_dir>/<name>.wav`, whitelists the name (no path traversal), and a missing file is a no-op that leaves the current sound playing (so clips layer over a fallback tone).
- The Operator requests greeting/era-ambience/drop/paradox clips; none ship in the repo.
- Docs: `host/AUDIO_CLIPS.md` (feasibility + authoring), `PLUGIN_AUTHORING.md`, `daemon.conf.example`.

## Testing
- `make test`: **118 unit tests pass, all 32 scenarios pass** under `-Werror`.
- New: 3 `wav_parse` unit tests, 3 Operator pure-logic tests, 7 Operator scenario tests, and a simulator `assert_clip` command.
- Tone discipline verified: every continuous ringback/busy is stopped on transition.

⚠️ The ALSA branch of `audio_tones_play_clip()` only compiles on Linux, so `make test` on macOS exercises the parser + wiring but not ALSA playback itself — validate on the Pi via `make daemon` (or `make compile-check` with `libasound2-dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)