### PR TITLE
operator: forced per-era story beat (firm up the ~5-min floor)

### DIFF
--- a/host/OPERATOR_PLAYTEST.md
+++ b/host/OPERATOR_PLAYTEST.md
@@ -33,8 +33,10 @@ Clips live in `/usr/local/share/millennium/audio/`; a missing one is a silent no
       ·  H: lifting really transitions to IDLE_UP (no API nudge).
 - [ ] **Homing feedback.** Dial `1 9 5 0`. V: `WARMER` / `A LITTLE LATER`. Dial `1 9 5 8`:
       `WARMER` / `A LITTLE EARLIER`. Dial `1 9 2 5`: `TOO EARLY`. (Deduce, then land it.)
-- [ ] **Piece A.** Dial `1 9 5 5`. V: connecting → `1955 TWO SISTERS` / `1=LISTEN 2=SPEAK`.
-      Press `1`. V: `PIECE A: 36` / `PIECES 1/3` · A: `era1_arrive`, then `era1_listen`.
+- [ ] **Piece A (+ forced story beat).** Dial `1 9 5 5`. V: connecting → `1955 TWO SISTERS` /
+      `1=LISTEN 2=SPEAK`. Press `1`. V: a forced ~14 s scene (`A SUMMER KITCHEN` / `call me, she says`,
+      A: `era1_scene`) that you **cannot skip**, then V: `PIECE A: 36` / `PIECES 1/3` · A: `era1_listen`.
+      (This beat plays in every era; it's what puts a floor under the session length.)
 - [ ] **Listen, don't speak (+ retire).** In a key era press `2`. V: `LINE TANGLED` · A: `px_tangle`.
       Press `1` to recover the piece. Thereafter the prompt reads `press 1=LISTEN` (SPEAK retired).
 - [ ] **Piece B — the exact year.** Dial `1 9 7 7` → `WARMER`/`A LITTLE LATER`; only

--- a/host/OPERATOR_STORY.md
+++ b/host/OPERATOR_STORY.md
@@ -77,11 +77,13 @@ decade roles (A/B/C/early/home/future/other) for reference; **arrival** is decid
 by `op_in_window` (the narrow windows above), not by that classifier.
 
 ## States (`plugins/time_operator.c`)
-`DORMANT → HUB → TRAVEL → {FLAVOR | KEY} → REVEAL → … → READY → FINAL → WIN`
+`DORMANT → HUB → TRAVEL → {FLAVOR | KEY} → SCENE → REVEAL → … → READY → FINAL → WIN`
+(`SCENE` is a forced, unskippable per-era story beat between LISTEN and the piece)
 plus `KEY` sub-flags `locked` (sealed) and `tangled` (spoke), and session flag
 `spoke_once` (retires the SPEAK prompt). Timers are sized to let each beat's voice
 clip finish (so the story isn't cut off mid-line, which paces a first session
-toward ~5 min): `TRAVEL_SECS 2`, `REVEAL_SECS 6`, `FLAVOR_SECS 5`, `DRIFT_SECS 30`,
+toward ~5 min): `TRAVEL_SECS 2`, `SCENE_SECS 14` (forced per-era story beat),
+`REVEAL_SECS 6`, `FLAVOR_SECS 5`, `DRIFT_SECS 30`,
 `EXTEND_SECS 30`, `GRACE_SECS 30`, final beats `8` then `6`, then `WIN_HOLD_SECS 8`
 before the quiet coda. Tuning knob: `WARM_BAND 6`.
 
@@ -92,8 +94,8 @@ DORMANT ──lift──▶ [won OR idle>grace?] ─ yes ▶ reset + op_intro �
 HUB (cryptic clue for lowest unfound piece; n/3)
   ├─ dial year off-target ─▶ FLAVOR nudge (TOO EARLY/LATE/WARMER) ─(timeout/#)─▶ HUB
   ├─ dial year in a piece window (unfound) ─▶ TRAVEL ─▶ KEY
-  │        ├─ 1 LISTEN ─▶ REVEAL (piece++) ─(timeout/#)─▶ HUB
-  │        └─ 2 SPEAK  ─▶ tangled (SPEAK retired) ──1 LISTEN──▶ REVEAL
+  │        ├─ 1 LISTEN ─▶ SCENE (forced story beat) ─▶ REVEAL (piece++) ─▶ HUB
+  │        └─ 2 SPEAK  ─▶ tangled (SPEAK retired) ──1 LISTEN──▶ SCENE ─▶ REVEAL
   ├─ dial a window already found ─▶ FLAVOR "already heard" ─▶ HUB
   ├─ dial 1998-window (sealed, unfound) ─▶ KEY locked ──card|coin──▶ KEY ─▶ …
   ├─ coin ─▶ sharper hint (decade)   │   # ─▶ repeat hint
@@ -106,7 +108,7 @@ ANY ── hang up ──▶ DORMANT (30 s grace; a WIN forces a fresh next sess
 ## Clips
 All voice lines (IDs + exact text + voice) are the manifest:
 `audio/clips.manifest`, rebuilt by `make regen-clips` (see `AUDIO_CLIPS.md`).
-Groups: `op_*` (hub), `era{1,2,3}_{arrive,listen}` + `era3_sealed`, `flv_*`,
+Groups: `op_*` (hub), `era{1,2,3}_{arrive,scene,listen}` + `era3_sealed`, `flv_*`,
 `px_tangle` / `drift_back` / `coin_hold`, `final_connect` / `final_clock` /
 `win_free`. Missing clips are silent no-ops; the experience still reads on the VFD.
 

--- a/host/audio/clips.manifest
+++ b/host/audio/clips.manifest
@@ -36,6 +36,11 @@ era3_sealed  This line is sealed, a trunk line. Swipe a pass, or feed the coinbo
 era3_arrive  Connecting. December, nineteen ninety-eight. A Christmas card, Ruth's new number folded inside. The last of it. Listen.
 era3_listen  Five, five. That is the end of it. The whole number, at last.
 
+# -- Per-era story beats (a forced moment between LISTEN and the piece) --
+era1_scene   The song ends, and the older girl leans close. Call me, she says, and gives the little one the number to keep. She writes it on her palm in blue ink, so she will never forget.
+era2_scene   She stands in the hallway a long while, the receiver humming against her ear. Pride, or fear, it is hard to say. In the end she sets it down, and the number stays unfinished, sitting in her chest like a stone.
+era3_scene   She copies Ruth's new number onto the back of her hand, meaning to call once the holidays are over. The holidays become the new year. For her, the new year never quite arrives.
+
 # -- Flavor eras + the homing nudges (too early / too late / warm) --
 flv_early   Too early. Come back, and I will point you nearer.
 flv_late    Too late. That is past her moment. Come back, and I will point you nearer.

--- a/host/plugins/time_operator.c
+++ b/host/plugins/time_operator.c
@@ -41,6 +41,7 @@
  * lands instead of being cut off mid-line -- this is what paces a first-time
  * session toward ~5 minutes. */
 #define TRAVEL_SECS        2
+#define SCENE_SECS         14  /* forced story beat after LISTEN; era*_scene ~11-13 s */
 #define REVEAL_SECS        6   /* hold a found piece; era*_listen runs ~4-5 s    */
 #define FLAVOR_SECS        5   /* a nudge/flavor beat; flv_* run ~3-5 s          */
 #define DRIFT_SECS         30
@@ -78,6 +79,7 @@ enum {
     TS_TRAVEL,     /* connecting beat (ringback)                    */
     TS_FLAVOR,     /* a non-key era; brief scene then back          */
     TS_KEY,        /* a key era; LISTEN/SPEAK (maybe locked/tangled)*/
+    TS_SCENE,      /* forced story beat after LISTEN, before the piece */
     TS_REVEAL,     /* a piece was just found                        */
     TS_READY,      /* all 3 pieces; dialing the final number        */
     TS_FINAL,      /* the call connects; scripted beats             */
@@ -317,6 +319,22 @@ static void op_enter_key(int idx, int locked) {
     }
 }
 
+/* A forced story beat after the caller chooses LISTEN, before the piece is
+ * revealed: it deepens each era and -- being unskippable -- puts a firm floor
+ * under the session length (a hurried player can't blow past the story). */
+static void op_enter_scene(void) {
+    const char *l1 = (op.cur_key == 0) ? "A SUMMER KITCHEN" :
+                     (op.cur_key == 1) ? "A HALLWAY PHONE" : "DECEMBER 1998";
+    const char *l2 = (op.cur_key == 0) ? "call me, she says" :
+                     (op.cur_key == 1) ? "the nerve fails" : "Ruth's last card";
+    sdk_stop_audio();
+    op.state = TS_SCENE;
+    op.timer_at = sdk_now();
+    sdk_display(l1, l2);
+    sdk_play_clip(op.cur_key == 0 ? "era1_scene" :
+                  op.cur_key == 1 ? "era2_scene" : "era3_scene");
+}
+
 static void op_enter_reveal(void) {
     char l1[24], l2[24];
     const char *piece = (op.cur_key == 0) ? PIECE_A :
@@ -493,7 +511,7 @@ static int op_handle_keypad(char key) {
             if (key == '#') op_enter_hub(NULL);
             else sdk_beep(key);
         } else if (key == '1') {
-            op_enter_reveal();
+            op_enter_scene();
         } else if (key == '2') {
             op.tangled = 1;
             op.spoke_once = 1;   /* learned the lesson; stop advertising SPEAK */
@@ -579,6 +597,9 @@ static void op_handle_tick(void) {
     case TS_FLAVOR:
         if (sdk_elapsed(op.timer_at) >= FLAVOR_SECS) op_enter_hub(NULL);
         break;
+    case TS_SCENE:
+        if (sdk_elapsed(op.timer_at) >= SCENE_SECS) op_enter_reveal();
+        break;
     case TS_REVEAL:
         if (sdk_elapsed(op.timer_at) >= REVEAL_SECS) op_enter_hub(NULL);
         break;
@@ -628,6 +649,8 @@ int time_operator_display_strings(const char **out, int max) {
         "BACK TO OPERATOR", "TOO EARLY", "TOO LATE", "WARMER",
         "A LITTLE LATER", "A LITTLE EARLIER", "ALREADY HEARD",
         "FROZEN MINUTE", "FUTURE SEALED",
+        "A SUMMER KITCHEN", "call me, she says", "A HALLWAY PHONE",
+        "the nerve fails", "DECEMBER 1998", "Ruth's last card",
         "1955 TWO SISTERS", "1978 SHE PAUSES", "1998 A CARD", "1998: SEALED",
         "SWIPE PASS / COIN", "1=LISTEN 2=SPEAK", "LINE TANGLED", "press 1=LISTEN",
         "TEMPORAL PASS", "PASS ACCEPTED", "NO SUCH YEAR", "try 1900-2100",

--- a/host/tests/test_operator_find_piece.scenario
+++ b/host/tests/test_operator_find_piece.scenario
@@ -9,8 +9,11 @@ wait 3
 assert_display 1=LISTEN
 assert_clip era1_arrive.wav
 
-# Listen (don't speak) -> first piece
+# Listen (don't speak) -> a forced story beat -> the first piece
 key 1
+assert_display A SUMMER KITCHEN
+assert_clip era1_scene.wav
+wait 14
 assert_display PIECE A
 assert_display 1/3
 assert_clip era1_listen.wav

--- a/host/tests/test_operator_grace.scenario
+++ b/host/tests/test_operator_grace.scenario
@@ -3,11 +3,11 @@
 activate_plugin The Operator
 hook_up
 
-# Earn piece A
+# Earn piece A (LISTEN -> story beat -> reveal)
 keys 1955
 wait 3
 key 1
-wait 3
+wait 14
 assert_display 1/3
 
 # Hang up, lift back quickly -> resume with progress intact

--- a/host/tests/test_operator_homing.scenario
+++ b/host/tests/test_operator_homing.scenario
@@ -32,6 +32,7 @@ keys 1955
 wait 3
 assert_display 1=LISTEN
 key 1
+wait 14
 assert_display PIECE A
 wait 6
 

--- a/host/tests/test_operator_sealed.scenario
+++ b/host/tests/test_operator_sealed.scenario
@@ -14,5 +14,6 @@ assert_display 1998 A CARD
 assert_clip era3_arrive.wav
 
 key 1
+wait 14
 assert_display PIECE C
 assert_display 1/3

--- a/host/tests/test_operator_tangle.scenario
+++ b/host/tests/test_operator_tangle.scenario
@@ -12,8 +12,9 @@ key 2
 assert_display LINE TANGLED
 assert_clip px_tangle.wav
 
-# Listen -> recovered, piece found
+# Listen -> recovered, then the story beat -> piece found
 key 1
+wait 14
 assert_display PIECE A
 assert_display 1/3
 

--- a/host/tests/test_operator_win.scenario
+++ b/host/tests/test_operator_win.scenario
@@ -7,13 +7,13 @@ hook_up
 keys 1955
 wait 3
 key 1
-wait 6
+wait 20
 
 # Piece B (1970s)
 keys 1978
 wait 3
 key 1
-wait 6
+wait 20
 
 # Piece C (1998, sealed -> swipe a pass)
 keys 1998
@@ -21,7 +21,7 @@ wait 3
 assert_display SEALED
 card 1234567890123456
 key 1
-wait 6
+wait 20
 
 # All three pieces -> ready to place the call (the number is NOT shown; you must
 # assemble the three pieces you collected from memory)


### PR DESCRIPTION
A fast player could still skip the narration and finish in ~2m45s. This adds an **unskippable per-era story beat** (new `TS_SCENE` state) between choosing LISTEN and the piece reveal — it plays a new `era*_scene` clip and holds `SCENE_SECS` (14 s), deepening each era and putting a firm floor under the session length.

**Flow:** `… → KEY (1=LISTEN) → SCENE (forced ~14 s, no input) → REVEAL (piece)`. The sealed era runs the beat after the coin/card unlock, like the others.

**New audio:** `era1_scene` / `era2_scene` / `era3_scene` (manifest + generated + deployed; 10.9 / 13.0 / 11.0 s).

**Tests/docs:** scenario `wait`s updated for the inserted beat; display-fits guardrail covers the new VFD lines (`A SUMMER KITCHEN`, `A HALLWAY PHONE`, `DECEMBER 1998`, …); `OPERATOR_STORY.md` + `OPERATOR_PLAYTEST.md` updated.

**Measured (hardware):** the engaged-first-timer floor rose **2m43s → 3m28s** (+45 s of unskippable story), so a typical first session now lands comfortably ~5 min and even a hurried player can't blow past the narrative. `make test` green (118 unit + all scenarios). `NRestarts=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)