### PR TITLE
Model-check The Operator game for soft-locks (SPIN)

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -297,4 +297,18 @@ model-check:
 	 ( cd $$tmp && $(SPIN) -run -ltl progress -m200000 live.pml ) | grep -iE "acceptance|never claim|errors:"; \
 	 rm -rf $$tmp
 
-.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke regen-clips tsan-queue cbmc-parser cbmc-parsers model-check pjsip-smoke
+# SPIN model-check of The Operator game (tests/operator_game.pml, mirrors
+# plugins/time_operator.c). Proves no dead-ends, bounded pieces, and no soft-lock
+# (WIN reachable from every state, AG EF win). Needs spin; not in `make test`.
+game-check:
+	@tmp=$$(mktemp -d); \
+	 grep -v '^ltl ' tests/operator_game.pml > $$tmp/safety.pml; cp tests/operator_game.pml $$tmp/g.pml; \
+	 echo "== no dead-ends =="; \
+	 ( cd $$tmp && $(SPIN) -run -safety -m300000 safety.pml ) | grep -iE "invalid end|errors:"; \
+	 echo "== bounded pieces ([] pieces<=3) =="; \
+	 ( cd $$tmp && $(SPIN) -run -ltl pieces_ok -m300000 g.pml ) | grep -iE "errors:"; \
+	 echo "== no soft-lock (AG EF win) =="; \
+	 ( cd $$tmp && $(SPIN) -run -ltl can_win -f -m1000000 g.pml ) | grep -iE "acceptance|errors:"; \
+	 rm -rf $$tmp
+
+.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke regen-clips tsan-queue cbmc-parser cbmc-parsers model-check game-check pjsip-smoke

--- a/host/tests/operator_game.pml
+++ b/host/tests/operator_game.pml
@@ -1,0 +1,81 @@
+/*
+ * SPIN model of "The Operator: The Last Call" game state machine
+ * (plugins/time_operator.c). The three number-pieces are abstracted to a counter
+ * and the tick-driven beats (travel/reveal/flavor/final) to immediate steps;
+ * the branching player choices are nondeterministic.
+ *
+ * Properties (make game-check):
+ *   - no dead-ends   : no invalid end states (every state but DORMANT, the
+ *                      on-hook idle, always has a move).
+ *   - bounded pieces : ltl pieces_ok { [] (pieces <= 3) }.
+ *   - no soft-lock   : ltl can_win { <> everWon } under weak fairness. The player
+ *     acts arbitrarily until a separate one-shot process (committer) sets
+ *     `committed` — weak fairness guarantees that process eventually runs (it's a
+ *     continuously-enabled process; SPIN fairness is process-level). Once
+ *     committed, only progress moves are enabled, so the game marches to WIN.
+ *     Thus can_win holds iff WIN is reachable from EVERY reachable state (the
+ *     commit can land anywhere) — i.e. AG EF win, no trap/soft-lock.
+ */
+
+#define DORMANT 0
+#define HUB     1
+#define KEYERA  2
+#define REVEAL  3
+#define FLAVOR  4
+#define READY   5
+#define FINAL   6
+#define WIN     7
+
+byte st = DORMANT;
+byte pieces = 0;
+bool pass = false;       /* temporal pass (card) or coin-forced sealed era */
+bool everWon = false;
+bool committed = false;  /* has the player committed to cooperative play? */
+
+/* One-shot: weak fairness guarantees this continuously-enabled process runs, so
+ * `committed` becomes true at some (nondeterministic) point in any run. */
+active proctype committer() { committed = true }
+
+active proctype game() {
+end_dormant:
+    do
+    :: st == DORMANT ->
+        if :: committed -> skip :: else -> if :: pieces = 0; pass = false :: skip fi fi;
+        if :: (pieces == 3) -> st = READY :: else -> st = HUB fi
+    :: st == HUB ->
+        if
+        :: st = KEYERA                  /* dial the current target key year */
+        :: !committed -> st = FLAVOR    /* wrong / flavor year */
+        :: !committed -> st = DORMANT   /* hang up */
+        fi
+    :: st == FLAVOR -> st = HUB
+    :: st == KEYERA ->
+        if
+        :: (pieces == 2 && !pass) ->
+            if :: pass = true :: !committed -> st = HUB fi   /* open it, or give up */
+        :: else -> skip
+        fi;
+        if
+        :: (st == KEYERA) ->
+            if
+            :: pieces = pieces + 1; st = REVEAL   /* LISTEN -> piece */
+            :: !committed -> st = KEYERA          /* SPEAK -> tangle (recoverable) */
+            :: !committed -> st = HUB             /* # / drift back */
+            fi
+        :: else -> skip
+        fi
+    :: st == REVEAL ->
+        if :: (pieces == 3) -> st = READY :: else -> st = HUB fi
+    :: st == READY ->
+        if
+        :: st = FINAL                   /* dial the full number correctly */
+        :: !committed -> st = READY     /* wrong number, retry */
+        :: !committed -> st = DORMANT   /* hang up */
+        fi
+    :: st == FINAL -> st = WIN; everWon = true
+    :: st == WIN -> st = DORMANT; pieces = 0; pass = false   /* hang up resets */
+    od
+}
+
+ltl pieces_ok { [] (pieces <= 3) }
+ltl can_win   { <> everWon }


### PR DESCRIPTION
`tests/operator_game.pml` models the plugin's state machine (`DORMANT/HUB/KEYERA/REVEAL/FLAVOR/READY/FINAL/WIN`), abstracting the 3 number-pieces to a counter and the tick beats to immediate steps. **`make game-check`** proves:

- **no dead-ends** — no invalid end states (every state but `DORMANT`, the on-hook idle, always has a move).
- **bounded pieces** — `[] (pieces <= 3)`.
- **no soft-lock** — WIN is reachable from **every** reachable state (AG EF win). Encoded via a one-shot `committer` process that weak fairness must eventually run (SPIN fairness is *process*-level, so a separate process is required, not an in-loop branch); once committed the player makes only progress moves, so `<> everWon` holds iff no reachable state is a trap.

All three: **errors: 0**. So a player who keeps trying can always finish the call from any state — meddling/tangle, wrong years, the sealed era (card *or* coin), drift, and hang-ups all recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)