### PR TITLE
operator: harder puzzle + playtest polish

### DIFF
--- a/host/OPERATOR_PLAYTEST.md
+++ b/host/OPERATOR_PLAYTEST.md
@@ -19,30 +19,37 @@ states the goal and the next step; the VFD shows `PIECES n/3` and the current hi
    ```
 2. Software pre-flight: `make operator-smoke OP_HOST=<pi>` (add `RUN_DRIFT=1` for the slow leg).
 3. Number/years (current tuning): pieces **36 / 41 / 55** → dial **364155** to win.
-   Key years: **1955** (A), **1978** (B), **1998** (C, sealed). Re-activating resets the session.
+   Target years: **1955** (A, ±2), **1978** (B, **exact**), **1998** (C ±2, sealed).
+   The hub no longer names the decade — clues are cryptic and a wrong year answers
+   `TOO EARLY`/`TOO LATE`/`WARMER`. The finale **hides** the number (`6 DIGITS`);
+   a coin at `READY` reveals it. Re-activating resets the session.
 
 Clips live in `/usr/local/share/millennium/audio/`; a missing one is a silent no-op.
 
 ## Checklist  (V = VFD, A = audio, H = hardware path)
 
 - [ ] **Greeting / hook switch.** Lift the handset.
-      V: `FIND THE 1950s` / `DIAL A YEAR  0/3`  ·  A: `op_intro` (states the mission)
+      V: `TWO GIRLS, A RADIO` / `DIAL A YEAR  0/3`  ·  A: `op_intro` (states the mission)
       ·  H: lifting really transitions to IDLE_UP (no API nudge).
+- [ ] **Homing feedback.** Dial `1 9 5 0`. V: `WARMER` / `A LITTLE LATER`. Dial `1 9 5 8`:
+      `WARMER` / `A LITTLE EARLIER`. Dial `1 9 2 5`: `TOO EARLY`. (Deduce, then land it.)
 - [ ] **Piece A.** Dial `1 9 5 5`. V: connecting → `1955 TWO SISTERS` / `1=LISTEN 2=SPEAK`.
       Press `1`. V: `PIECE A: 36` / `PIECES 1/3` · A: `era1_arrive`, then `era1_listen`.
-- [ ] **Listen, don't speak.** In a key era press `2`. V: `LINE TANGLED` · A: `px_tangle`.
-      Press `1` to recover the piece.
-- [ ] **Wrong year nudge.** Dial `1 9 2 5`. V: `TOO EARLY`, then back to the Operator.
-- [ ] **Piece B.** Dial `1 9 7 8` → `1=LISTEN` → `1` → `PIECE B: 41` / `2/3`.
+- [ ] **Listen, don't speak (+ retire).** In a key era press `2`. V: `LINE TANGLED` · A: `px_tangle`.
+      Press `1` to recover the piece. Thereafter the prompt reads `press 1=LISTEN` (SPEAK retired).
+- [ ] **Piece B — the exact year.** Dial `1 9 7 7` → `WARMER`/`A LITTLE LATER`; only
+      `1 9 7 8` opens the era → `1=LISTEN` → `1` → `PIECE B: 41` / `2/3`.
 - [ ] **Sealed final year.** Dial `1 9 9 8`. V: `1998: SEALED` / `SWIPE PASS / COIN`.
 - [ ] **Temporal pass (magstripe).** Swipe any card.
       V: `1998 A CARD` / `1=LISTEN 2=SPEAK`  ·  H: the reader fires `handle_card`.
       Press `1` → `PIECE C: 55` / `3/3`.  (A real coin also forces it open — try both.)
-- [ ] **Coin validator — hints & time.** At the Operator, drop a coin → blunter hint
-      (`DIAL 1955` …) · A: `op_hint_*`. In an era, a coin → A: `coin_hold` (holds the line).
-      ·  H: the validator registers the coin.
-- [ ] **The last call.** With `3/3`: V: `DIAL HER NUMBER` / `36 41 55`. Dial `3 6 4 1 5 5`.
-      V: `...RINGING...` → `11:59 ... 12:00` → `12:00  2000` / `SHE IS FREE`
+- [ ] **Coin validator — hints & time.** At the Operator, drop a coin → sharper hint
+      naming the decade (`TRY THE 1950s` …) · A: `op_hint_*`. In an era, a coin → A:
+      `coin_hold` (holds the line). ·  H: the validator registers the coin.
+- [ ] **The last call.** With `3/3`: V: `DIAL HER NUMBER` / `6 DIGITS` (number hidden —
+      a coin here reveals `36 41 55`). Dial `3 6 4 1 5 5`.
+      V: `...RINGING...` → `11:59 ... 12:00` → `12:00  2000` / `SHE IS FREE`,
+      then after a beat the coda `THE LINE IS QUIET` / `hang up: she's home`
       ·  A: `final_connect` → `final_clock` → `win_free`.
 - [ ] **Temporal drift.** In an era, touch nothing ~30 s. V: pulled back to the Operator
       (`DIAL A YEAR`) · A: `drift_back`. (A coin in the era buys ~30 s more first.)

--- a/host/OPERATOR_STORY.md
+++ b/host/OPERATOR_STORY.md
@@ -16,8 +16,18 @@ climax is literally placing the call.
 
 ## Agreed choices
 - **Core:** goal-driven quest (find 3 number-pieces → place the call → time resumes).
-- **Coins (never gate winning):** at the Operator a coin buys a **sharper hint**;
-  in an era a coin buys **more line time** before drift (and **forces** the sealed era).
+- **Finding a year is a homing search, not a decade lookup.** The hub gives a
+  **cryptic** clue (no decade named). A wrong-but-valid year answers with
+  direction — `TOO EARLY` / `TOO LATE`, and `WARMER` (+ *a little earlier/later*)
+  once within `WARM_BAND` years. You deduce the year from the clue + this feedback.
+- **One real inference:** pieces A and C accept a small window (±2 yrs of 1955 / 1998);
+  the middle piece **B demands the exact year (1978)** — the one genuine deduction.
+- **The finale hides the answer:** `READY` shows `6 DIGITS`, a wrong attempt says
+  `TRY AGAIN`. You assemble the three pieces you collected from memory.
+- **Coins (never gate winning), the escape hatches:** at the hub a coin buys a
+  **sharper hint** (names the decade); in an era a coin buys **more line time**
+  before drift (and **forces** the sealed era); at `READY` a coin **reveals the
+  assembled number**.
 - **Reset:** on hang-up, with a ~30 s **grace** (re-lift resumes; later, or after a
   win, starts fresh). All state is in-memory for the session.
 - **Tone & length:** warm & bittersweet, ~3–5 minutes.
@@ -25,11 +35,14 @@ climax is literally placing the call.
 ## Legibility rules
 - The Operator's **voice** states the goal and the next step; every line is echoed
   as VFD text so it works without audio.
-- The **VFD HUD**: line 1 = current hint, line 2 = `… n/3`. Every line ≤ 20 chars
-  (no scroll), so it's stable and readable.
-- You can't hard-fail; every mistake is recoverable and the next action is clear.
+- The **VFD HUD**: line 1 = current **cryptic** clue, line 2 = `… n/3`. Every line
+  ≤ 20 chars (no scroll), so it's stable and readable.
+- You can't hard-fail; every mistake is recoverable and the next action is clear —
+  the directional/warm feedback always points you nearer.
 - **Listen, don't speak:** in a key era `1=LISTEN` gives the piece; `2=SPEAK`
   tangles the line — recover by pressing `1`. Self-teaching, local, no penalty.
+  After you've spoken once the `2=SPEAK` prompt is **retired** (it reads
+  `press 1=LISTEN`) so it doesn't keep advertising a dead end.
 
 ## Hardware → meaning
 | Input | Role |
@@ -37,7 +50,7 @@ climax is literally placing the call.
 | Lift handset | Connect to the Operator (mission / resume / next hint) |
 | Dial 4-digit **year** | Travel to that era |
 | **1 / 2** in a key era | `1=LISTEN` (get piece) vs `2=SPEAK` (tangle) |
-| **Coin** | Hub: sharper hint · Era: hold the line / force the sealed era |
+| **Coin** | Hub: sharper hint (names decade) · Era: hold the line / force the sealed era · Ready: reveal the number |
 | **Card** swipe | "Trunk-line pass" → opens the sealed era |
 | Idle (**drift**) | Pulled back to the Operator (nothing lost) |
 | **#** | Repeat the hint / back to the Operator |
@@ -45,38 +58,46 @@ climax is literally placing the call.
 
 ## The number & the eras
 Ruth's number is **36‑41‑55** (→ dial `364155`), in fixed positions A‑B‑C; find
-pieces in any order. Year roles (see `operator_year_role`):
+pieces in any order. Each piece has a **target year** and an **arrival window**
+(`op_target_year` / `op_in_window`):
 
-| Years | Role | Holds |
+| Year(s) | Role | Holds |
 |---|---|---|
-| 1950–1959 | **KEY A** | piece **36** — two girls, a kitchen radio |
-| 1970–1989 | **KEY B** | piece **41** — the night she lost her nerve |
-| 1995–1999 | **KEY C** (sealed) | piece **55** — a Christmas card; needs pass/coin |
-| < 1950 | flavor `early` | "too early — she wasn't born" |
-| 2000 | flavor `home` | "the frozen minute; only silence" |
+| 1955 ±2 (1953–1957) | **KEY A** | piece **36** — two girls, a kitchen radio |
+| **1978 exact** | **KEY B** | piece **41** — the night she lost her nerve (the inference) |
+| 1998 ±2 (1996–2000\*) | **KEY C** (sealed) | piece **55** — a Christmas card; needs pass/coin |
+| 2000 | flavor `home` | "the frozen minute; only silence" (\*checked before C) |
 | ≥ 2050 | flavor `future` | "the future is sealed" |
-| other in range | flavor `other` | "not one of the years she held it" |
+| any other 1900–2100 | **nudge** | `TOO EARLY`/`TOO LATE`, or `WARMER` within `WARM_BAND` (6 yrs) of the current target |
 | outside 1900–2100 | `bad` | "no such year" (refused at the hub) |
+| an already-found era | flavor `heard` | "already heard" |
+
+`operator_year_role` (the unit-tested classifier) still reports the historical
+decade roles (A/B/C/early/home/future/other) for reference; **arrival** is decided
+by `op_in_window` (the narrow windows above), not by that classifier.
 
 ## States (`plugins/time_operator.c`)
 `DORMANT → HUB → TRAVEL → {FLAVOR | KEY} → REVEAL → … → READY → FINAL → WIN`
-plus `KEY` sub-flags `locked` (sealed) and `tangled` (spoke). Timers:
-`TRAVEL_SECS 2`, `REVEAL_SECS 3`, `FLAVOR_SECS 3`, `DRIFT_SECS 30`,
-`EXTEND_SECS 30`, `GRACE_SECS 30`, final beats `3` then `4`.
+plus `KEY` sub-flags `locked` (sealed) and `tangled` (spoke), and session flag
+`spoke_once` (retires the SPEAK prompt). Timers: `TRAVEL_SECS 2`, `REVEAL_SECS 3`,
+`FLAVOR_SECS 3`, `DRIFT_SECS 30`, `EXTEND_SECS 30`, `GRACE_SECS 30`, final beats
+`3` then `4`, then `WIN_HOLD_SECS 6` before the quiet coda. Tuning knob:
+`WARM_BAND 6`.
 
 ## Decision tree
 ```
 DORMANT ──lift──▶ [won OR idle>grace?] ─ yes ▶ reset + op_intro ▶ HUB
                                          └ no ▶ op_resume ───────▶ HUB
-HUB (hint for lowest unfound piece; n/3)
-  ├─ dial flavor year ─▶ FLAVOR ─(timeout/#)─▶ HUB
-  ├─ dial key year (unfound) ─▶ TRAVEL ─▶ KEY
+HUB (cryptic clue for lowest unfound piece; n/3)
+  ├─ dial year off-target ─▶ FLAVOR nudge (TOO EARLY/LATE/WARMER) ─(timeout/#)─▶ HUB
+  ├─ dial year in a piece window (unfound) ─▶ TRAVEL ─▶ KEY
   │        ├─ 1 LISTEN ─▶ REVEAL (piece++) ─(timeout/#)─▶ HUB
-  │        └─ 2 SPEAK  ─▶ tangled ──1 LISTEN──▶ REVEAL
-  ├─ dial key year (already found) ─▶ FLAVOR "already heard" ─▶ HUB
-  ├─ dial 1998 (sealed, unfound) ─▶ KEY locked ──card|coin──▶ KEY ─▶ …
-  ├─ coin ─▶ sharper hint     │   # ─▶ repeat hint
-  └─ 3/3 ─▶ READY ──dial 364155──▶ FINAL ─▶ WIN ─▶ (hang up) reset
+  │        └─ 2 SPEAK  ─▶ tangled (SPEAK retired) ──1 LISTEN──▶ REVEAL
+  ├─ dial a window already found ─▶ FLAVOR "already heard" ─▶ HUB
+  ├─ dial 1998-window (sealed, unfound) ─▶ KEY locked ──card|coin──▶ KEY ─▶ …
+  ├─ coin ─▶ sharper hint (decade)   │   # ─▶ repeat hint
+  └─ 3/3 ─▶ READY (6 DIGITS) ──dial 364155──▶ FINAL ─▶ WIN ─(hold)─▶ quiet coda ─▶ (hang up) reset
+                              └─ wrong ─▶ TRY AGAIN   coin ─▶ reveal number
 KEY ── idle ──▶ drift_back ─▶ HUB        ── coin ──▶ hold the line (timer +)
 ANY ── hang up ──▶ DORMANT (30 s grace; a WIN forces a fresh next session)
 ```
@@ -91,6 +112,7 @@ Groups: `op_*` (hub), `era{1,2,3}_{arrive,listen}` + `era3_sealed`, `flv_*`,
 ## Tests
 - Unit (`tests/unit_tests.c`): `parse_year`, `operator_year_role`,
   `operator_target_piece`, plus the display-line-budget guardrail.
-- Scenario (`tests/test_operator_*.scenario`): intro, find-piece, flavor, tangle,
-  sealed, full win, drift, grace, coin-hint.
+- Scenario (`tests/test_operator_*.scenario`): intro, find-piece, flavor, tangle
+  (+ SPEAK retire), homing (directional/warm + exact-year B), sealed, full win
+  (hidden number, coin-reveal, win coda), drift, grace, coin-hint.
 - Live: `make operator-smoke` (web API) + `OPERATOR_PLAYTEST.md` (hands-on).

--- a/host/audio/clips.manifest
+++ b/host/audio/clips.manifest
@@ -17,15 +17,15 @@
 # Spell out numbers and years so they are read aloud the way you want.
 
 # -- Operator hub: mission, guidance, hints --
-op_intro   Operator. I have held one last call since the clock stopped, eleven fifty-nine on New Year's Eve, nineteen ninety-nine. A woman calling her sister Ruth to make peace, frozen mid-ring. Help me finish it, and time moves again. Her number is lost across the years she held it. Start where she first dialed it: two girls and a kitchen radio, the chrome-and-radio fifties. Dial a year. A coin buys a hint; press pound to hear me again.
+op_intro   Operator. I have held one last call since the clock stopped, eleven fifty-nine on New Year's Eve, nineteen ninety-nine. A woman calling her sister Ruth to make peace, frozen mid-ring. Help me finish it, and time moves again. Her number is lost across the years she held it. Start where she first dialed it: two girls and a kitchen radio. Listen for when. Dial a year, and I will tell you if you are too early, too late, or warm. A coin buys a sharper hint; press pound to hear me again.
 op_resume  Still on the line. Good. We were finding her number. Keep going.
-op_next_a  Start where she first dialed it, the chrome-and-radio fifties.
-op_next_b  Now the night she lost her nerve, the receiver warm in her hand, the long-wire seventies.
-op_next_c  The last piece is sealed away, the final analog year, ninety-eight. You will need a pass, or force the coinbox.
-op_ready   That is all of it. Three, six, four, one, five, five. The whole number, after all these years. Dial it now, and finish her call.
-op_hint_a  Try nineteen fifty-five.
-op_hint_b  Try nineteen seventy-eight.
-op_hint_c  Try nineteen ninety-eight, and bring a pass.
+op_next_a  Start where she first dialed it. Two girls and a kitchen radio.
+op_next_b  Now the night she lost her nerve, the receiver warm in her hand. Find the exact year.
+op_next_c  The last piece is sealed away, her final attempt. You will need a pass, or force the coinbox.
+op_ready   That is all three pieces. Put them in the order you found them, and dial her number. Finish her call.
+op_hint_a  A sharper hint: the nineteen fifties.
+op_hint_b  A sharper hint: the nineteen seventies. But you must dial the exact year.
+op_hint_c  A sharper hint: the nineteen nineties. And bring a pass.
 
 # -- Key eras: arrival scenes and the number-pieces --
 era1_arrive  Connecting. Nineteen fifty-five. A kitchen radio, two sisters, a number inked on a small palm. Listen, do not speak.
@@ -36,11 +36,12 @@ era3_sealed  This line is sealed, a trunk line. Swipe a pass, or feed the coinbo
 era3_arrive  Connecting. December, nineteen ninety-eight. A Christmas card, Ruth's new number folded inside. The last of it. Listen.
 era3_listen  Five, five. That is the end of it. The whole number, at last.
 
-# -- Flavor eras --
-flv_early   Too early. She was not even born yet. Come back, and I will point you right.
+# -- Flavor eras + the homing nudges (too early / too late / warm) --
+flv_early   Too early. Come back, and I will point you nearer.
+flv_late    Too late. That is past her moment. Come back, and I will point you nearer.
+flv_warm    Warm. You are close now, just a little off. Try once more.
 flv_2000    The year two thousand, the frozen minute. Only silence here, and me, waiting.
 flv_future  The future is sealed. There is nothing there for you yet.
-flv_other   Not here. This is not one of the years she held the number. Come back to me.
 flv_heard   You have already heard everything this line can tell you.
 
 # -- Hazards --

--- a/host/plugin_sdk.c
+++ b/host/plugin_sdk.c
@@ -110,6 +110,10 @@ const char *sdk_keypad(void) {
     return daemon_state ? daemon_state->keypad_buffer : "";
 }
 
+void sdk_clear_keypad(void) {
+    if (daemon_state) daemon_state_clear_keypad(daemon_state);
+}
+
 /* ── Coin balance ────────────────────────────────────────────────────── */
 
 int sdk_balance(void) {

--- a/host/plugin_sdk.h
+++ b/host/plugin_sdk.h
@@ -106,6 +106,10 @@ int sdk_receiver_is_up(void);
 /* The digits the user has typed (daemon-level buffer). Never NULL. */
 const char *sdk_keypad(void);
 
+/* Clear the daemon's shared dial buffer. Apps that keep their own per-field
+ * entry call this so /api/state's keypad buffer doesn't accumulate every key. */
+void sdk_clear_keypad(void);
+
 /* ── Coin balance ────────────────────────────────────────────────────────
  * The daemon tracks a shared inserted-cents balance. These helpers read and
  * adjust it while keeping the daemon's view in sync (so the dashboard, coin

--- a/host/plugins/time_operator.c
+++ b/host/plugins/time_operator.c
@@ -45,6 +45,8 @@
 #define FINAL_CONNECT_SECS 3
 #define FINAL_CLOCK_SECS   4
 #define ENTRY_TIMEOUT_SECS 6   /* clear a half-typed year/number after this idle */
+#define WARM_BAND          6   /* within this many years of a target reads "warmer" */
+#define WIN_HOLD_SECS      6   /* hold the win before settling to the quiet coda    */
 
 /* Ruth's number, in three positional pieces A-B-C (tunable). */
 #define PIECE_A "36"
@@ -89,6 +91,7 @@ typedef struct {
     int    cur_key;       /* key index while TS_KEY (0/1/2), else -1 */
     int    locked;        /* current key era sealed, awaiting access */
     int    tangled;       /* current key era tangled (spoke)         */
+    int    spoke_once;    /* tried SPEAK once; stop advertising it    */
     int    final_step;
     time_t timer_at;      /* transient-state timer                   */
     time_t last_input_at; /* drift timer base in TS_KEY              */
@@ -142,7 +145,20 @@ int operator_target_piece(int pieces) {
     return 3;
 }
 
+/* The canonical year for each piece, and how close a dial must land to "arrive".
+ * Piece B (the middle scene) demands the exact year -- the one real inference;
+ * A and C accept a small window, so the clue plus warmer/colder feedback is
+ * enough to home in. */
+static int op_target_year(int idx) {
+    return (idx == 0) ? 1955 : (idx == 1) ? 1978 : 1998;
+}
+static int op_in_window(int idx, int year) {
+    int ty = op_target_year(idx);
+    if (idx == 1) return year == ty;                 /* exact: the night she faltered */
+    return year >= ty - 2 && year <= ty + 2;
+}
 static int op_have(int idx) { return (op.pieces & (1 << idx)) != 0; }
+
 static int op_count(void) {
     return ((op.pieces & 1) ? 1 : 0) + ((op.pieces & 2) ? 1 : 0) +
            ((op.pieces & 4) ? 1 : 0);
@@ -157,8 +173,8 @@ static void op_render_dormant(void) {
 static void op_render_hub(void) {
     char l2[24];
     int t = operator_target_piece(op.pieces);
-    const char *l1 = (t == 0) ? "FIND THE 1950s" :
-                     (t == 1) ? "FIND THE 1970s" : "FIND 1998 SEALED";
+    const char *l1 = (t == 0) ? "TWO GIRLS, A RADIO" :
+                     (t == 1) ? "NIGHT SHE FALTERED" : "HER LAST ATTEMPT";
     if (op.len > 0) {
         char l2b[24];
         snprintf(l2b, sizeof(l2b), "YEAR: %s_", op.buf);
@@ -176,7 +192,7 @@ static void op_render_ready(void) {
         sdk_display("DIALING...", l2);
         return;
     }
-    sdk_display("DIAL HER NUMBER", PIECE_A " " PIECE_B " " PIECE_C);
+    sdk_display("DIAL HER NUMBER", "6 DIGITS");
 }
 
 /* ── State transitions (each stops any continuous tone first) ────────── */
@@ -227,6 +243,7 @@ static void op_reset_session(void) {
     op.pass = 0;
     op.won = 0;
     op.tangled = 0;
+    op.spoke_once = 0;
     op.locked = 0;
     op.cur_key = -1;
     op.buf[0] = '\0';
@@ -244,12 +261,28 @@ static void op_enter_travel(int year) {
     sdk_display("CONNECTING...", l2);
 }
 
-static void op_enter_flavor(const char *clip, const char *label) {
+static void op_enter_flavor(const char *clip, const char *l1, const char *l2) {
     sdk_stop_audio();
     op.state = TS_FLAVOR;
     op.timer_at = sdk_now();
-    sdk_display(label, "BACK TO OPERATOR");
+    sdk_display(l1, l2);
     sdk_play_clip(clip);
+}
+
+/* A wrong-but-valid year nudges the caller toward the current target's year:
+ * directional far out, "warmer" once within WARM_BAND. This turns finding a year
+ * into a homing search instead of a decade lookup. */
+static void op_nudge(int dialed, int target_year) {
+    int diff = dialed - target_year;
+    int ad = (diff < 0) ? -diff : diff;
+    if (ad <= WARM_BAND) {
+        op_enter_flavor("flv_warm", "WARMER",
+                        (diff < 0) ? "A LITTLE LATER" : "A LITTLE EARLIER");
+    } else if (diff < 0) {
+        op_enter_flavor("flv_early", "TOO EARLY", "BACK TO OPERATOR");
+    } else {
+        op_enter_flavor("flv_late", "TOO LATE", "BACK TO OPERATOR");
+    }
 }
 
 static void op_render_key(void) {
@@ -260,7 +293,7 @@ static void op_render_key(void) {
     } else if (op.tangled) {
         sdk_display("LINE TANGLED", "press 1=LISTEN");
     } else {
-        sdk_display(l1, "1=LISTEN 2=SPEAK");
+        sdk_display(l1, op.spoke_once ? "press 1=LISTEN" : "1=LISTEN 2=SPEAK");
     }
 }
 
@@ -300,6 +333,8 @@ static void op_enter_win(void) {
     sdk_stop_audio();
     op.state = TS_WIN;
     op.won = 1;
+    op.final_step = 0;
+    op.timer_at = sdk_now();
     sdk_display("12:00  2000", "SHE IS FREE");
     sdk_log(TS_CAT, "The last call connected; the Operator is free");
     sdk_play_clip("win_free");
@@ -316,26 +351,36 @@ static void op_enter_final(void) {
 
 /* Resolve a completed TRAVEL beat to the right era. */
 static void op_resolve_travel(void) {
-    int role = year_role(op.travel_year);
-    int idx = (role == ROLE_KEY_A) ? 0 : (role == ROLE_KEY_B) ? 1 : 2;
+    int year = op.travel_year;
+    int t = operator_target_piece(op.pieces);   /* the piece the hub suggests */
+    int hit, i;
 
-    switch (role) {
-    case ROLE_KEY_A:
-    case ROLE_KEY_B:
-    case ROLE_KEY_C:
-        if (op_have(idx)) {
-            op_enter_flavor("flv_heard", "ALREADY HEARD");
-        } else if (role == ROLE_KEY_C && !op.pass) {
-            op_enter_key(idx, 1);   /* sealed */
-        } else {
-            op_enter_key(idx, 0);
-        }
-        break;
-    case ROLE_EARLY:  op_enter_flavor("flv_early",  "TOO EARLY");      break;
-    case ROLE_HOME:   op_enter_flavor("flv_2000",   "FROZEN MINUTE");  break;
-    case ROLE_FUTURE: op_enter_flavor("flv_future", "FUTURE SEALED");  break;
-    default:          op_enter_flavor("flv_other",  "NOTHING HERE");   break;
+    /* Poetic special years, answered regardless of the current target. */
+    if (year == 2000) {
+        op_enter_flavor("flv_2000", "FROZEN MINUTE", "BACK TO OPERATOR");
+        return;
     }
+    if (year >= FUTURE_SEALED_YEAR) {
+        op_enter_flavor("flv_future", "FUTURE SEALED", "BACK TO OPERATOR");
+        return;
+    }
+    /* Does the dialed year land on one of her three moments? You may visit them
+     * in any order; the hub only suggests the next one. */
+    hit = -1;
+    for (i = 0; i < 3; i++) { if (op_in_window(i, year)) { hit = i; break; } }
+    if (hit >= 0) {
+        if (op_have(hit)) {
+            op_enter_flavor("flv_heard", "ALREADY HEARD", "BACK TO OPERATOR");
+        } else if (hit == 2 && !op.pass) {
+            op_enter_key(2, 1);            /* the sealed final year */
+        } else {
+            op_enter_key(hit, 0);
+        }
+        return;
+    }
+    /* A year she never held the number: nudge toward the current target. */
+    if (t <= 2) op_nudge(year, op_target_year(t));
+    else op_enter_hub(NULL);
 }
 
 /* ── Year / number entry ─────────────────────────────────────────────── */
@@ -357,7 +402,7 @@ static void op_eval_number(void) {
     } else {
         op.buf[0] = '\0';
         op.len = 0;
-        sdk_display("WRONG NUMBER", PIECE_A " " PIECE_B " " PIECE_C);
+        sdk_display("WRONG NUMBER", "TRY AGAIN");
     }
 }
 
@@ -368,9 +413,12 @@ static int op_handle_coin(int coin_value, const char *coin_code) {
     (void)coin_code;
     sdk_coin_chime();
     if (op.state == TS_HUB) {
+        /* A coin buys a sharper hint -- it names the decade (the old level of
+         * help), an escape hatch for a public phone. Piece B still needs the
+         * exact year nailed down within that decade. */
         int t = operator_target_piece(op.pieces);
-        const char *l1 = (t == 0) ? "DIAL 1955" :
-                         (t == 1) ? "DIAL 1978" : "DIAL 1998";
+        const char *l1 = (t == 0) ? "TRY THE 1950s" :
+                         (t == 1) ? "TRY THE 1970s" : "TRY THE 1990s";
         char l2[24];
         snprintf(l2, sizeof(l2), "DIAL A YEAR  %d/3", op_count());
         sdk_display(l1, l2);
@@ -383,12 +431,18 @@ static int op_handle_coin(int coin_value, const char *coin_code) {
             sdk_play_clip("coin_hold");
         }
     } else if (op.state == TS_READY) {
-        op_render_ready();
+        /* A coin reveals the assembled number for a stuck caller. */
+        sdk_display("HER NUMBER", PIECE_A " " PIECE_B " " PIECE_C);
+        sdk_play_clip("op_ready");
     }
     return 0;
 }
 
 static int op_handle_keypad(char key) {
+    /* This app keeps its own per-field entry; keep the daemon's shared dial
+     * buffer (Classic Phone's) clean so /api/state isn't a confusing pile of
+     * every digit ever pressed. */
+    sdk_clear_keypad();
     switch (op.state) {
     case TS_HUB:
         op.last_input_at = sdk_now();   /* for the stale-entry auto-clear */
@@ -438,6 +492,7 @@ static int op_handle_keypad(char key) {
             op_enter_reveal();
         } else if (key == '2') {
             op.tangled = 1;
+            op.spoke_once = 1;   /* learned the lesson; stop advertising SPEAK */
             op_render_key();
             sdk_play_clip("px_tangle");
         } else if (key == '#') {
@@ -539,6 +594,14 @@ static void op_handle_tick(void) {
             op_enter_win();
         }
         break;
+    case TS_WIN:
+        /* Hold the win a beat, then settle to a quiet coda inviting hang-up so
+         * the screen doesn't freeze on SHE IS FREE forever. */
+        if (op.final_step == 0 && sdk_elapsed(op.timer_at) >= WIN_HOLD_SECS) {
+            op.final_step = 1;
+            sdk_display("THE LINE IS QUIET", "hang up: she's home");
+        }
+        break;
     default:
         break;
     }
@@ -553,16 +616,20 @@ static int op_collect(const char **out, int max, int n, const char *s) {
 
 int time_operator_display_strings(const char **out, int max) {
     static const char *const ui[] = {
-        "THE OPERATOR", "Lift: the last call", "FIND THE 1950s",
-        "FIND THE 1970s", "FIND 1998 SEALED", "DIAL A YEAR", "DIAL HER NUMBER",
+        "THE OPERATOR", "Lift: the last call",
+        "TWO GIRLS, A RADIO", "NIGHT SHE FALTERED", "HER LAST ATTEMPT",
+        "TRY THE 1950s", "TRY THE 1970s", "TRY THE 1990s",
+        "DIAL A YEAR", "DIAL HER NUMBER", "6 DIGITS", "HER NUMBER",
         PIECE_A " " PIECE_B " " PIECE_C, "DIALING...", "CONNECTING...",
-        "BACK TO OPERATOR", "TOO EARLY", "FROZEN MINUTE", "FUTURE SEALED",
-        "NOTHING HERE", "ALREADY HEARD", "1955 TWO SISTERS", "1978 SHE PAUSES",
-        "1998 A CARD", "1998: SEALED", "SWIPE PASS / COIN", "1=LISTEN 2=SPEAK",
-        "LINE TANGLED", "press 1=LISTEN", "DIAL 1955", "DIAL 1978", "DIAL 1998",
+        "BACK TO OPERATOR", "TOO EARLY", "TOO LATE", "WARMER",
+        "A LITTLE LATER", "A LITTLE EARLIER", "ALREADY HEARD",
+        "FROZEN MINUTE", "FUTURE SEALED",
+        "1955 TWO SISTERS", "1978 SHE PAUSES", "1998 A CARD", "1998: SEALED",
+        "SWIPE PASS / COIN", "1=LISTEN 2=SPEAK", "LINE TANGLED", "press 1=LISTEN",
         "TEMPORAL PASS", "PASS ACCEPTED", "NO SUCH YEAR", "try 1900-2100",
-        "WRONG NUMBER", "...RINGING...", "the last call", "11:59 ... 12:00",
-        "the clock turns", "12:00  2000", "SHE IS FREE"
+        "WRONG NUMBER", "TRY AGAIN", "...RINGING...", "the last call",
+        "11:59 ... 12:00", "the clock turns", "12:00  2000", "SHE IS FREE",
+        "THE LINE IS QUIET", "hang up: she's home"
     };
     int n = 0, i;
     for (i = 0; i < (int)(sizeof(ui) / sizeof(ui[0])); i++) {

--- a/host/tests/test_operator_coin_hint.scenario
+++ b/host/tests/test_operator_coin_hint.scenario
@@ -3,9 +3,9 @@
 activate_plugin The Operator
 hook_up
 
-# Coin at the hub -> blunt hint for the current target
+# Coin at the hub -> a sharper hint: it names the decade for the current target
 coin 25
-assert_display DIAL 1955
+assert_display TRY THE 1950s
 assert_clip op_hint_a.wav
 
 # Coin in an era -> the Operator holds the line longer

--- a/host/tests/test_operator_find_piece.scenario
+++ b/host/tests/test_operator_find_piece.scenario
@@ -3,7 +3,7 @@
 activate_plugin The Operator
 hook_up
 
-# Dial the 1950s -> connecting beat -> the era
+# Dial 1955 (her childhood) -> connecting beat -> the era
 keys 1955
 wait 3
 assert_display 1=LISTEN
@@ -18,4 +18,4 @@ assert_clip era1_listen.wav
 # After the reveal, back to the Operator pointing at piece B
 wait 3
 assert_display DIAL A YEAR
-assert_display FIND THE 1970s
+assert_display NIGHT SHE FALTERED

--- a/host/tests/test_operator_homing.scenario
+++ b/host/tests/test_operator_homing.scenario
@@ -1,0 +1,48 @@
+# The Operator: finding a year is a homing search, not a decade lookup. A wrong
+# but valid year answers with direction (TOO EARLY/LATE) and, once close, warmth
+# (WARMER + a little earlier/later). The middle moment demands the EXACT year --
+# the one real inference.
+activate_plugin The Operator
+hook_up
+
+# Far off -> a blunt direction back toward the target (childhood, 1955)
+keys 1925
+wait 3
+assert_display TOO EARLY
+assert_clip flv_early.wav
+wait 3
+
+# Close, but a touch early -> warmer, nudged later
+keys 1950
+wait 3
+assert_display WARMER
+assert_display A LITTLE LATER
+wait 3
+
+# Close, but a touch late -> warmer, nudged earlier
+keys 1958
+wait 3
+assert_display A LITTLE EARLIER
+wait 3
+
+# On the moment -> the era opens, first piece earned
+keys 1955
+wait 3
+assert_display 1=LISTEN
+key 1
+assert_display PIECE A
+wait 3
+
+# Now hunting the middle piece: it needs the EXACT year, not just the decade
+keys 1977
+wait 3
+assert_display WARMER
+assert_display A LITTLE LATER
+wait 3
+keys 1980
+wait 3
+assert_display A LITTLE EARLIER
+wait 3
+keys 1978
+wait 3
+assert_display 1=LISTEN

--- a/host/tests/test_operator_intro.scenario
+++ b/host/tests/test_operator_intro.scenario
@@ -7,5 +7,5 @@ hook_up
 assert_state IDLE_UP
 assert_display DIAL A YEAR
 assert_display 0/3
-assert_display FIND THE 1950s
+assert_display TWO GIRLS, A RADIO
 assert_clip op_intro.wav

--- a/host/tests/test_operator_tangle.scenario
+++ b/host/tests/test_operator_tangle.scenario
@@ -16,3 +16,9 @@ assert_clip px_tangle.wav
 key 1
 assert_display PIECE A
 assert_display 1/3
+
+# Having spoken once, the SPEAK prompt is retired: later eras only offer LISTEN
+wait 3
+keys 1978
+wait 3
+assert_display press 1=LISTEN

--- a/host/tests/test_operator_win.scenario
+++ b/host/tests/test_operator_win.scenario
@@ -23,10 +23,15 @@ card 1234567890123456
 key 1
 wait 3
 
-# All three pieces -> ready to place the call; the number is shown
+# All three pieces -> ready to place the call (the number is NOT shown; you must
+# assemble the three pieces you collected from memory)
 assert_display DIAL HER NUMBER
-assert_display 36 41 55
+assert_display 6 DIGITS
 assert_clip op_ready.wav
+
+# A coin reveals the assembled number for a stuck caller
+coin 25
+assert_display 36 41 55
 
 # Dial Ruth's number -> the call connects
 keys 364155
@@ -39,3 +44,7 @@ assert_display the clock turns
 wait 5
 assert_display SHE IS FREE
 assert_clip win_free.wav
+
+# The win settles to a quiet coda inviting hang-up (no longer frozen)
+wait 7
+assert_display THE LINE IS QUIET


### PR DESCRIPTION
Acts on the playtest feedback (\"a guided tour, not a puzzle\") to make **The Last Call** genuinely harder while keeping it fair and self-contained, plus three polish fixes. Design locked with the owner before implementing.

## Difficulty
- **Cryptic hub clues** — the hub no longer names the decade (`TWO GIRLS, A RADIO` / `NIGHT SHE FALTERED` / `HER LAST ATTEMPT`).
- **Homing search** — a wrong-but-valid year answers `TOO EARLY` / `TOO LATE`, and `WARMER` (+ *a little earlier/later*) within `WARM_BAND` (6) years. You deduce the year from clue + feedback instead of being told the decade.
- **One real inference** — A and C accept ±2 years; the middle piece **B demands the exact year (1978)**.
- **Hidden finale** — `READY` shows `6 DIGITS`, a wrong attempt says `TRY AGAIN`; you assemble the three pieces from memory.
- **Coin escape hatches** — a coin at the hub names the decade; a coin at `READY` reveals the assembled number.

## Polish (from the feedback)
- **Win coda** — no longer freezes on `SHE IS FREE`; settles to `THE LINE IS QUIET / hang up: she's home`.
- **SPEAK retired** — `2=SPEAK` is advertised only until the first tangle (pressing 2 still tangles in-world).
- **keypad_buffer tidy** — `/api/state` no longer accumulates raw history during an app session (new `sdk_clear_keypad()`).

## Tests / docs
Updated the 4 affected scenarios, added `test_operator_homing` (directional/warm + exact-year B), extended `win` (hidden number, coin-reveal, coda) and `tangle` (SPEAK retire); refreshed the display-fits guardrail, `OPERATOR_STORY.md`, `OPERATOR_PLAYTEST.md`, and the clips manifest (clues no longer leak the decade/number).

## Verification
`make test` green (118 unit + all scenarios). Full win played on **live hardware** with every new mechanic confirmed; `NRestarts=0`.

> ⚠️ The Pi's recorded **audio clips are now stale** vs the manifest (old audio names the decades and reads the number aloud, which would spoil the harder VFD design for in-person players). Run `make regen-clips` to resync the spoken layer — left out here because it costs ElevenLabs credits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)