### PR TITLE
audio: regen_clips.sh subset support (MANIFEST override)

### DIFF
--- a/host/audio/regen_clips.sh
+++ b/host/audio/regen_clips.sh
@@ -15,6 +15,8 @@
 #
 # Env knobs (all optional):
 #   ELEVENLABS_API_KEY  required  — API key (never hard-code it / commit it)
+#   MANIFEST            default clips.manifest — point at a subset file to
+#                                  regenerate only some clips (saves TTS spend)
 #   VOICE_ID            default Sarah (EXAVITQu4vr4xnSDxMaL)
 #   MODEL_ID            default eleven_multilingual_v2
 #   OUTDIR              default <script dir>/out
@@ -25,7 +27,7 @@
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
-MANIFEST="$HERE/clips.manifest"
+MANIFEST="${MANIFEST:-$HERE/clips.manifest}"   # override to regen a subset
 OUTDIR="${OUTDIR:-$HERE/out}"
 VOICE_ID="${VOICE_ID:-EXAVITQu4vr4xnSDxMaL}"   # Sarah
 MODEL_ID="${MODEL_ID:-eleven_multilingual_v2}"


### PR DESCRIPTION
`regen_clips.sh` now honors a `MANIFEST` env override so you can rebuild only some clips instead of the whole set (saves ElevenLabs spend).

Used it to regenerate just the **11 clips** whose text changed for the harder Operator design (#216) and deploy only those to the Pi:
- `op_intro`, `op_next_a/b/c` — cryptic clues, no decade named
- `op_hint_a/b/c` — coin hints now name the decade (B notes "exact year"), not the literal year
- `op_ready` — no longer reads the full number aloud
- `flv_early` — genericized; **new** `flv_warm` / `flv_late` homing nudges

Verified on hardware: clips deploy as RIFF PCM 16-bit mono 8 kHz, `flv_warm` fires on a close-but-wrong year, daemon stable (`NRestarts=0`). The spoken layer now matches the cryptic VFD design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)