### PR TITLE
Fix serial event-queue / control-command data race (found by playtesting)

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -256,4 +256,15 @@ operator-smoke:
 regen-clips:
 	@cd audio && ./regen_clips.sh $(if $(DEPLOY),--deploy,)
 
-.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke regen-clips pjsip-smoke
+# ThreadSanitizer check for the serial event queue's lock (mirrors
+# millennium_sdk.c). Needs a TSan-capable toolchain (clang/gcc on x86-64 or
+# arm64; NOT the 32-bit Pi). The locked build must be race-free; the -DNO_LOCK
+# build demonstrates the pre-fix race. Not part of `make test`.
+TSAN_CC ?= clang
+tsan-queue:
+	@$(TSAN_CC) -fsanitize=thread -g -O1 tests/tsan_event_queue.c -o /tmp/tsan_queue_lock
+	@echo "[locked] (expect: no races, prints done)"; /tmp/tsan_queue_lock
+	@$(TSAN_CC) -fsanitize=thread -g -O1 -DNO_LOCK tests/tsan_event_queue.c -o /tmp/tsan_queue_nolock
+	@echo "[no-lock] (expect: ThreadSanitizer data race warnings)"; /tmp/tsan_queue_nolock || true
+
+.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke regen-clips tsan-queue pjsip-smoke

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -56,6 +56,12 @@ static const char *state_file_path = NULL;
 /* Thread synchronization */
 pthread_mutex_t running_mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t daemon_state_mutex = PTHREAD_MUTEX_INITIALIZER;
+/* Serializes one whole engine step (serial read + event dispatch + plugin ticks
+ * + display writes) in the main loop against web-thread control commands, which
+ * run the same paths via send_control_command. Held only around the work, never
+ * across the idle sleep. Lock order: engine_mutex -> daemon_state_mutex /
+ * plugins_mutex / the SDK queue mutex (never the reverse). */
+static pthread_mutex_t engine_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /* Simple validation macro */
 #define VALIDATE_BASICS() do { \
@@ -575,7 +581,20 @@ void handle_card_event(card_event_t *card_event) {
 }
 
 /* Implementation of sendControlCommand */
+static int dispatch_control_command(const char* action);
+
+/* Public entry for web-thread control commands. Runs the dispatch under
+ * engine_mutex so it can't touch the serial fd / event queue / plugin state /
+ * display concurrently with the main loop's engine step. */
 int send_control_command(const char* action) {
+    int result;
+    pthread_mutex_lock(&engine_mutex);
+    result = dispatch_control_command(action);
+    pthread_mutex_unlock(&engine_mutex);
+    return result;
+}
+
+static int dispatch_control_command(const char* action) {
     char command[MAX_STRING_LEN];
     char arg[MAX_STRING_LEN];
     const char *colon_pos;
@@ -1149,6 +1168,7 @@ int main(int argc, char *argv[]) {
     /* Main event loop */
     while (1) {
         event_t *event;
+        int had_event;
         pthread_mutex_lock(&running_mutex);
         if (!running) {
             pthread_mutex_unlock(&running_mutex);
@@ -1156,22 +1176,15 @@ int main(int argc, char *argv[]) {
         }
         pthread_mutex_unlock(&running_mutex);
 
+        pthread_mutex_lock(&engine_mutex);
+
         millennium_client_update(client);
 
         event = (event_t *)millennium_client_next_event(client);
+        had_event = (event != NULL);
         if (event) {
             event_processor_process_event(event_processor, event);
             event_destroy(event);
-        } else {
-            /* No event: yield ~10ms to keep idle CPU low (the OS buffers serial,
-             * so input latency stays imperceptible) — frees the single core for
-             * call audio (#115). */
-            {
-                struct timeval tv;
-                tv.tv_sec = 0;
-                tv.tv_usec = 10000;
-                select(0, NULL, NULL, NULL, &tv);
-            }
         }
         
         /* Periodic work on a wall-clock schedule. The loop now idles at ~10ms
@@ -1220,8 +1233,20 @@ int main(int argc, char *argv[]) {
                 }
             }
         }
+
+        pthread_mutex_unlock(&engine_mutex);
+
+        if (!had_event) {
+            /* No event: yield ~10ms OUTSIDE the engine lock to keep idle CPU low
+             * without blocking web-thread control commands. The OS buffers
+             * serial, so input latency stays imperceptible (#115). */
+            struct timeval tv;
+            tv.tv_sec = 0;
+            tv.tv_usec = 10000;
+            select(0, NULL, NULL, NULL, &tv);
+        }
     }
-    
+
     /* Cleanup */
     logger_info_with_category("Daemon", "Shutting down daemon");
     

--- a/host/millennium_sdk.c
+++ b/host/millennium_sdk.c
@@ -35,6 +35,13 @@ static int g_sip_registered = 0;
 static char g_sip_last_error[256] = {0};
 static pthread_mutex_t g_sip_mutex = PTHREAD_MUTEX_INITIALIZER;
 
+/* The event queue is produced by both the main loop (serial events) and PJSUA
+ * worker threads (SIP call-state events, via the SIP callback) and consumed by
+ * the main loop, so its linked-list/malloc operations must be serialized or the
+ * heap corrupts. This guards push/pop/empty; clear() runs only at shutdown and
+ * reuses those locked primitives, so it stays lock-free itself. */
+static pthread_mutex_t g_queue_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 /* Event queue implementation */
 static void event_queue_push(struct millennium_client *client, void *event) {
     struct event_queue_node *node = malloc(sizeof(struct event_queue_node));
@@ -42,22 +49,27 @@ static void event_queue_push(struct millennium_client *client, void *event) {
         logger_error_with_category("SDK", "Failed to allocate memory for event queue node");
         return;
     }
-    
+
     node->event = event;
     node->next = NULL;
-    
+
+    pthread_mutex_lock(&g_queue_mutex);
     if (client->event_queue_tail) {
         client->event_queue_tail->next = node;
     } else {
         client->event_queue_head = node;
     }
     client->event_queue_tail = node;
+    pthread_mutex_unlock(&g_queue_mutex);
 }
 
 static void *event_queue_pop(struct millennium_client *client) {
     struct event_queue_node *node;
     void *event;
+
+    pthread_mutex_lock(&g_queue_mutex);
     if (!client->event_queue_head) {
+        pthread_mutex_unlock(&g_queue_mutex);
         return NULL;
     }
 
@@ -68,13 +80,18 @@ static void *event_queue_pop(struct millennium_client *client) {
     if (!client->event_queue_head) {
         client->event_queue_tail = NULL;
     }
-    
+    pthread_mutex_unlock(&g_queue_mutex);
+
     free(node);
     return event;
 }
 
 static int event_queue_empty(struct millennium_client *client) {
-    return client->event_queue_head == NULL;
+    int empty;
+    pthread_mutex_lock(&g_queue_mutex);
+    empty = (client->event_queue_head == NULL);
+    pthread_mutex_unlock(&g_queue_mutex);
+    return empty;
 }
 
 static void event_queue_clear(struct millennium_client *client) {

--- a/host/plugins/time_operator.c
+++ b/host/plugins/time_operator.c
@@ -44,6 +44,7 @@
 #define GRACE_SECS         30   /* re-lift within this window resumes a session */
 #define FINAL_CONNECT_SECS 3
 #define FINAL_CLOCK_SECS   4
+#define ENTRY_TIMEOUT_SECS 6   /* clear a half-typed year/number after this idle */
 
 /* Ruth's number, in three positional pieces A-B-C (tunable). */
 #define PIECE_A "36"
@@ -390,6 +391,7 @@ static int op_handle_coin(int coin_value, const char *coin_code) {
 static int op_handle_keypad(char key) {
     switch (op.state) {
     case TS_HUB:
+        op.last_input_at = sdk_now();   /* for the stale-entry auto-clear */
         if (key >= '0' && key <= '9') {
             if (op.len < 4) {
                 op.buf[op.len++] = key;
@@ -409,6 +411,7 @@ static int op_handle_keypad(char key) {
         break;
 
     case TS_READY:
+        op.last_input_at = sdk_now();   /* for the stale-entry auto-clear */
         if (key >= '0' && key <= '9') {
             if (op.len < 6) {
                 op.buf[op.len++] = key;
@@ -497,6 +500,20 @@ static void op_handle_activation(void) {
 
 static void op_handle_tick(void) {
     switch (op.state) {
+    case TS_HUB:
+        /* A half-typed year left by a hesitant or fumbling caller clears itself
+         * so stray digits can't derail the next dial. */
+        if (op.len > 0 && sdk_elapsed(op.last_input_at) >= ENTRY_TIMEOUT_SECS) {
+            op.buf[0] = '\0'; op.len = 0;
+            op_render_hub();
+        }
+        break;
+    case TS_READY:
+        if (op.len > 0 && sdk_elapsed(op.last_input_at) >= ENTRY_TIMEOUT_SECS) {
+            op.buf[0] = '\0'; op.len = 0;
+            op_render_ready();
+        }
+        break;
     case TS_TRAVEL:
         if (sdk_elapsed(op.timer_at) >= TRAVEL_SECS) op_resolve_travel();
         break;

--- a/host/tests/test_operator_entry_timeout.scenario
+++ b/host/tests/test_operator_entry_timeout.scenario
@@ -1,0 +1,19 @@
+# The Operator: a half-typed year left idle clears itself, so a hesitant caller's
+# stray digits can't corrupt the next dial.
+activate_plugin The Operator
+hook_up
+
+# Start typing a year, then walk away
+key 1
+key 9
+assert_display YEAR: 19
+
+# After the idle timeout it returns to the clean hub
+wait 7
+assert_display DIAL A YEAR
+assert_display 0/3
+
+# A fresh dial now works cleanly (no stale "19" prefix)
+keys 1955
+wait 3
+assert_display 1=LISTEN

--- a/host/tests/tsan_event_queue.c
+++ b/host/tests/tsan_event_queue.c
@@ -1,0 +1,88 @@
+/*
+ * ThreadSanitizer harness for the daemon's serial event queue.
+ *
+ * The push/pop below are kept identical to event_queue_push/event_queue_pop in
+ * millennium_sdk.c. In the daemon the queue is produced by both the main loop
+ * (serial events) and PJSUA worker threads (SIP call-state events) and consumed
+ * by the main loop; with no lock those concurrent linked-list/malloc operations
+ * corrupt the heap (observed as a SIGABRT under load). This reproduces that and
+ * verifies the fix.
+ *
+ *   make tsan-queue        # builds + runs both variants under ThreadSanitizer
+ *
+ * Locked build  -> clean (no races).  -DNO_LOCK build -> ThreadSanitizer reports
+ * data races on event_queue_head/tail. (Keep in sync with millennium_sdk.c.)
+ */
+#include <pthread.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+struct event_queue_node { void *event; struct event_queue_node *next; };
+struct millennium_client {
+    struct event_queue_node *event_queue_head, *event_queue_tail;
+};
+
+#ifdef NO_LOCK
+#define QLOCK()   ((void)0)
+#define QUNLOCK() ((void)0)
+#else
+static pthread_mutex_t g_queue_mutex = PTHREAD_MUTEX_INITIALIZER;
+#define QLOCK()   pthread_mutex_lock(&g_queue_mutex)
+#define QUNLOCK() pthread_mutex_unlock(&g_queue_mutex)
+#endif
+
+static void event_queue_push(struct millennium_client *client, void *event) {
+    struct event_queue_node *node = malloc(sizeof(struct event_queue_node));
+    if (!node) return;
+    node->event = event;
+    node->next = NULL;
+    QLOCK();
+    if (client->event_queue_tail) client->event_queue_tail->next = node;
+    else client->event_queue_head = node;
+    client->event_queue_tail = node;
+    QUNLOCK();
+}
+
+static void *event_queue_pop(struct millennium_client *client) {
+    struct event_queue_node *node;
+    void *event;
+    QLOCK();
+    if (!client->event_queue_head) { QUNLOCK(); return NULL; }
+    node = client->event_queue_head;
+    event = node->event;
+    client->event_queue_head = node->next;
+    if (!client->event_queue_head) client->event_queue_tail = NULL;
+    QUNLOCK();
+    free(node);
+    return event;
+}
+
+static struct millennium_client cl;
+#define N 50000
+
+static void *producer(void *arg) {
+    long id = (long)arg, i;
+    for (i = 0; i < N; i++) event_queue_push(&cl, (void *)(id * N + i + 1));
+    return NULL;
+}
+
+/* Bounded pop attempts so the (corrupting) no-lock run still terminates after
+ * ThreadSanitizer has flagged the race, instead of spinning on a lost item. */
+static void *consumer(void *arg) {
+    long tries = 0;
+    (void)arg;
+    while (tries < 4 * N) { event_queue_pop(&cl); tries++; }
+    return NULL;
+}
+
+int main(void) {
+    pthread_t p1, p2, c1;
+    pthread_create(&p1, NULL, producer, (void *)1);  /* main-loop serial pushes */
+    pthread_create(&p2, NULL, producer, (void *)2);  /* PJSUA call-state pushes */
+    pthread_create(&c1, NULL, consumer, NULL);        /* main-loop consumer      */
+    pthread_join(p1, NULL);
+    pthread_join(p2, NULL);
+    pthread_join(c1, NULL);
+    printf("done\n");
+    return 0;
+}


### PR DESCRIPTION
## The bug
Playtesting the game under load, the daemon **SIGABRT'd** (heap corruption) and systemd restarted it. Three threads hit the core with **no synchronization**:
- **main loop** — serial read → `event_queue_push`, `pop`, dispatch, display writes;
- **web worker threads** — `send_control_command` dispatches keypad/coin/hook events *directly*, running plugin handlers + serial display writes;
- **PJSUA worker threads** — the SIP call-state callback pushes onto the event queue.

The event queue is a `malloc`'d linked list spliced with **no lock**, and plugin dispatch + the serial fd were written from two threads at once → list/heap corruption → abort. AddressSanitizer over the simulator was **clean**, which (correctly) pointed away from the plugins and at the hardware/threading layer the simulator stubs.

## The fix
- `millennium_sdk.c`: a mutex around `event_queue_push/pop/empty` so the main-loop and PJSUA producers/consumer can't corrupt the list.
- `daemon.c`: an `engine_mutex` serializing one whole main-loop engine step (serial read + dispatch + plugin ticks + display) against `send_control_command` (same paths, web thread). Held only around the work, never across the idle sleep. Lock order is always `engine_mutex → daemon_state_mutex / plugins_mutex / queue mutex` (no inversion).

## Verification (you asked for ThreadSanitizer)
- **`make tsan-queue`** (`tests/tsan_event_queue.c`, queue code mirrored from `millennium_sdk.c`): the `-DNO_LOCK` build → **ThreadSanitizer data races** on the queue; the locked build → **clean**. (TSan is unsupported on the 32-bit Pi, so this runs on the dev box.)
- **On the Pi:** built clean under GCC 10; **~40 s of heavy concurrent control traffic → NRestarts=0, no ABRT, daemon responsive.**
- `make test`: 118 unit + all scenarios green.

## Also (2nd commit)
A small playtest UX fix: a stale half-typed year/number now auto-clears after 6 s idle, so a hesitant caller's stray digits can't corrupt the next dial (+ scenario test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)