### PR TITLE
deploy-daemon skill: correct SSH key, Pi IP, zsh/GCC gotchas

### DIFF
--- a/.claude/skills/deploy-daemon/SKILL.md
+++ b/.claude/skills/deploy-daemon/SKILL.md
@@ -13,16 +13,32 @@ verifies SIP registration.
 ## Connection
 
 ```bash
-# Pi address is DHCP and HAS changed before (.145 -> .115 after a board swap).
-# Prefer the hostname; fall back to finding the current IP.
-PI=matzen@raspberrypi.local
-SSH="ssh -i $HOME/.ssh/id_ed25519_claude_anima -o IdentitiesOnly=yes -o BatchMode=yes -o ConnectTimeout=8"
+# Pi address is DHCP and HAS changed before (.145 -> .115 -> .152). mDNS
+# (raspberrypi.local) is FLAKY and often doesn't resolve, so the last-known IP
+# is usually the faster path: 192.168.86.152 (as of 2026-06-13).
+PI=matzen@192.168.86.152
+KEY=$HOME/.ssh/id_ed25519_sk_anima_notouch
 ```
 
-If `raspberrypi.local` doesn't resolve and the last-known IP is dead, find the
-Pi: `arp -a | grep -i 'b8:27\|dc:a6\|e4:5f\|d8:3a'` (Raspberry Pi OUIs) or
-check the router's DHCP table. `~/.ssh/id_ed25519_claude_anima` is the
-non-interactive key in this environment (passwordless sudo on the Pi).
+The working key is `id_ed25519_sk_anima_notouch` — a **YubiKey-backed** (`sk`)
+key, so the YubiKey must be physically attached (the `notouch` variant needs no
+button press, but the hardware must be present). The old `id_ed25519_claude_anima`
+key was RETIRED (`.retired-20260608`) and no longer works. The key gives
+passwordless sudo on the Pi.
+
+If `192.168.86.152` is dead, find the Pi: `arp -a | grep -i 'b8:27\|dc:a6\|e4:5f\|d8:3a'`
+(Raspberry Pi OUIs) or check the router's DHCP table.
+
+GOTCHA (this environment's shell is **zsh**): do NOT stash the ssh command in a
+variable and run it as `$SSH $PI '...'` — zsh does not word-split unquoted
+parameters, so the whole `ssh -i ...` string is treated as one command name and
+fails with "no such file or directory". Invoke `ssh`/`rsync` directly with the
+flags inline, e.g.:
+```bash
+ssh -i "$KEY" -o IdentitiesOnly=yes -o BatchMode=yes -o ConnectTimeout=8 "$PI" 'whoami'
+```
+(The PQ-crypto "not using a post-quantum key exchange" warning the Pi prints is
+harmless; filter it out of output if it's noisy.)
 
 Pi layout: scratch build dir `~/millennium-pjsip/host` · installed binary
 `/usr/local/bin/millennium-daemon` · systemd unit `daemon.service` · config
@@ -36,23 +52,33 @@ Pi layout: scratch build dir `~/millennium-pjsip/host` · installed binary
    ```bash
    rsync -az --delete --exclude '*.o' --exclude daemon --exclude simulator \
      --exclude unit_tests --exclude pjsip_smoke \
-     -e "$SSH" host/ $PI:millennium-pjsip/host/
+     -e "ssh -i $KEY -o IdentitiesOnly=yes -o BatchMode=yes -o ConnectTimeout=8" \
+     host/ "$PI":millennium-pjsip/host/
    ```
    (Or, for released code already on `main`, `git pull` in a Pi clone instead.)
 
 3. **Rebuild — `make clean` FIRST.** rsync preserves source mtimes, so a plain
-   `make daemon` often prints "up to date" and silently keeps the OLD binary:
+   `make daemon` often prints "up to date" and silently keeps the OLD binary.
+   The build takes ~40 s on the Pi Zero 2 W:
    ```bash
-   $SSH $PI 'cd ~/millennium-pjsip/host && make clean && make daemon'
+   ssh -i "$KEY" -o IdentitiesOnly=yes -o BatchMode=yes "$PI" \
+     'cd ~/millennium-pjsip/host && make clean && make daemon 2>&1 | tail -15'
    ```
    GOTCHA: never `pkill -f "make daemon"` over SSH — the remote shell's own argv
    contains that string, so it self-matches and kills your command. Use a `[m]ake`
    bracket pattern or check the binary mtime instead.
 
+   GOTCHA: the **Pi's GCC is 10.2.1, which is STRICTER than CI's GCC on some
+   `-Werror` warnings** (e.g. `stringop-truncation`), so code that builds in CI
+   and `make test` on the Mac (clang) can still fail `make daemon` here. If the
+   build dies on a file you didn't touch, it's likely a latent warning the Pi
+   toolchain newly flags — fix it (usually `snprintf` over `strncpy`) and land it
+   on `main` so the repo stays buildable on the deployment target.
+
 4. **Swap the binary and restart** (must stop first — can't overwrite a running
    binary). Keep a rollback copy:
    ```bash
-   $SSH $PI '
+   ssh -i "$KEY" -o IdentitiesOnly=yes -o BatchMode=yes "$PI" '
      sudo cp -a /usr/local/bin/millennium-daemon /usr/local/bin/millennium-daemon.prev.bak
      sudo systemctl stop daemon.service
      sudo cp ~/millennium-pjsip/host/daemon /usr/local/bin/millennium-daemon
@@ -61,7 +87,8 @@ Pi layout: scratch build dir `~/millennium-pjsip/host` · installed binary
 
 5. **Verify:**
    ```bash
-   $SSH $PI 'systemctl is-active daemon.service; \
+   ssh -i "$KEY" -o IdentitiesOnly=yes -o BatchMode=yes "$PI" \
+     'systemctl is-active daemon.service; \
      echo NRestarts=$(systemctl show daemon.service -p NRestarts --value); \
      curl -s --max-time 4 http://127.0.0.1:80/api/state'
    ```
@@ -71,7 +98,8 @@ Pi layout: scratch build dir `~/millennium-pjsip/host` · installed binary
 
 ## Rollback
 ```bash
-$SSH $PI 'sudo systemctl stop daemon.service; \
+ssh -i "$KEY" -o IdentitiesOnly=yes -o BatchMode=yes "$PI" \
+  'sudo systemctl stop daemon.service; \
   sudo cp /usr/local/bin/millennium-daemon.prev.bak /usr/local/bin/millennium-daemon; \
   sudo systemctl start daemon.service'
 ```


### PR DESCRIPTION
Refreshes the `deploy-daemon` skill doc from a real deploy. The skill pointed at the retired `id_ed25519_claude_anima` key and assumed `raspberrypi.local` resolves — both fail today.

- **SSH key**: `id_ed25519_sk_anima_notouch` (YubiKey-backed; hardware must be attached); old key retired.
- **Address**: `raspberrypi.local` mDNS is flaky → prefer last-known IP `192.168.86.152`.
- **zsh gotcha**: examples now invoke `ssh`/`rsync` inline instead of via a `$SSH` variable — zsh doesn't word-split unquoted params, so `$SSH $PI '...'` fails.
- **Toolchain gotcha**: Pi GCC 10.2.1 is stricter than CI's GCC (e.g. `stringop-truncation`), so `make daemon` can fail on the Pi on code that passes CI + `make test` (clang). Documented (this is what blocked PR #201's deploy until #202).
- Note the harmless post-quantum SSH warning.

Docs-only; no CI-relevant code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)