### PR TITLE
audio: dmix ipc_perm 0666 (immune to root-run IPC lockout)

### DIFF
--- a/host/asoundrc.example
+++ b/host/asoundrc.example
@@ -2,6 +2,11 @@
 pcm.dmix_usb {
     type dmix
     ipc_key 1024
+    # World-accessible IPC (semaphore + shm) so the mixer can be shared no matter
+    # which user opens it first. Without this it defaults to 0600/owner-only, and
+    # if the daemon is ever run as root (e.g. under sudo gdb) the root-owned IPC
+    # locks out the normal `matzen` service afterward -> all audio fails silently.
+    ipc_perm 0666
     slave {
         pcm "hw:1,0"     # adjust if your USB isn't card 1
         rate 48000


### PR DESCRIPTION
## Problem
ALSA `dmix` creates a SysV semaphore + shared memory on first open, defaulting to **0600 (owner-only)**. If the daemon is ever run as a different user than the service — e.g. under `sudo gdb` during debugging — the root-owned IPC persists, and afterward the normal `matzen` service **cannot attach**. Every ALSA open then fails, and because the daemon now *logs* ALSA errors instead of aborting (the earlier crash fix), **all audio goes silent with no obvious cause**.

This actually happened: a `sudo gdb` crash-diagnosis run left root-owned dmix IPC, which silenced the phone until the stale objects were removed.

## Fix
Set `ipc_perm 0666` on `dmix_usb` so the mixer's IPC is shareable regardless of which user opens it first.

## Verified
Deployed to the Pi; the dmix sem/shm are now created with perms `666` and audio is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)