### PR TITLE
The Operator: paradox-persistence test, clip assertions, smoke test + playtest checklist

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -240,4 +240,14 @@ break-test:
 	@chmod +x tests/break_test.sh
 	@HOST=$(HOST) ./tests/break_test.sh $(HOST)
 
-.PHONY: all clean install uninstall test unit_tests api-test device-test break-test pjsip-smoke
+# "The Operator" plugin smoke test against a live daemon over the web API. Drives
+# the state machine end-to-end (greeting, eras, fares, 1999 drop, sealed refusal,
+# paradox+repair). Does NOT cover audio/coins/card/hook — those need the physical
+# phone; see host/OPERATOR_PLAYTEST.md. Usage: make operator-smoke [OP_HOST=<ip>]
+# [RUN_DRIFT=1] (default host = the Pi).
+OP_HOST ?= 192.168.86.152
+operator-smoke:
+	@chmod +x tests/operator_smoke.sh
+	@RUN_DRIFT=$(RUN_DRIFT) ./tests/operator_smoke.sh $(OP_HOST)
+
+.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke pjsip-smoke

--- a/host/OPERATOR_PLAYTEST.md
+++ b/host/OPERATOR_PLAYTEST.md
@@ -1,0 +1,80 @@
+# The Operator — physical playtest checklist
+
+A hands-on pass for the **The Operator** plugin on the real phone. Everything
+here was verified in software (unit + scenario tests, and the web-API smoke
+test); this checklist covers the parts that need **real hardware and your ears**:
+the handset hook switch, the coin validator, the magstripe reader, and audio on
+the earpiece.
+
+## Before you start
+
+1. Make it the active plugin (web dashboard, or):
+   ```bash
+   curl -s -X POST -H 'Content-Type: application/json' \
+     -d '{"action":"activate_plugin","plugin":"The Operator"}' http://<pi>/api/control
+   ```
+2. Software pre-flight (optional but recommended) — confirms the state machine
+   is healthy before you touch the phone:
+   ```bash
+   make operator-smoke OP_HOST=<pi>        # add RUN_DRIFT=1 for the slow drift leg
+   ```
+3. Re-activating the plugin resets session state (clears an armed paradox / the
+   temporal pass). Do it between runs if you want a clean slate.
+
+Audio clips live in `/usr/local/share/millennium/audio/` (see `AUDIO_CLIPS.md`).
+A missing clip is a silent no-op, so anything you didn't install just won't speak.
+
+## Checklist
+
+Tick VFD (V), audio (A), and the hardware path (H) for each.
+
+- [ ] **Greeting / hook switch.** Lift the handset.
+      V: `TIME OPERATOR` / `DIAL A YEAR  #=BACK`  ·  A: `operator.wav` greeting
+      ·  H: lifting really transitions to IDLE_UP (no API nudge).
+- [ ] **Coin validator + fare.** With the handset up, drop a real coin.
+      V: `CREDIT $0.25` (value matches the coin)  ·  A: coin chime
+      ·  H: the validator credits the balance.
+- [ ] **Travel to an era.** Dial `2 0 0 5` (fare 25¢ — insert a quarter first).
+      V: `CONNECTING... / YEAR 2005`, then `STATIC YEARS`  ·  A: ringback, then
+      `era_static.wav` ("Connecting. The static years…").
+- [ ] **Era branches.** In the era press `1` (listen) then `#` (back).
+      V: branch line ("…seven… nine…"), then back to the Operator.
+- [ ] **Home, free.** Dial `2 0 0 0` (no fare).  V: `FROZEN MINUTE` · A: `era_frozen.wav`.
+- [ ] **Insufficient funds.** Fresh lift, dial `2 0 0 5` with no coins.
+      V: `NEED $0.25 / HAVE $0.00`. Now insert a quarter → it connects.
+- [ ] **The 1999 drop.** Insert a quarter, dial `1 9 9 9`.
+      V: `ALMOST 2000... / NEVER MIDNIGHT`, then `LINE DROPPED` → Operator
+      ·  A: `drop.wav` ("…it always drops before midnight").
+- [ ] **Sealed future refused.** Dial `2 0 8 0` with no pass.  V: `FUTURE SEALED`.
+- [ ] **Temporal pass (magstripe).** Swipe any card.
+      V: `TEMPORAL PASS / PASS ACCEPTED`  ·  H: the reader fires `handle_card`.
+      Then dial `2 0 5 0` with enough coins (fare $1.50) → `SEALED FUTURE`.
+- [ ] **Paradox.** Dial an era (e.g. `1 9 9 5`), in it press `2` (meddle →
+      `TIMELINE BENT`), press `#`, then dial a *different* era (`2 0 0 5`).
+      V: `LINE FAULT 19## / #=OPERATOR`  ·  A: `paradox.wav`.
+- [ ] **Paradox survives a hang-up.** While armed, hang up and lift again, then
+      dial a different era — still `LINE FAULT`. (Consequences persist for the
+      session; re-activating the plugin is what clears it.)
+- [ ] **Paradox repair.** From the fault press `#`, dial back to the source year
+      (`1 9 9 5`), and press `1` (the opposite branch).  V: `TIMELINE / MENDED`.
+- [ ] **Temporal drift.** In any era, touch nothing for ~30 s.
+      V: snaps back with `TEMPORAL DRIFT / DIAL A YEAR`.
+- [ ] **Hang up.** Place the handset down from anywhere.
+      V: `THE OPERATOR / Lift to dial`  ·  A: any clip/tone stops immediately.
+
+## What to listen for (audio judgement — only doable here)
+
+- Clip **clarity** through the TDA2822M earpiece amp at 8 kHz narrowband.
+- Clip **volume vs the tones** (dial/ring/busy/DTMF). If a clip is noticeably
+  hotter or quieter than the tones, note it — clip levels can be normalized in
+  the conversion step and redeployed without touching the daemon.
+- No clipping/buzz, and that a clip **stops cleanly** on hang-up / dialing on.
+
+## If something's off
+
+- Wrong/no audio for one step: check the matching file exists and is 16-bit PCM
+  WAV in the clip dir (`ls -la /usr/local/share/millennium/audio/`).
+- Unexpected `LINE FAULT`: a paradox is still armed from a previous run —
+  re-activate the plugin to reset.
+- Coins not crediting / card not read / hook not switching: that's the Arduino
+  serial path, not the plugin — see `phone-status` and `journalctl -u daemon`.

--- a/host/tests/operator_smoke.sh
+++ b/host/tests/operator_smoke.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# operator_smoke.sh — drive "The Operator" plugin end-to-end against a LIVE
+# daemon over the web API and assert the VFD reaches each expected state. This
+# exercises everything that does NOT need physical hardware (state machine,
+# fares, year parsing, paradox, drift), so you can confirm the software is
+# healthy right before a hands-on session with real coins/handset/card/audio.
+#
+# It does NOT verify audio playback (the API can't read that) — use the
+# companion OPERATOR_PLAYTEST.md to check clips/coins/card/hook by hand.
+#
+# Usage:  ./operator_smoke.sh [HOST]          # default 192.168.86.152
+#         RUN_DRIFT=1 ./operator_smoke.sh     # also run the slow ~32s drift test
+#
+set -uo pipefail
+
+HOST="${1:-192.168.86.152}"
+BASE="http://${HOST}"
+PASS=0; FAIL=0
+
+post() { curl -s --max-time 5 -X POST -H 'Content-Type: application/json' \
+             -d "$1" "${BASE}/api/control" >/dev/null; }
+key()  { post "{\"action\":\"keypad_press\",\"key\":\"$1\"}"; sleep 0.4; }
+keys() { local d; for d in $(echo "$1" | fold -w1); do key "$d"; done; }
+coin() { post "{\"action\":\"coin_insert\",\"cents\":${1:-25}}"; sleep 0.4; }
+reset(){ post '{"action":"activate_plugin","plugin":"The Operator"}'; sleep 0.6
+         post '{"action":"handset_up"}'; sleep 1; }   # fresh session, 0 coins
+vfd()  { curl -s --max-time 5 "${BASE}/api/state" \
+             | tr ',' '\n' | grep -E '"line1"|"line2"' | sed 's/.*://;s/}//' | tr '\n' ' '; }
+# expect <label> <substring>
+expect() {
+    local got; got="$(vfd)"
+    if printf '%s' "$got" | grep -q "$2"; then
+        printf '  PASS  %-28s [%s]\n' "$1" "$2"; PASS=$((PASS+1))
+    else
+        printf '  FAIL  %-28s want [%s] got %s\n' "$1" "$2" "$got"; FAIL=$((FAIL+1))
+    fi
+}
+
+echo "== Operator smoke test against ${HOST} =="
+
+# Sanity: daemon reachable + plugin present
+if ! curl -s --max-time 5 "${BASE}/api/plugins" | grep -q "The Operator"; then
+    echo "  FAIL  daemon unreachable or plugin missing at ${HOST}"; exit 1
+fi
+
+echo "-- greeting --";        reset;            expect "greeting" "DIAL A YEAR"
+echo "-- era (2005) --";      coin 25; keys 2005; sleep 6; expect "era static" "STATIC YEARS"
+echo "-- home (2000, free) --"; reset; keys 2000; sleep 6; expect "frozen minute" "FROZEN MINUTE"
+echo "-- need-fare then pay --"; reset; keys 2005; expect "need fare" "NEED"
+                              coin 25; sleep 6;   expect "connects" "STATIC YEARS"
+echo "-- 1999 drop --";       reset; coin 25; keys 1999; sleep 6; expect "drop" "MIDNIGHT"
+                              sleep 4;            expect "back to operator" "DIAL A YEAR"
+echo "-- sealed future + pass --"; reset; keys 2080; expect "sealed refused" "SEALED"
+                              post '{"action":"activate_plugin","plugin":"The Operator"}'; sleep 0.6
+                              post '{"action":"handset_up"}'; sleep 1
+                              # NOTE: a real magstripe swipe can't be injected via this API;
+                              # this leg only confirms the refusal. Swipe a card by hand for the pass.
+echo "-- paradox + repair --"; reset
+                              coin 25; coin 25; coin 25; coin 25
+                              keys 1995; sleep 6; expect "era A" "LAST ANALOG"
+                              key 2;              expect "armed" "BENT"
+                              key '#'; keys 2005; expect "jammed" "LINE FAULT"
+                              key '#'; keys 1995; sleep 6; key 1; expect "repaired" "MENDED"
+
+if [ "${RUN_DRIFT:-0}" = "1" ]; then
+    echo "-- temporal drift (~32s) --"; reset; coin 25; keys 2005; sleep 6
+                              expect "in era" "STATIC YEARS"
+                              echo "  ...idling 32s..."; sleep 32
+                              expect "drifted back" "TEMPORAL DRIFT"
+fi
+
+post '{"action":"handset_down"}'
+echo "== ${PASS} passed, ${FAIL} failed =="
+[ "$FAIL" -eq 0 ]

--- a/host/tests/test_operator_1999_drop.scenario
+++ b/host/tests/test_operator_1999_drop.scenario
@@ -9,6 +9,7 @@ keys 1999
 # The line rings, then drops before the clock can turn over
 wait 6
 assert_display MIDNIGHT
+assert_clip drop.wav
 
 # After the drop it returns to the Operator
 wait 4

--- a/host/tests/test_operator_paradox.scenario
+++ b/host/tests/test_operator_paradox.scenario
@@ -20,6 +20,7 @@ assert_display BENT
 key #
 keys 2005
 assert_display LINE FAULT
+assert_clip paradox.wav
 
 # Return to the source year and choose the opposite branch (1) -> mended
 key #

--- a/host/tests/test_operator_paradox_persists.scenario
+++ b/host/tests/test_operator_paradox_persists.scenario
@@ -1,0 +1,36 @@
+# The Operator: an armed paradox is a session-long consequence -- it survives
+# hanging up and lifting the handset again (state only resets when the plugin is
+# re-activated). Meddle in one era, hang up, come back, open a DIFFERENT era,
+# and the line is still jammed.
+activate_plugin The Operator
+
+# Lift, travel to 1995, and meddle (branch 2) -> arms the paradox
+hook_up
+coin 25
+keys 1995
+wait 6
+assert_display LAST ANALOG
+key 2
+assert_display BENT
+
+# Hang up completely, then lift again -- a fresh call, but the timeline is
+# still bent (coins are cleared on hook-up, so pay the fare again).
+hook_down
+assert_state IDLE_DOWN
+hook_up
+assert_display DIAL A YEAR
+coin 25
+
+# Opening a different era still jams the line: the paradox persisted.
+keys 2005
+assert_display LINE FAULT
+assert_clip paradox.wav
+
+# Re-activating the plugin is what clears session state -- now a different era
+# connects normally instead of jamming.
+activate_plugin The Operator
+hook_up
+coin 25
+keys 2005
+wait 6
+assert_display STATIC YEARS


### PR DESCRIPTION
Remote work before the physical playtest — strengthen tests and prep the hands-on session.

## Tests
- **New scenario** `test_operator_paradox_persists.scenario`: locks in that an armed paradox **survives a hang-up/lift cycle** (a session-long consequence) and is only cleared by re-activating the plugin. This is the behavior that briefly fooled a manual hardware check.
- **`assert_clip` coverage**: added `drop.wav` and `paradox.wav` assertions to their scenarios (greeting/travel already assert `operator.wav`/`era_static.wav`), so the clip-request wiring is locked into the suite.

## Physical-test prep
- **`tests/operator_smoke.sh`** (`make operator-smoke [OP_HOST=<ip>] [RUN_DRIFT=1]`): drives the plugin end-to-end against a **live daemon** over the web API — greeting, eras, fares, the 1999 drop, sealed refusal, paradox + repair, optional drift. A quick software pre-flight before touching the phone. **Verified 12/12 against the Pi.**
- **`host/OPERATOR_PLAYTEST.md`**: hands-on checklist for the parts that genuinely need hardware/ears — hook switch, coin validator, magstripe temporal pass, and audio clarity/volume through the earpiece amp.

## Notes
- Also confirmed during this work that `call.idle_timeout_seconds` is **dead config** (never consumed) — so nothing resets `IDLE_UP` out from under a long era listen; the plugin's 30 s temporal-drift is the only timeout in play.

`make test`: 118 unit tests pass, all scenarios pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)