### PR TITLE
operator: pace beats so clips finish (~5 min target)

### DIFF
--- a/host/OPERATOR_STORY.md
+++ b/host/OPERATOR_STORY.md
@@ -79,10 +79,11 @@ by `op_in_window` (the narrow windows above), not by that classifier.
 ## States (`plugins/time_operator.c`)
 `DORMANT → HUB → TRAVEL → {FLAVOR | KEY} → REVEAL → … → READY → FINAL → WIN`
 plus `KEY` sub-flags `locked` (sealed) and `tangled` (spoke), and session flag
-`spoke_once` (retires the SPEAK prompt). Timers: `TRAVEL_SECS 2`, `REVEAL_SECS 3`,
-`FLAVOR_SECS 3`, `DRIFT_SECS 30`, `EXTEND_SECS 30`, `GRACE_SECS 30`, final beats
-`3` then `4`, then `WIN_HOLD_SECS 6` before the quiet coda. Tuning knob:
-`WARM_BAND 6`.
+`spoke_once` (retires the SPEAK prompt). Timers are sized to let each beat's voice
+clip finish (so the story isn't cut off mid-line, which paces a first session
+toward ~5 min): `TRAVEL_SECS 2`, `REVEAL_SECS 6`, `FLAVOR_SECS 5`, `DRIFT_SECS 30`,
+`EXTEND_SECS 30`, `GRACE_SECS 30`, final beats `8` then `6`, then `WIN_HOLD_SECS 8`
+before the quiet coda. Tuning knob: `WARM_BAND 6`.
 
 ## Decision tree
 ```

--- a/host/plugins/time_operator.c
+++ b/host/plugins/time_operator.c
@@ -36,17 +36,21 @@
 #define YEAR_MIN           1900
 #define YEAR_MAX           2100
 #define FUTURE_SEALED_YEAR 2050
+/* Transient-state durations. The reveal/flavor/final beats are sized to let
+ * their voice clip finish (see audio/clips.manifest durations) so the story
+ * lands instead of being cut off mid-line -- this is what paces a first-time
+ * session toward ~5 minutes. */
 #define TRAVEL_SECS        2
-#define REVEAL_SECS        3
-#define FLAVOR_SECS        3
+#define REVEAL_SECS        6   /* hold a found piece; era*_listen runs ~4-5 s    */
+#define FLAVOR_SECS        5   /* a nudge/flavor beat; flv_* run ~3-5 s          */
 #define DRIFT_SECS         30
 #define EXTEND_SECS        30   /* a coin buys this much extra line time */
 #define GRACE_SECS         30   /* re-lift within this window resumes a session */
-#define FINAL_CONNECT_SECS 3
-#define FINAL_CLOCK_SECS   4
+#define FINAL_CONNECT_SECS 8   /* "...RINGING..."; final_connect runs ~7.4 s    */
+#define FINAL_CLOCK_SECS   6   /* "11:59 ... 12:00"; final_clock runs ~5.4 s    */
 #define ENTRY_TIMEOUT_SECS 6   /* clear a half-typed year/number after this idle */
 #define WARM_BAND          6   /* within this many years of a target reads "warmer" */
-#define WIN_HOLD_SECS      6   /* hold the win before settling to the quiet coda    */
+#define WIN_HOLD_SECS      8   /* hold the win (win_free runs ~6.8 s) before coda    */
 
 /* Ruth's number, in three positional pieces A-B-C (tunable). */
 #define PIECE_A "36"

--- a/host/tests/test_operator_find_piece.scenario
+++ b/host/tests/test_operator_find_piece.scenario
@@ -16,6 +16,6 @@ assert_display 1/3
 assert_clip era1_listen.wav
 
 # After the reveal, back to the Operator pointing at piece B
-wait 3
+wait 6
 assert_display DIAL A YEAR
 assert_display NIGHT SHE FALTERED

--- a/host/tests/test_operator_flavor.scenario
+++ b/host/tests/test_operator_flavor.scenario
@@ -7,6 +7,6 @@ wait 3
 assert_display TOO EARLY
 assert_clip flv_early.wav
 
-# Returns to the Operator on its own
-wait 3
+# Returns to the Operator on its own (after FLAVOR_SECS)
+wait 5
 assert_display DIAL A YEAR

--- a/host/tests/test_operator_homing.scenario
+++ b/host/tests/test_operator_homing.scenario
@@ -2,6 +2,8 @@
 # but valid year answers with direction (TOO EARLY/LATE) and, once close, warmth
 # (WARMER + a little earlier/later). The middle moment demands the EXACT year --
 # the one real inference.
+# (waits: ~3 s catches the beat after the travel hop; ~5 s lets a flavor/nudge
+#  clear back to the hub; ~6 s lets a reveal clear -- see the *_SECS timers.)
 activate_plugin The Operator
 hook_up
 
@@ -10,20 +12,20 @@ keys 1925
 wait 3
 assert_display TOO EARLY
 assert_clip flv_early.wav
-wait 3
+wait 5
 
 # Close, but a touch early -> warmer, nudged later
 keys 1950
 wait 3
 assert_display WARMER
 assert_display A LITTLE LATER
-wait 3
+wait 5
 
 # Close, but a touch late -> warmer, nudged earlier
 keys 1958
 wait 3
 assert_display A LITTLE EARLIER
-wait 3
+wait 5
 
 # On the moment -> the era opens, first piece earned
 keys 1955
@@ -31,18 +33,18 @@ wait 3
 assert_display 1=LISTEN
 key 1
 assert_display PIECE A
-wait 3
+wait 6
 
 # Now hunting the middle piece: it needs the EXACT year, not just the decade
 keys 1977
 wait 3
 assert_display WARMER
 assert_display A LITTLE LATER
-wait 3
+wait 5
 keys 1980
 wait 3
 assert_display A LITTLE EARLIER
-wait 3
+wait 5
 keys 1978
 wait 3
 assert_display 1=LISTEN

--- a/host/tests/test_operator_tangle.scenario
+++ b/host/tests/test_operator_tangle.scenario
@@ -18,7 +18,7 @@ assert_display PIECE A
 assert_display 1/3
 
 # Having spoken once, the SPEAK prompt is retired: later eras only offer LISTEN
-wait 3
+wait 6
 keys 1978
 wait 3
 assert_display press 1=LISTEN

--- a/host/tests/test_operator_win.scenario
+++ b/host/tests/test_operator_win.scenario
@@ -7,13 +7,13 @@ hook_up
 keys 1955
 wait 3
 key 1
-wait 3
+wait 6
 
 # Piece B (1970s)
 keys 1978
 wait 3
 key 1
-wait 3
+wait 6
 
 # Piece C (1998, sealed -> swipe a pass)
 keys 1998
@@ -21,7 +21,7 @@ wait 3
 assert_display SEALED
 card 1234567890123456
 key 1
-wait 3
+wait 6
 
 # All three pieces -> ready to place the call (the number is NOT shown; you must
 # assemble the three pieces you collected from memory)
@@ -39,12 +39,12 @@ assert_display RINGING
 assert_clip final_connect.wav
 
 # The clock turns over, and she is free
-wait 4
+wait 8
 assert_display the clock turns
-wait 5
+wait 6
 assert_display SHE IS FREE
 assert_clip win_free.wav
 
 # The win settles to a quiet coda inviting hang-up (no longer frozen)
-wait 7
+wait 8
 assert_display THE LINE IS QUIET


### PR DESCRIPTION
Chosen approach: **lean on narration/pacing**. Size the transient-state timers to each beat's voice-clip length so the story isn't cut off mid-line, and give the climax room. Deduction difficulty unchanged (bounded by coin hints + drift).

| Timer | was | now | clip it covers |
|---|----|----|----|
| `REVEAL_SECS` | 3 | 6 | `era*_listen` ~4–5 s |
| `FLAVOR_SECS` | 3 | 5 | `flv_*` ~3–5 s |
| `FINAL_CONNECT_SECS` | 3 | 8 | `final_connect` ~7.4 s |
| `FINAL_CLOCK_SECS` | 4 | 6 | `final_clock` ~5.4 s |
| `WIN_HOLD_SECS` | 6 | 8 | `win_free` ~6.8 s |

Scenario `wait`s updated to match.

## Measured (hardware)
- Engaged first-timer (listens, ~1 nudge/piece): **~2m45s** — the floor.
- With real clue-comprehension + a few more wrong guesses: typically **~4.5–5.5 min**.
- A hard ~5-min floor for a *fast* player would need more narrated content (a 4th beat / longer lines), not just pacing.

`make test` green (118 unit + all scenarios). Full arc replayed on hardware, `NRestarts=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)