### PR TITLE
Add SPIN model-check of the Pi<->Arduino wire protocol

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -276,4 +276,17 @@ cbmc-parser:
 	  --bounds-check --pointer-check --pointer-overflow-check --conversion-check \
 	  --memory-leak-check --unwind 37 --unwinding-assertions
 
-.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke regen-clips tsan-queue cbmc-parser pjsip-smoke
+# SPIN model-check of the Pi<->Arduino display-command wire protocol
+# (tests/protocol.pml, mirrors display.ino's framing). Proves overrun-freedom,
+# deadlock-freedom, and full-consumption (self-resync). Needs spin; not in `make test`.
+SPIN ?= spin
+model-check:
+	@tmp=$$(mktemp -d); \
+	 grep -v '^ltl ' tests/protocol.pml > $$tmp/safety.pml; cp tests/protocol.pml $$tmp/live.pml; \
+	 echo "== safety: overrun-freedom + deadlock-freedom =="; \
+	 ( cd $$tmp && $(SPIN) -run -safety -m200000 safety.pml ) | grep -iE "assertion viol|invalid end|errors:"; \
+	 echo "== liveness: full-consumption []<> at_idle =="; \
+	 ( cd $$tmp && $(SPIN) -run -ltl progress -m200000 live.pml ) | grep -iE "acceptance|never claim|errors:"; \
+	 rm -rf $$tmp
+
+.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke regen-clips tsan-queue cbmc-parser model-check pjsip-smoke

--- a/host/tests/protocol.pml
+++ b/host/tests/protocol.pml
@@ -1,0 +1,96 @@
+/*
+ * SPIN model of the Pi <-> Arduino (Beta) display-command wire protocol.
+ *
+ * Mirrors the framing in Arduino/sketches/display/display.ino loop():
+ *   STX (0x02), one length byte, bounds-check (num_bytes > sizeof(buf) -> bail),
+ *   then num_bytes data bytes copied into buf[BUFSZ].
+ * waitForSerial()'s 2-second timeout (which makes the receiver bail and resync
+ * instead of blocking) is modeled as a nondeterministic bail. The Pi opens the
+ * serial fd O_NONBLOCK, so it can't block forever either.
+ *
+ * BUFSZ and the length range are scaled down; the bounds-check comparison
+ * (strict '>' against the buffer size, allowing len == BUFSZ) is modeled exactly
+ * as in the firmware, so the off-by-one is what gets verified — the constant's
+ * magnitude doesn't change that logic.
+ *
+ * Properties checked (make model-check):
+ *   - overrun-freedom : assert(i < BUFSZ) on every buffer write (safety)
+ *   - deadlock-freedom: no invalid end states (SPIN default safety check)
+ *   - full-consumption: ltl progress { []<> at_idle } -- the receiver always
+ *     returns to idle, i.e. it can never get permanently stuck mid-frame
+ *     (any desync/partial/garbage frame self-resyncs).
+ */
+
+#define BUFSZ 4
+#define STX   2
+#define DAT   1     /* any non-STX data/noise byte */
+
+chan link = [2] of { byte };   /* Pi -> Arduino serial bytes */
+
+bool at_idle = true;
+byte widx;                     /* last buffer write index (for inspection) */
+
+active proctype Arduino() {
+    byte data, num_bytes, i;
+idle:
+    at_idle = true;
+    if
+    :: link ? data ->
+        at_idle = false;
+        if
+        :: data == STX ->
+            if
+            :: link ? num_bytes ->                 /* got the length byte */
+                if
+                :: num_bytes > BUFSZ -> goto idle  /* bounds check: reject + bail */
+                :: else ->
+                    i = 0;
+                    do
+                    :: i < num_bytes ->
+                        if
+                        :: link ? _ ->
+                            assert(i < BUFSZ);      /* OVERRUN-FREEDOM */
+                            widx = i;
+                            i++
+                        :: skip -> goto idle        /* waitForSerial timeout -> resync */
+                        fi
+                    :: else -> break
+                    od;
+                    goto idle                       /* frame delivered */
+                fi
+            :: skip -> goto idle                    /* timeout waiting for length */
+            fi
+        :: else -> goto idle                        /* other command handled */
+        fi
+    :: skip -> goto idle                            /* nothing on the line yet */
+    fi;
+    goto idle
+}
+
+active proctype Pi() {
+    byte n, k;
+    do
+    :: /* a possibly-malformed display frame: STX, an arbitrary length, then
+        * 0..n data bytes (under-sending models an aborted/desynced frame). */
+        link ! STX;
+        if
+        :: n = 0
+        :: n = 1
+        :: n = 2
+        :: n = 3
+        :: n = 4
+        :: n = 5    /* > BUFSZ: must be rejected by the bounds check */
+        :: n = 6
+        fi;
+        link ! n;
+        k = 0;
+        do
+        :: k < n -> link ! DAT; k++
+        :: k < n -> break          /* abort mid-frame */
+        :: else  -> break
+        od
+    :: link ! DAT                  /* stray noise byte (no STX) */
+    od
+}
+
+ltl progress { [] <> at_idle }


### PR DESCRIPTION
The 4th formal-verification target: the **display-command framing protocol** (Pi → Beta), mirroring `display.ino`'s `loop()` — `STX(0x02)`, a length byte, bounds-check (`num_bytes > sizeof(buf)` → bail), then `num_bytes` data bytes into `buf[BUFSZ]`. `waitForSerial()`'s 2 s timeout (which makes the receiver bail and resync) is modeled as a nondeterministic bail; the Pi opens the fd `O_NONBLOCK`, so neither side blocks forever.

`tests/protocol.pml` + **`make model-check`** verify, exhaustively (`errors: 0`):
- **Overrun-freedom** — `assert(i < BUFSZ)` on every buffer write holds for *any* length byte (including `> BUFSZ`) and any garbage/partial frame. The firmware's strict-`>` check (which correctly allows `len == BUFSZ`) is modeled exactly, so the **off-by-one is what's verified**.
- **Deadlock-freedom** — no invalid end states.
- **Full-consumption** — `ltl progress { []<> at_idle }`: the receiver always returns to idle, i.e. can never get permanently stuck mid-frame (any desync self-resyncs). Holds **even with fairness disabled**.

`BUFSZ` and the length range are scaled down; the bounds-check logic is structurally identical to the real `buf[100]` (standard small-model abstraction, noted in the file).

This completes the verification pass you scoped: cppcheck (static) → data-race fix verified with **ThreadSanitizer** (#207) → **CBMC** parser memory-safety proof (#208) → **SPIN** protocol model-check (here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)