### PR TITLE
Make The Operator's voice clips reproducible (manifest + regen script)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ pcb/*-erc.rpt
 host/unit_tests
 host/pjsip_smoke
 host/daemon-override.conf.tmp
+host/audio/out/

--- a/host/AUDIO_CLIPS.md
+++ b/host/AUDIO_CLIPS.md
@@ -35,6 +35,29 @@ ffmpeg -i voice.mp3 -ac 1 -ar 8000 -sample_fmt s16 operator.wav
 scp operator.wav matzen@raspberrypi.local:/usr/local/share/millennium/audio/
 ```
 
+## Reproducible clips (manifest + regen script)
+
+The clips are **not in git** (binary, and easy to regenerate), so the source of
+truth is [`audio/clips.manifest`](audio/clips.manifest): one line per clip,
+`<clip_name> <text>`, plus the voice/model in its header. The current set is
+"The Operator" narration in ElevenLabs' *Sarah* voice.
+
+[`audio/regen_clips.sh`](audio/regen_clips.sh) rebuilds every clip from the
+manifest — synthesize via ElevenLabs TTS, convert to the format above, write to
+`audio/out/`, and optionally deploy to the Pi. Use this to restore the clips
+after an SD reflash or to re-voice them (edit the manifest, or set `VOICE_ID`).
+
+```sh
+export ELEVENLABS_API_KEY=sk_...        # a TTS-capable key; never commit it
+make regen-clips                        # build into host/audio/out/
+make regen-clips DEPLOY=1               # build + scp/install onto the Pi
+# voice/host overrides: VOICE_ID=... PI_HOST=user@ip ./audio/regen_clips.sh --deploy
+```
+
+To re-voice, change the `Voice:` line + `VOICE_ID`. Free ElevenLabs accounts
+can't use "library" voices via the API (HTTP 402); current default voices like
+Sarah/Brian/George work.
+
 ## Using clips from a plugin
 
 ```c
@@ -56,8 +79,10 @@ sdk_play_clip("operator");   /* plays <clip_dir>/operator.wav */
 "The Operator" uses this for an Operator greeting on lift (`operator`), per-era
 ambience on arrival (`era_wires`, `era_golden`, `era_space`, `era_analog`,
 `era_frozen`, `era_static`, `era_sealed`), the 1999 line-drop (`drop`), and the
-paradox sting (`paradox`). None ship in the repo — add your own to bring the
-phone to life, or leave them out and the experience runs on tones + text.
+paradox sting (`paradox`). The recordings themselves aren't committed, but their
+text is — all 10 are defined in `audio/clips.manifest` and rebuilt by
+`make regen-clips` (see above). Leave them out and the experience still runs on
+tones + text.
 
 ## Testing
 

--- a/host/Makefile
+++ b/host/Makefile
@@ -250,4 +250,10 @@ operator-smoke:
 	@chmod +x tests/operator_smoke.sh
 	@RUN_DRIFT=$(RUN_DRIFT) ./tests/operator_smoke.sh $(OP_HOST)
 
-.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke pjsip-smoke
+# Regenerate The Operator's voice clips from audio/clips.manifest via ElevenLabs
+# TTS. Needs ELEVENLABS_API_KEY in the environment and ffmpeg. Add DEPLOY=1 to
+# also push the rebuilt WAVs to the Pi. See host/AUDIO_CLIPS.md.
+regen-clips:
+	@cd audio && ./regen_clips.sh $(if $(DEPLOY),--deploy,)
+
+.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke regen-clips pjsip-smoke

--- a/host/audio/clips.manifest
+++ b/host/audio/clips.manifest
@@ -1,0 +1,31 @@
+# Millennium "The Operator" voice-clip manifest.
+#
+# The recorded clips live only on the Pi's SD card (not in git), so this file is
+# the reproducible source of truth: regen_clips.sh reads it, synthesizes each
+# clip with ElevenLabs text-to-speech, converts to 8 kHz mono 16-bit PCM WAV,
+# and (optionally) deploys to the phone. See AUDIO_CLIPS.md.
+#
+# Voice : Sarah  (ElevenLabs voice_id EXAVITQu4vr4xnSDxMaL)
+# Model : eleven_multilingual_v2
+# Both are overridable via VOICE_ID / MODEL_ID env vars when running the script.
+#
+# Format: one clip per line  ->  <clip_name><whitespace><text...>
+#   - clip_name is a single token; the daemon plays <clip_name>.wav
+#   - everything after the first whitespace run is the spoken text
+#   - blank lines and lines starting with '#' are ignored
+#
+# Keep text plain (the script JSON-escapes it safely); spell out numbers and
+# years so they are read aloud the way you want ("nineteen ninety-nine").
+
+operator   Finally. You picked up. This is the Operator. Dial a year, and I will put you through.
+
+drop       The line is ringing. Almost there. Almost the new year... no. It always drops before midnight. No one ever reaches nineteen ninety-nine.
+paradox    You have bent the timeline. The line is jammed now, two moments crossing at once. Go back to the year you meddled with, and set it right.
+
+era_wires  Connecting. The nineteen hundreds, the age of wires. Hear the copper hum. Every call here is plugged by hand, by an operator like me.
+era_golden Connecting. The golden age of the air. A radio crackles to life, and a big band swings its way down the line.
+era_space  Connecting. The space age. Static drifts in from orbit, and somewhere a countdown is ticking toward the stars.
+era_analog Connecting. The last analog years. Modems screech and handshake, and a young world wide web begins to sing.
+era_frozen Connecting. The frozen minute. Eleven fifty-nine, forever. You are home now, where the clock never turned over.
+era_static Connecting. The static years. Dead air and faint voices, a number station counting out to no one at all.
+era_sealed Connecting. The sealed future. Only a temporal pass opens this line. A calm machine is waiting, and it knows your name.

--- a/host/audio/regen_clips.sh
+++ b/host/audio/regen_clips.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# regen_clips.sh — rebuild "The Operator" voice clips from clips.manifest.
+#
+# For each clip in the manifest it calls ElevenLabs text-to-speech, converts the
+# result to the daemon's clip format (8 kHz mono 16-bit PCM WAV), writes it to
+# OUTDIR, and optionally deploys to the Pi. The recorded WAVs are not in git, so
+# this is how you restore them after an SD reflash or change the script.
+#
+# Requires: curl, ffmpeg, python3, and an ElevenLabs API key with TTS access.
+#
+# Usage:
+#   ELEVENLABS_API_KEY=sk_... ./regen_clips.sh            # build into ./out
+#   ELEVENLABS_API_KEY=sk_... ./regen_clips.sh --deploy   # build + copy to Pi
+#
+# Env knobs (all optional):
+#   ELEVENLABS_API_KEY  required  — API key (never hard-code it / commit it)
+#   VOICE_ID            default Sarah (EXAVITQu4vr4xnSDxMaL)
+#   MODEL_ID            default eleven_multilingual_v2
+#   OUTDIR              default <script dir>/out
+#   PI_HOST             default matzen@192.168.86.152   (for --deploy)
+#   SSH_KEY             default ~/.ssh/id_ed25519_sk_anima_notouch
+#   CLIP_DIR            default /usr/local/share/millennium/audio  (on the Pi)
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+MANIFEST="$HERE/clips.manifest"
+OUTDIR="${OUTDIR:-$HERE/out}"
+VOICE_ID="${VOICE_ID:-EXAVITQu4vr4xnSDxMaL}"   # Sarah
+MODEL_ID="${MODEL_ID:-eleven_multilingual_v2}"
+PI_HOST="${PI_HOST:-matzen@192.168.86.152}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519_sk_anima_notouch}"
+CLIP_DIR="${CLIP_DIR:-/usr/local/share/millennium/audio}"
+DEPLOY=0
+[ "${1:-}" = "--deploy" ] && DEPLOY=1
+
+die() { echo "error: $*" >&2; exit 1; }
+command -v curl    >/dev/null || die "curl not found"
+command -v ffmpeg  >/dev/null || die "ffmpeg not found"
+command -v python3 >/dev/null || die "python3 not found"
+[ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
+[ -n "${ELEVENLABS_API_KEY:-}" ] || die "set ELEVENLABS_API_KEY (TTS-capable key)"
+
+mkdir -p "$OUTDIR"
+echo "Voice $VOICE_ID · model $MODEL_ID · out $OUTDIR"
+
+built=0
+while read -r name text || [ -n "$name" ]; do
+    # skip blanks / comments (read leaves name empty on a blank line)
+    [ -z "${name:-}" ] && continue
+    case "$name" in \#*) continue ;; esac
+    [ -n "${text:-}" ] || { echo "  skip $name (no text)"; continue; }
+
+    body="$(python3 -c 'import json,sys; print(json.dumps({"text":sys.argv[1],"model_id":sys.argv[2]}))' "$text" "$MODEL_ID")"
+    mp3="$OUTDIR/$name.mp3"; wav="$OUTDIR/$name.wav"
+
+    code="$(curl -s -w '%{http_code}' -X POST \
+        "https://api.elevenlabs.io/v1/text-to-speech/$VOICE_ID" \
+        -H "xi-api-key: $ELEVENLABS_API_KEY" -H "Content-Type: application/json" \
+        -d "$body" --output "$mp3")"
+
+    if [ "$code" != "200" ] || head -c1 "$mp3" | grep -qa '{'; then
+        echo "  FAIL $name: HTTP $code -> $(head -c 200 "$mp3" 2>/dev/null)"
+        rm -f "$mp3"; die "TTS failed for '$name' (check key/voice/plan)"
+    fi
+
+    ffmpeg -y -loglevel error -i "$mp3" -ac 1 -ar 8000 -sample_fmt s16 \
+        -c:a pcm_s16le "$wav"
+    rm -f "$mp3"
+    [ "$(head -c4 "$wav")" = "RIFF" ] || die "bad WAV produced for '$name'"
+    printf '  ok   %-11s %s bytes\n' "$name" "$(wc -c <"$wav" | tr -d ' ')"
+    built=$((built+1))
+done < "$MANIFEST"
+
+echo "built $built clip(s) into $OUTDIR"
+
+if [ "$DEPLOY" = "1" ]; then
+    [ -f "$SSH_KEY" ] || die "ssh key not found: $SSH_KEY"
+    SSH="ssh -i $SSH_KEY -o IdentitiesOnly=yes -o BatchMode=yes -o ConnectTimeout=8"
+    echo "deploying to $PI_HOST:$CLIP_DIR"
+    $SSH "$PI_HOST" 'rm -rf ~/op_clips_in && mkdir -p ~/op_clips_in'
+    scp -i "$SSH_KEY" -o IdentitiesOnly=yes -o BatchMode=yes "$OUTDIR"/*.wav "$PI_HOST":op_clips_in/ >/dev/null
+    $SSH "$PI_HOST" "sudo mkdir -p $CLIP_DIR && sudo cp ~/op_clips_in/*.wav $CLIP_DIR/ && sudo chmod 644 $CLIP_DIR/*.wav && rm -rf ~/op_clips_in && ls -1 $CLIP_DIR"
+    echo "deployed."
+fi


### PR DESCRIPTION
The 10 voice clips live only on the Pi's SD card — an SD reflash loses them, and nothing recorded *what is said*. This adds a committed source of truth and a one-command rebuild.

- **`host/audio/clips.manifest`** — one line per clip (`<name> <text>`), with the voice (ElevenLabs *Sarah*) + model in the header. The exact narration for all 10 clips (greeting, 7 era intros, the 1999 drop, the paradox).
- **`host/audio/regen_clips.sh`** — reads the manifest, synthesizes each clip via ElevenLabs TTS, converts to the daemon's 8 kHz mono 16-bit PCM WAV, writes to `audio/out/`, and with `--deploy` scp/installs onto the Pi. Key comes from `ELEVENLABS_API_KEY` (never committed); voice/host/dirs are env-overridable; JSON is built with `python3` so future text edits are safely escaped.
- **`make regen-clips [DEPLOY=1]`**; `audio/out/` is gitignored.
- Workflow documented in `AUDIO_CLIPS.md`.

**Verified:** the script rebuilt all 10 clips from the manifest, each a valid 16-bit PCM mono 8 kHz WAV accepted by the `wav.c` parser.

To re-voice the phone: edit the manifest (or set `VOICE_ID=`) and `make regen-clips DEPLOY=1`.

`make test`: 118 unit tests pass, all scenarios pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)