### PR TITLE
health_monitor: fix GCC 10 -Werror=stringop-truncation (Pi build break)

### DIFF
--- a/host/health_monitor.c
+++ b/host/health_monitor.c
@@ -399,8 +399,7 @@ static health_status_t execute_check(health_check_t* check) {
     check->last_status = status;
     check->last_check_time = time(NULL);
     if (message[0] != '\0') {
-        strncpy(check->last_message, message, sizeof(check->last_message) - 1);
-        check->last_message[sizeof(check->last_message) - 1] = '\0';
+        snprintf(check->last_message, sizeof(check->last_message), "%s", message);
     } else {
         snprintf(check->last_message, sizeof(check->last_message),
                  "Status: %s", health_monitor_status_to_string(status));


### PR DESCRIPTION
`execute_check()` used `strncpy(dst, src, sizeof-1)` + explicit null-terminate. That is safe, but **GCC 10.2.1 on the Raspberry Pi** rejects it under `-Werror=stringop-truncation` when the function is inlined, so `make daemon` fails on the Pi — even though the newer CI GCC accepts it. `main` therefore did not build on the deployment target.

Switched to `snprintf(dst, size, "%s", src)`, which always null-terminates, never warns, and matches the idiom already used in the `else` branch two lines down. No behavior change; health-monitor unit tests still pass.

Found while running `deploy-daemon` to the Pi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)