### PR TITLE
keypad firmware: fully initialize MagstripeData (fix uninitialized members)

### DIFF
--- a/Arduino/sketches/keypad/keypad.ino
+++ b/Arduino/sketches/keypad/keypad.ino
@@ -73,9 +73,19 @@ struct MagstripeData {
  */
 struct MagstripeData parseTrack2(char *rawData, int length) {
   MagstripeData result;
+  /* Initialize every field so all return paths yield a fully-defined struct.
+   * The discretionary fields below are only filled in when a long-enough
+   * discretionary section is present; without these defaults the early returns
+   * (and the short-data case) would return uninitialized pointers. */
   result.valid = false;
   result.pan = NULL;
   result.pan_len = 0;
+  result.expirationDate = NULL;
+  result.expiration_date_len = 0;
+  result.serviceCode = NULL;
+  result.service_code_len = 0;
+  result.otherData = NULL;
+  result.other_data_len = 0;
 
   int startSentinelIndex = -1;
   for (int i = 0; i < length; i++) {


### PR DESCRIPTION
`parseTrack2()` only set the discretionary fields (`expirationDate`, `serviceCode`, `otherData` + lengths) inside the `discretionaryLen >= 7` branch, so the early returns and the short-data case returned a struct with **uninitialized pointer members** — undefined behavior, flagged by cppcheck (`uninitvar` / `uninitStructMember`) in the static-analysis pass.

The caller only reads `pan` (gated on `valid`), so it was **latent**, but it's a real defect. This initializes all fields up front (`NULL` / `0`) so every return path yields a fully-defined struct. No behavior change for the live path.

cppcheck is now clean on `keypad.ino`. (The full AVR compile happens at flash time via `deploy-arduino`; CI here is host-only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)