### PR TITLE
verify: add TLA+ model checking; fix handset tracking and two updater defects

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -339,4 +339,17 @@ tla-check:
 tla-check-race:
 	cd tests && $(TLC) -config EventOrderingRace.cfg EventOrdering.tla
 
-.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke regen-clips tsan-queue cbmc-parser cbmc-parsers model-check game-check state-check tla-check tla-check-race pjsip-smoke
+# TLC model-check of coin accounting across the three ledgers that hold the
+# same balance: daemon_state->inserted_cents, classic_phone_data.inserted_cents
+# and the persisted file. Only the charge and refund paths sync the first two
+# (#109); every other write is unilateral. See docs/COIN_LEDGER.md.
+coin-check:
+	cd tests && $(TLC) -config CoinLedger.cfg CoinLedger.tla
+
+# The ledger-divergence properties. Expected to report violations: four
+# independent paths let the daemon and plugin ledgers drift. Each counterexample
+# and its code site is listed in tests/CoinLedgerDrift.cfg.
+coin-check-drift:
+	cd tests && $(TLC) -config CoinLedgerDrift.cfg CoinLedger.tla
+
+.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke regen-clips tsan-queue cbmc-parser cbmc-parsers model-check game-check state-check tla-check tla-check-race coin-check coin-check-drift pjsip-smoke

--- a/host/Makefile
+++ b/host/Makefile
@@ -352,4 +352,16 @@ coin-check:
 coin-check-drift:
 	cd tests && $(TLC) -config CoinLedgerDrift.cfg CoinLedger.tla
 
-.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke regen-clips tsan-queue cbmc-parser cbmc-parsers model-check game-check state-check tla-check tla-check-race coin-check coin-check-drift pjsip-smoke
+# TLC model-check of the OTA updater (tests/Updater.tla): the check FSM, the
+# four-step apply pipeline, and what a restart does to a call in progress.
+# See docs/OTA_UPDATE.md.
+ota-check:
+	cd tests && $(TLC) -config Updater.cfg Updater.tla
+
+# The open updater findings. Expected to report violations: the check FSM is a
+# one-way ratchet, "success" is reported without checking the restart, a failed
+# build strands the tree, and the restart ignores call state.
+ota-check-open:
+	cd tests && $(TLC) -config UpdaterOpen.cfg Updater.tla
+
+.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke regen-clips tsan-queue cbmc-parser cbmc-parsers model-check game-check state-check tla-check tla-check-race coin-check coin-check-drift ota-check ota-check-open pjsip-smoke

--- a/host/Makefile
+++ b/host/Makefile
@@ -318,4 +318,25 @@ state-check:
 	$(CBMC) tests/cbmc_state_machine.c --function verify_invariants
 	$(CBMC) tests/cbmc_state_machine.c --function verify_equiv
 
-.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke regen-clips tsan-queue cbmc-parser cbmc-parsers model-check game-check state-check pjsip-smoke
+# TLC model-check of concurrent event ordering (tests/EventOrdering.tla).
+# Where state-check verifies ONE transition sequentially, this checks every
+# interleaving of the two racing producers -- the serial/Arduino path and the
+# PJSUA worker thread -- through the single-consumer main loop. Formalizes the
+# hand-written case analysis in docs/EVENT_ORDERING.md (#100).
+#
+# Needs tla2tools.jar (https://github.com/tlaplus/tlaplus/releases) and a JRE:
+#   make tla-check TLA_TOOLS=/path/to/tla2tools.jar
+# Not part of `make test`; takes ~25s.
+TLA_TOOLS ?= tla2tools.jar
+TLC = java -XX:+UseParallelGC -cp $(TLA_TOOLS) tlc2.TLC
+
+tla-check:
+	cd tests && $(TLC) -config EventOrdering.cfg EventOrdering.tla
+
+# The two invariants that currently FAIL, both from the unguarded
+# EVENT_CALL_STATE_ACTIVE arm at daemon.c:387. Expected to report a violation
+# until that arm is guarded -- see tests/EventOrderingRace.cfg for the traces.
+tla-check-race:
+	cd tests && $(TLC) -config EventOrderingRace.cfg EventOrdering.tla
+
+.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke regen-clips tsan-queue cbmc-parser cbmc-parsers model-check game-check state-check tla-check tla-check-race pjsip-smoke

--- a/host/daemon.c
+++ b/host/daemon.c
@@ -385,18 +385,34 @@ void handle_call_state_event(call_state_event_t *call_state_event) {
         daemon_state_update_activity(daemon_state);
         
     } else if (call_state_event_get_state(call_state_event) == EVENT_CALL_STATE_ACTIVE) {
-        /* Handle call established (when the SIP stack reports CALL_ESTABLISHED) */
-        logger_info_with_category("Call", "Call established - audio should be working");
-        metrics_increment_counter("calls_established", 1);
-        
-        update_display_with_content("Call active", "Audio connected");
+        /* Handle call established (when the SIP stack reports CALL_ESTABLISHED).
+         *
+         * Guarded on the *physical* handset position, not on current_state:
+         * CALL_INCOMING is reachable both on-hook (ringing in the cradle) and
+         * off-hook (#92), so a current_state test cannot tell them apart.
+         *
+         * A CALL_ESTABLISHED arriving with the handset cradled -- a SIP-side
+         * answer, or one queued by the PJSUA thread and dispatched after the
+         * user already hung up -- would otherwise leave the daemon in
+         * CALL_ACTIVE on-hook, with nothing to recover it. Found by
+         * tests/EventOrdering.tla; see docs/EVENT_ORDERING.md. */
+        if (daemon_state->handset_up) {
+            logger_info_with_category("Call", "Call established - audio should be working");
+            metrics_increment_counter("calls_established", 1);
 
-        daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
-        daemon_state_update_activity(daemon_state);
-        /* If this transition answered a ring (SIP-side answer), close it out;
-         * a no-op for outbound calls that were never ringing. */
-        call_metrics_ringing_answered();
-        call_metrics_started();
+            update_display_with_content("Call active", "Audio connected");
+
+            daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
+            daemon_state_update_activity(daemon_state);
+            /* If this transition answered a ring (SIP-side answer), close it out;
+             * a no-op for outbound calls that were never ringing. */
+            call_metrics_ringing_answered();
+            call_metrics_started();
+        } else {
+            logger_warn_with_category("Call",
+                    "Ignoring CALL_ESTABLISHED received with handset on hook");
+            metrics_increment_counter("calls_established_ignored_onhook", 1);
+        }
     } else if (call_state_event_get_state(call_state_event) == EVENT_CALL_STATE_INVALID) {
         /* #90/#91: Call ended - remote hung up or call failed during dial */
         if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE) {
@@ -405,7 +421,11 @@ void handle_call_state_event(call_state_event_t *call_state_event) {
             call_metrics_ended();
             daemon_state_clear_keypad(daemon_state);
             daemon_state->inserted_cents = 0;
-            daemon_state->current_state = DAEMON_STATE_IDLE_UP;
+            /* Return to whichever idle state matches the physical handset: a
+             * call that ended while the handset was cradled must land in
+             * IDLE_DOWN, not IDLE_UP. See docs/EVENT_ORDERING.md. */
+            daemon_state->current_state = daemon_state->handset_up
+                    ? DAEMON_STATE_IDLE_UP : DAEMON_STATE_IDLE_DOWN;
             daemon_state_update_activity(daemon_state);
             need_hangup_sync = 1;
         } else if (daemon_state->current_state == DAEMON_STATE_CALL_INCOMING) {
@@ -417,7 +437,11 @@ void handle_call_state_event(call_state_event_t *call_state_event) {
              * without a ring) counts an outbound dial failure (calls_failed). */
             call_metrics_incoming_ended();
             daemon_state_clear_keypad(daemon_state);
-            daemon_state->current_state = DAEMON_STATE_IDLE_UP;
+            /* Same as above: an unanswered ring that ends while the handset is
+             * still in the cradle returns to IDLE_DOWN. Coins are preserved
+             * either way (#91) for the plugin to refund. */
+            daemon_state->current_state = daemon_state->handset_up
+                    ? DAEMON_STATE_IDLE_UP : DAEMON_STATE_IDLE_DOWN;
             daemon_state_update_activity(daemon_state);
             need_hangup_sync = 1;
         }
@@ -468,7 +492,15 @@ void handle_hook_event(hook_state_change_event_t *hook_event) {
     pthread_mutex_lock(&daemon_state_mutex);
     hook_up = (hook_state_change_event_get_direction(hook_event) == 'U');
     hook_down = (hook_state_change_event_get_direction(hook_event) == 'D');
-    
+
+    /* Record the physical handset position before any state-machine decision.
+     * This is ground truth; current_state is only the daemon's belief. */
+    if (hook_up) {
+        daemon_state->handset_up = 1;
+    } else if (hook_down) {
+        daemon_state->handset_up = 0;
+    }
+
     if (hook_up) {
         int call_incoming = (daemon_state->current_state == DAEMON_STATE_CALL_INCOMING);
         int phone_down = (daemon_state->current_state == DAEMON_STATE_IDLE_DOWN);
@@ -1137,6 +1169,13 @@ int main(int argc, char *argv[]) {
 
             pthread_mutex_lock(&daemon_state_mutex);
             daemon_state->inserted_cents = ps.inserted_cents;
+            /* handset_up is not persisted (the keypad firmware only reports
+             * hook *transitions*, so a restart cannot observe the position).
+             * Derive it from the state we are restoring, which keeps the two
+             * self-consistent: the daemon already trusts last_state enough to
+             * come back up in IDLE_UP, so the handset must have been lifted.
+             * The next real hook event corrects it either way. */
+            daemon_state->handset_up = (ps.last_state == (int)DAEMON_STATE_IDLE_UP);
             pthread_mutex_unlock(&daemon_state_mutex);
 
             if (strlen(ps.active_plugin) > 0) {

--- a/host/daemon_state.c
+++ b/host/daemon_state.c
@@ -11,6 +11,7 @@ void daemon_state_init(daemon_state_data_t* state) {
     memset(state->keypad_buffer, 0, sizeof(state->keypad_buffer));
     state->inserted_cents = 0;
     state->last_activity = mclock_now();
+    state->handset_up = 0;
 }
 
 void daemon_state_reset(daemon_state_data_t* state) {
@@ -20,6 +21,7 @@ void daemon_state_reset(daemon_state_data_t* state) {
     daemon_state_clear_keypad(state);
     state->inserted_cents = 0;
     state->last_activity = mclock_now();
+    state->handset_up = 0;
 }
 
 void daemon_state_update_activity(daemon_state_data_t* state) {

--- a/host/daemon_state.h
+++ b/host/daemon_state.h
@@ -17,6 +17,20 @@ typedef struct {
     char keypad_buffer[11];  /* Fixed size: 10 digits + null terminator */
     int inserted_cents;
     time_t last_activity;  /* C89 compatible time representation */
+    /* Physical handset position, tracked separately from current_state.
+     *
+     * current_state cannot stand in for this: CALL_INCOMING is reachable both
+     * on-hook (a phone ringing in its cradle) and off-hook (#92 interrupt
+     * dialing), so inferring the handset from the state machine is unsound.
+     * Call-state events racing hook events could then strand the daemon in
+     * CALL_ACTIVE with the handset cradled, or in IDLE_UP after an unanswered
+     * on-hook ring. Found by tests/EventOrdering.tla; see docs/EVENT_ORDERING.md.
+     *
+     * Not persisted: the keypad firmware never reports the hook position at
+     * boot (it only emits on a transition), so a restart cannot know it. 0 is
+     * the safe assumption and matches the existing unclean-shutdown coercion
+     * to IDLE_DOWN in daemon.c. */
+    int handset_up;
 } daemon_state_data_t;
 
 /* Function declarations (C equivalent of class methods) */

--- a/host/docs/COIN_LEDGER.md
+++ b/host/docs/COIN_LEDGER.md
@@ -1,0 +1,76 @@
+# Coin Ledger Consistency
+
+The same coin balance lives in **three** places:
+
+| Ledger | Declared | Who reads it |
+|---|---|---|
+| `daemon_state->inserted_cents` | `daemon_state.h:18` | web API `/api/state`, the `inserted_cents` metrics gauge, `daemon_save_state` |
+| `classic_phone_data.inserted_cents` | `plugins/classic_phone.c:18` | the VFD display (`"Have: 50c"`, `:298`) and the dial gate (`:334`) |
+| `persisted_state_t.inserted_cents` | `state_persistence.h:8` | restored at boot, `daemon.c:1171` |
+
+The only sync channel between the first two is `plugins_adjust_inserted_cents`
+(`daemon.c:102-110`, added by #109), and it is called from exactly **two** sites —
+the charge (`classic_phone.c:396`) and the refund (`:190`). Every other write to
+either ledger is unilateral.
+
+`tests/CoinLedger.tla` models all three. Run with `make coin-check` (properties
+that hold) and `make coin-check-drift` (the divergences).
+
+## Scope
+
+Physical coin custody is deliberately **not** modelled. Conservation against real
+money would need the meaning of the validator's `'c'` / `'z'` commands, and
+`docs/COIN_VALIDATOR.md` records those with a question mark — *"commit/execute
+(sequence terminator?)"* — alongside an explicitly unmitigated reconnect race.
+Modelling them would mean inventing semantics. The three software ledgers are
+fully determined by code, so those are what is checked.
+
+## Verified (`make coin-check`, 3316 states)
+
+No ledger goes negative, and all three stay well-typed across every interleaving
+of coin insert, hook, charge, refund, timeout, return, save and restart.
+
+## Divergences (`make coin-check-drift`)
+
+Four independent paths, each a separate counterexample:
+
+| # | Path | Site | Effect |
+|---|---|---|---|
+| 1 | Coin return | `daemon.c:800-819` | Zeroes the **daemon** ledger and bumps the revenue metrics; the plugin keeps its balance, so the VFD keeps offering credit the daemon will not honour. |
+| 2 | Idle timeout | `classic_phone.c:477` | Zeroes the **plugin** ledger from the tick handler. No event reaches the daemon, so the daemon ledger, the persisted file and the metrics gauge all keep phantom credit. |
+| 3 | Boot ordering | `daemon.c:1160-1174` | `plugins_init()` activates Classic Phone, whose `handle_activation` (`classic_phone.c:246`) seeds its ledger from `daemon_state->inserted_cents` — still 0, because the persisted balance is not written until `:1171`. The re-activation at `:1174` repairs this **only** when the persisted plugin name is non-empty. |
+| 4 | Call timeout | `classic_phone.c:430` | `classic_phone_end_call` zeroes the **plugin** ledger on the plugin's own call timeout, raising no daemon event. Any leftover change diverges. |
+
+Direction matters when choosing a fix:
+
+- **`pcents > dcents`** (path 1) — the phone promises the customer credit that is already gone.
+- **`dcents > pcents`** (paths 2, 3, 4) — the daemon, the persisted file and the operator's revenue figures carry credit the customer cannot spend, and a restart can resurrect it.
+
+The clamp at `daemon.c:107` (`if (inserted_cents < 0) inserted_cents = 0`)
+**masks** rather than prevents this: once the ledgers drift, a charge silently
+absorbs the difference instead of surfacing it.
+
+## A note on bounds
+
+`CoinLedger.cfg` uses `MaxEvents = 7`, not 5. At 5, path 4 does not appear —
+reaching it needs leftover change after a paid call (lift, three coins, charge,
+end = seven actions). The model reported "no error" for that path at the lower
+bound. A bound is not a proof; if you add actions to the spec, re-check whether
+the bound still reaches them.
+
+## Fixing
+
+The paths are independent, so they can be closed separately, but they share a
+shape: a single balance with two owners and no invalidation protocol. Two broad
+options —
+
+1. **One ledger.** Delete `classic_phone_data.inserted_cents` and have the plugin
+   read `sdk_balance()` at every use. Removes the class of bug rather than
+   patching instances. Touches the plugin SDK contract, and other plugins keep
+   their own balances too.
+2. **Make every write go through the sync channel.** Route the four paths above
+   through `plugins_adjust_inserted_cents` (or add the missing
+   `handle_deactivation` hook, which the plugin API lacks entirely). Smaller, but
+   leaves the next unilateral write free to reintroduce the problem.
+
+Option 1 is what the invariant actually wants. Neither is applied yet.

--- a/host/docs/EVENT_ORDERING.md
+++ b/host/docs/EVENT_ORDERING.md
@@ -24,4 +24,74 @@ Events are processed asynchronously: the PJSIP (PJSUA worker) thread queues call
 
 ## Testing
 
-Scenario tests `test_remote_hangup.scenario` and `test_incoming_handset_up.scenario` cover call-state transitions. Interleaved hook + call_ended could be added for more comprehensive race testing.
+Scenario tests `test_remote_hangup.scenario` and `test_incoming_handset_up.scenario` cover call-state transitions.
+
+## Model checking (`make tla-check`)
+
+The idempotency argument above is a hand analysis of two orderings of two events. `tests/EventOrdering.tla` discharges it mechanically over *all* interleavings of every event type, across the two producers that actually race: the serial/Arduino path and the PJSUA worker thread, feeding the single-consumer main loop.
+
+The model separates `hook` (the *physical* handset position) from `state` (the daemon's *belief*). The daemon's five-state enum conflates the two, so they can silently disagree — and that disagreement is only statable as an invariant once they are distinct variables.
+
+**Verified (`make tla-check`, 3389 states):** under every interleaving, not just the two above — no reachable `INVALID`, balance stays non-negative, `IDLE_DOWN` always implies zero credit, and once the queue drains the daemon never sits in `CALL_ACTIVE` on-hook (`SettledNotActiveOnHook`) and its belief agrees with the physical handset (`Converged`).
+
+**Confirms the analysis above:** the hook-down vs. `CALL_INVALID` race really is idempotent; both orders settle in `IDLE_DOWN`. The intermediate `IDLE_UP` in Order 2 is a genuine transient.
+
+### Finding: the daemon could not tell an on-hook ring from an off-hook one
+
+The first run of this spec produced three violations with a **single structural
+root cause**, not a missing guard.
+
+`daemon_state_data_t` had no field for the handset position, so the daemon
+*inferred* it from `current_state` — and that inference is unsound, because
+`CALL_INCOMING` is reachable both on-hook (a phone ringing in its cradle) and
+off-hook (#92 interrupt dialing). No test on `current_state` can distinguish
+them, so no guard placed there could be correct. Two intermediate attempts at a
+`current_state` guard were both refuted by TLC before this became clear.
+
+| Invariant | Failing behaviour |
+|---|---|
+| `SettledNotActiveOnHook` | A `CALL_ESTABLISHED` dispatched after the user hung up left the phone parked in `CALL_ACTIVE` with the handset cradled, with nothing left in the queue to recover it. |
+| `Converged` | `CALL_INVALID` ending an unanswered on-hook ring dropped to `IDLE_UP` (`daemon.c:407`, `:411`), leaving the daemon believing the handset was lifted while it sat in the cradle. |
+| `ActiveImpliesOffHook` | The instantaneous version of the first — see "By design" below. |
+
+**Fix applied.** `daemon_state_data_t` gained an explicit `handset_up` field,
+recorded in `handle_hook_event` from the physical hook direction. The
+`EVENT_CALL_STATE_ACTIVE` arm now guards on it, and both `EVENT_CALL_STATE_INVALID`
+arms return to `IDLE_DOWN` or `IDLE_UP` to match it. Mirrored in `simulator.c`
+and `tests/cbmc_state_machine.c`.
+
+Two consequences worth knowing:
+
+- **`handset_up` is not persisted.** The keypad firmware only emits hook
+  *transitions*, never the position at boot, so a restart cannot observe it. It
+  is derived from the restored `last_state` instead, which keeps the two
+  self-consistent.
+- **Six scenario assertions changed** in `test_call_duration_metrics`,
+  `test_failed_call_metrics`, and `test_missed_call_metrics`. Each was a
+  `call_ended` with no preceding `hook_up`, asserting `IDLE_UP`. They were
+  encoding the bug: the handset was never lifted, so `IDLE_DOWN` is correct.
+
+### By design: `ActiveImpliesOffHook` (`make tla-check-race`)
+
+The *instantaneous* property — never `CALL_ACTIVE` while the handset is
+physically cradled, at every moment — cannot hold in an event-queue
+architecture, and its violation is not a defect. The handset moves, the firmware
+queues a hook event, and until the main loop dispatches it the daemon has not
+yet learned. Every queued-event design has this window.
+
+What is verified is that the window always **closes**: `SettledNotActiveOnHook`
+and `Converged` both hold once the queue drains. Closing the instantaneous
+window would require the firmware to report hook position synchronously — a
+hardware change, not a daemon one.
+
+### How the three tools divide the work
+
+`make state-check` (CBMC) proves the **inductive step**: given a consistent
+state, one transition preserves consistency — and that `simulator.c` and
+`daemon.c` agree, now including `handset_up`. It cannot express two events in
+flight.
+
+`make tla-check` (TLC) proves the **reachability** half: no interleaving of
+queued events can reach an inconsistent state to begin with. Neither tool covers
+both halves alone, which is why the `CALL_ACTIVE` bug survived until now — CBMC
+transcribed the unguarded arm faithfully and asserted nothing about it.

--- a/host/docs/OTA_UPDATE.md
+++ b/host/docs/OTA_UPDATE.md
@@ -1,0 +1,81 @@
+# OTA Update: Check and Apply
+
+`host/updater.c` holds two independent state machines behind two mutexes:
+`check_state` (`:12`) and `apply_state` (`:152`). `tests/Updater.tla` models
+both, plus what a restart does to a call in progress and to escrowed coins.
+
+Run with `make ota-check` (properties that hold) and `make ota-check-open`
+(the open findings).
+
+## Verified (`make ota-check`, 758 states)
+
+- Nothing is ever installed without having been pulled first — the pipeline's
+  step ordering is genuinely enforced.
+- Coins survive a restart: `daemon_save_state` runs after every insert, so the
+  persisted file and the daemon ledger agree at restart time.
+
+Worth noting what is *not* claimed: "installed = new implies build = new" is
+**false**, and correctly so. A second apply runs `make clean` and wipes the
+build tree while the previously installed binary stays in place. That is
+expected behaviour, not a defect — the first version of this spec asserted it
+and TLC was right to reject it.
+
+## Fixed
+
+### 1. The check FSM was a one-way ratchet — `RecheckAlwaysPossible`
+
+`check_state` moves `0 → 1 → 2` and **never returns to 0**. The only writes are
+`:89` (=2), `:100` (=1), `:106` (=0, only on `pthread_create` failure) and
+`:127` (=2). `updater_check_async` requires state 0 to start (`:99`).
+
+So `/api/check-update` (`web_server.c:1624`) was inert after the first call for
+the life of the process. Worse when the **first** check failed: `:90` clears
+`latest_version`, so the phone reported "no update known" permanently and only a
+daemon restart cleared it. A phone that booted with the network down never
+learned about an update again.
+
+**Fixed**: the guard is now `check_state != 1` — start a check unless one is
+already running. `check_state` stays 2 after completion so the last known
+version keeps being reported while a re-check runs.
+
+Stated as `ENABLED CheckStart` rather than a bad-state predicate, because the
+harm here is the *absence of a possible action*, not a state you can point at.
+
+### 2. "Update applied successfully" was reported without checking — `StatusHonest`
+
+`updater.c:273` calls `run_command("sudo systemctl restart daemon.service")`
+and **discards the return code**, then `:276` sets the status to
+`"Update applied successfully"` unconditionally. If the restart failed, the
+dashboard showed success while the old binary kept running. Every other step in
+the pipeline checked its return code; this one did not.
+
+**Fixed**: the return code is checked and the status reports
+`"Error: installed, but daemon restart failed"`. On success systemd kills the
+process before that line runs, so reaching it at all means the restart did not
+take.
+
+## Open findings (`make ota-check-open`)
+
+### 3. A failed build strands the tree — `NoStrandedTree` (3 steps)
+
+Step 2 is `make clean && make daemon` (`:250`). `make clean` runs first and
+unconditionally, and step 1 has already moved the working tree to the new
+commit. A build failure therefore leaves **new source with no binary**, and
+nothing records the previous commit to return to. There is no rollback at any
+step of the pipeline.
+
+### 4. The restart ignores call state — `NoRestartMidCall` (6 steps)
+
+Nothing in the update path consults `web_server_is_in_call()` (`web_server.h:148`)
+or `daemon_state->current_state`. An OTA applied while someone is on the phone
+drops the call with no warning. Coins are not lost (see above), but the call is.
+
+## Fixing
+
+Items 3 and 4 are policy decisions, which is why they are not applied. Rollback would mean recording the pre-update
+commit and restoring it on failure. Call-awareness would mean either refusing
+the update while `CALL_ACTIVE` or deferring it until the call ends — the latter
+needs somewhere to park the request.
+
+Items 1 and 2 are fixed in `updater.c` and their properties are now checked by
+`make ota-check`.

--- a/host/simulator.c
+++ b/host/simulator.c
@@ -329,6 +329,13 @@ static void sim_handle_hook(hook_state_change_event_t *ev) {
     hook_up   = (hook_state_change_event_get_direction(ev) == 'U');
     hook_down = (hook_state_change_event_get_direction(ev) == 'D');
 
+    /* mirror daemon.c: physical handset position is ground truth */
+    if (hook_up) {
+        daemon_state->handset_up = 1;
+    } else if (hook_down) {
+        daemon_state->handset_up = 0;
+    }
+
     if (hook_up) {
         if (daemon_state->current_state == DAEMON_STATE_CALL_INCOMING) {
             daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
@@ -388,10 +395,14 @@ static void sim_handle_call_state(call_state_event_t *ev) {
         call_metrics_ringing_started();  /* mirror daemon.c: ring started */
         daemon_state_update_activity(daemon_state);
     } else if (st == EVENT_CALL_STATE_ACTIVE) {
-        daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
-        daemon_state_update_activity(daemon_state);
-        call_metrics_ringing_answered();  /* mirror daemon.c: SIP-side answer */
-        call_metrics_started();  /* mirror daemon.c: call established */
+        /* mirror daemon.c: guard on the physical handset, not current_state --
+         * CALL_INCOMING is reachable both on-hook and off-hook (#92) */
+        if (daemon_state->handset_up) {
+            daemon_state->current_state = DAEMON_STATE_CALL_ACTIVE;
+            daemon_state_update_activity(daemon_state);
+            call_metrics_ringing_answered();  /* mirror daemon.c: SIP-side answer */
+            call_metrics_started();  /* mirror daemon.c: call established */
+        }
     } else if (st == EVENT_CALL_STATE_INVALID) {
         /* #90: Remote hung up */
         if (daemon_state->current_state == DAEMON_STATE_CALL_ACTIVE ||
@@ -408,7 +419,9 @@ static void sim_handle_call_state(call_state_event_t *ev) {
                  * refund -- mirror daemon.c (which does NOT clear here). */
             }
             daemon_state_clear_keypad(daemon_state);
-            daemon_state->current_state = DAEMON_STATE_IDLE_UP;
+            /* mirror daemon.c: land in the idle state matching the handset */
+            daemon_state->current_state = daemon_state->handset_up
+                    ? DAEMON_STATE_IDLE_UP : DAEMON_STATE_IDLE_DOWN;
             daemon_state_update_activity(daemon_state);
             sim_call_active = 0;
         }
@@ -808,6 +821,9 @@ static int run_scenario(const char *path) {
             if (state_persistence_load(&ps, arg) == 0) {
                 daemon_state->inserted_cents = ps.inserted_cents;
                 daemon_state->current_state = (daemon_state_t)ps.last_state;
+                /* mirror daemon.c: derive the handset from the restored state */
+                daemon_state->handset_up =
+                        (ps.last_state == (int)DAEMON_STATE_IDLE_UP);
                 if (strlen(ps.active_plugin) > 0) {
                     plugins_activate(ps.active_plugin);
                 }

--- a/host/tests/CoinLedger.cfg
+++ b/host/tests/CoinLedger.cfg
@@ -1,0 +1,23 @@
+\* TLC configuration -- the properties that HOLD.  `make coin-check`
+\*
+\* Cost = 50 matches the default call.cost_cents in daemon.conf.example.
+\*
+\* MaxEvents = 7, NOT 5. At 5 the model reports no EndCallTimeout violation,
+\* because reaching it needs leftover change after a paid call: lift, three
+\* coins, charge, end -- seven actions. A bound is not a proof, and this one
+\* hid a real divergence path until it was raised.
+\*
+\* The ledger-divergence properties live in CoinLedgerDrift.cfg.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Cost       = 50
+    CoinValues = {5, 10, 25}
+    MaxEvents  = 7
+
+INVARIANT
+    TypeOK
+    NonNegative
+
+CHECK_DEADLOCK FALSE

--- a/host/tests/CoinLedger.tla
+++ b/host/tests/CoinLedger.tla
@@ -1,0 +1,213 @@
+----------------------------- MODULE CoinLedger -----------------------------
+(***************************************************************************)
+(* TLA+ model of coin accounting across the daemon's THREE ledgers.        *)
+(*                                                                         *)
+(* The same balance is stored in three places, mutated by different code   *)
+(* paths that do not all notify each other:                                *)
+(*                                                                         *)
+(*   dcents -- daemon_state->inserted_cents        (daemon_state.h:18)     *)
+(*   pcents -- classic_phone_data.inserted_cents   (classic_phone.c:18)    *)
+(*   fcents -- persisted_state_t.inserted_cents    (state_persistence.h:8) *)
+(*                                                                         *)
+(* The only sync channel between the first two is                          *)
+(* plugins_adjust_inserted_cents (daemon.c:102-110, added by #109), and it *)
+(* is called from exactly two sites in classic_phone.c -- the charge (:396)*)
+(* and the refund (:190). Every other write to either ledger is unilateral.*)
+(*                                                                         *)
+(* SCOPE -- what this deliberately does NOT model:                         *)
+(*                                                                         *)
+(* Physical coin custody. Conservation against real money would need the   *)
+(* meaning of the validator's 'c' / 'z' commands, and docs/COIN_VALIDATOR.md*)
+(* documents those with a question mark ("commit/execute (sequence         *)
+(* terminator?)") and an explicitly unmitigated reconnect race. Modelling   *)
+(* them would mean inventing semantics. The three software ledgers above    *)
+(* are fully determined by code, so that is what is checked here.          *)
+(***************************************************************************)
+EXTENDS Naturals, Sequences
+
+CONSTANTS
+    Cost,        \* call.cost_cents (config); 50 in the default config
+    CoinValues,  \* denominations the daemon credits (daemon.c:316-322)
+    MaxEvents    \* bound on actions, to keep the state space finite
+
+VARIABLES
+    state,    \* phone state, restricted to what the coin paths care about
+    dcents,   \* the daemon ledger
+    pcents,   \* the Classic Phone plugin ledger
+    fcents,   \* the persisted file
+    budget
+
+vars == <<state, dcents, pcents, fcents, budget>>
+
+Max(a, b) == IF a > b THEN a ELSE b
+
+Init ==
+    /\ state  = "IDLE_DOWN"
+    /\ dcents = 0
+    /\ pcents = 0
+    /\ fcents = 0
+    /\ budget = MaxEvents
+
+-----------------------------------------------------------------------------
+(***************************************************************************)
+(* Actions. Each mirrors one code path; the comment gives the site and,     *)
+(* crucially, WHICH ledgers that path touches.                              *)
+(***************************************************************************)
+
+(* Handset lifted. daemon.c:492 zeroes the daemon ledger; classic_phone.c:142
+   zeroes the plugin ledger. BOTH -- consistent. *)
+HookUp ==
+    /\ budget > 0
+    /\ state = "IDLE_DOWN"
+    /\ state'  = "IDLE_UP"
+    /\ dcents' = 0
+    /\ pcents' = 0
+    /\ UNCHANGED fcents
+    /\ budget' = budget - 1
+
+(* Handset replaced. daemon.c:507 and classic_phone.c:153. BOTH -- consistent. *)
+HookDown ==
+    /\ budget > 0
+    /\ state # "IDLE_DOWN"
+    /\ state'  = "IDLE_DOWN"
+    /\ dcents' = 0
+    /\ pcents' = 0
+    /\ UNCHANGED fcents
+    /\ budget' = budget - 1
+
+(* A coin drops. daemon.c:328 credits the daemon ledger under the mutex, then
+   plugins_handle_coin -> classic_phone.c:63 credits the plugin ledger. Both
+   gate on IDLE_UP (daemon.c:213 / classic_phone.c:61). BOTH -- consistent. *)
+Coin ==
+    /\ budget > 0
+    /\ state = "IDLE_UP"
+    /\ \E v \in CoinValues :
+         /\ dcents' = dcents + v
+         /\ pcents' = pcents + v
+    /\ UNCHANGED <<state, fcents>>
+    /\ budget' = budget - 1
+
+(* Web dashboard "return coins". daemon.c:800-819 zeroes the DAEMON ledger and
+   bumps the coin_returns / coins_returned_cents metrics -- and never touches
+   the plugin. The plugin still believes the money is there. ONE LEDGER. *)
+CoinReturn ==
+    /\ budget > 0
+    /\ dcents' = 0
+    /\ UNCHANGED <<state, pcents, fcents>>
+    /\ budget' = budget - 1
+
+(* Classic Phone idle timeout. classic_phone.c:477 zeroes the PLUGIN ledger
+   from the tick handler. No event reaches the daemon, so daemon.c never
+   learns. ONE LEDGER, the other direction. *)
+IdleTimeout ==
+    /\ budget > 0
+    /\ state = "IDLE_UP"
+    /\ pcents' = 0
+    /\ UNCHANGED <<state, dcents, fcents>>
+    /\ budget' = budget - 1
+
+(* Dialling a paid call. classic_phone.c:395-396 debits the plugin ledger and
+   calls plugins_adjust_inserted_cents(-cost) to mirror it. SYNCED -- but note
+   the daemon side clamps at zero (daemon.c:107), so if the two ledgers have
+   already diverged the clamp silently absorbs the difference instead of
+   surfacing it. *)
+Charge ==
+    /\ budget > 0
+    /\ state = "IDLE_UP"
+    /\ pcents >= Cost                       \* classic_phone.c:334 gates on the plugin ledger
+    /\ pcents' = pcents - Cost
+    /\ dcents' = Max(0, dcents - Cost)      \* daemon.c:106-108, clamped
+    /\ state'  = "CALL_ACTIVE"
+    /\ UNCHANGED fcents
+    /\ budget' = budget - 1
+
+(* Call failed while dialling (#91). classic_phone.c:189-190 credits both. *)
+Refund ==
+    /\ budget > 0
+    /\ state = "CALL_ACTIVE"
+    /\ pcents' = pcents + Cost
+    /\ dcents' = dcents + Cost
+    /\ state'  = "IDLE_UP"
+    /\ UNCHANGED fcents
+    /\ budget' = budget - 1
+
+(* Call ends on the plugin's own timeout: classic_phone_end_call (:430) zeroes
+   the PLUGIN ledger. Reached from classic_phone_tick, which raises no daemon
+   event, so daemon.c keeps its balance. ONE LEDGER. *)
+EndCallTimeout ==
+    /\ budget > 0
+    /\ state = "CALL_ACTIVE"
+    /\ pcents' = 0
+    /\ state'  = "IDLE_UP"
+    /\ UNCHANGED <<dcents, fcents>>
+    /\ budget' = budget - 1
+
+(* daemon_save_state (daemon.c:223-237) snapshots the DAEMON ledger only. *)
+Save ==
+    /\ budget > 0
+    /\ fcents' = dcents
+    /\ UNCHANGED <<state, dcents, pcents>>
+    /\ budget' = budget - 1
+
+(* Restart + restore, daemon.c:1160-1185.
+   Boot order is: plugins_init() -> plugins_activate("Classic Phone") ->
+   classic_phone handle_activation (:246) copies daemon_state->inserted_cents
+   into the plugin ledger -- and only THEN is the persisted balance written
+   into daemon_state (:1171). So the plugin seeds from 0, not from the file.
+   daemon.c:1174 re-activates the persisted plugin afterwards, which would
+   re-seed it -- but only when the persisted plugin name is non-empty. *)
+RestartPluginNameEmpty ==
+    /\ budget > 0
+    /\ state'  = "IDLE_DOWN"
+    /\ dcents' = fcents      \* daemon ledger restored from the file
+    /\ pcents' = 0           \* plugin seeded from daemon_state while it was still 0
+    /\ UNCHANGED fcents
+    /\ budget' = budget - 1
+
+RestartPluginNameSet ==
+    /\ budget > 0
+    /\ state'  = "IDLE_DOWN"
+    /\ dcents' = fcents
+    /\ pcents' = fcents      \* re-activation at :1174 re-seeds from the restored value
+    /\ UNCHANGED fcents
+    /\ budget' = budget - 1
+
+Next ==
+    \/ HookUp \/ HookDown \/ Coin
+    \/ CoinReturn \/ IdleTimeout
+    \/ Charge \/ Refund \/ EndCallTimeout
+    \/ Save \/ RestartPluginNameEmpty \/ RestartPluginNameSet
+
+Spec == Init /\ [][Next]_vars
+
+-----------------------------------------------------------------------------
+(***************************************************************************)
+(* Properties.                                                             *)
+(***************************************************************************)
+
+TypeOK ==
+    /\ state  \in {"IDLE_DOWN", "IDLE_UP", "CALL_ACTIVE"}
+    /\ dcents \in Nat
+    /\ pcents \in Nat
+    /\ fcents \in Nat
+    /\ budget \in 0..MaxEvents
+
+NonNegative == dcents >= 0 /\ pcents >= 0 /\ fcents >= 0
+
+(* THE property. The daemon ledger is what the web API, the metrics gauge and
+   the persisted file all report; the plugin ledger is what the customer sees
+   on the VFD ("Have: 50c", classic_phone.c:298) and what actually gates
+   dialling (:334). If they disagree, the phone is lying to somebody -- either
+   the display promises credit the daemon will not honour, or the operator's
+   revenue figures do not match what the customer was charged. *)
+LedgerAgreement == dcents = pcents
+
+(* Weaker fallback: even if the exact figures drift, the customer should never
+   be shown MORE credit than the daemon will actually honour. *)
+NeverPromiseMoreThanHeld == pcents <= dcents
+
+(* A restart must not resurrect credit that was already spent or returned, nor
+   silently destroy credit the customer still has. *)
+PersistenceFaithful == fcents = 0 \/ fcents = dcents
+
+=============================================================================

--- a/host/tests/CoinLedgerDrift.cfg
+++ b/host/tests/CoinLedgerDrift.cfg
@@ -1,0 +1,55 @@
+\* TLC configuration -- the ledger-divergence properties. Expected to FAIL.
+\* `make coin-check-drift`
+\*
+\* This is not a broken config. dcents (daemon), pcents (Classic Phone) and
+\* fcents (persisted file) hold the same balance, but only two code paths sync
+\* the first two -- the charge (classic_phone.c:396) and the refund (:190), both
+\* via plugins_adjust_inserted_cents (#109). Every other write is unilateral.
+\*
+\* Four independent divergence paths, each found as a separate counterexample:
+\*
+\*   1. CoinReturn      daemon.c:800-819 zeroes the DAEMON ledger and bumps the
+\*                      revenue metrics; the plugin keeps its balance and the
+\*                      VFD keeps offering credit the daemon will not honour.
+\*                      (3 steps -- shortest.)
+\*   2. IdleTimeout     classic_phone.c:477 zeroes the PLUGIN ledger from the
+\*                      tick handler. No event reaches the daemon, so the daemon
+\*                      ledger, the persisted file and the metrics gauge all
+\*                      keep phantom credit. (3 steps.)
+\*   3. Boot ordering   daemon.c:1160-1174: plugins_init() activates Classic
+\*                      Phone, whose handle_activation (classic_phone.c:246)
+\*                      seeds its ledger from daemon_state->inserted_cents --
+\*                      which is still 0, because the persisted balance is not
+\*                      written until :1171. The re-activation at :1174 repairs
+\*                      this ONLY when the persisted plugin name is non-empty.
+\*                      (4 steps.)
+\*   4. EndCallTimeout  classic_phone_end_call (:430) zeroes the PLUGIN ledger
+\*                      on the plugin's own call timeout, raising no daemon
+\*                      event. Any leftover change diverges. (7 steps -- needs
+\*                      a balance above the call cost, which is why a bound of
+\*                      5 misses it entirely.)
+\*
+\* Direction matters when picking a fix:
+\*   pcents > dcents (path 1) -- the phone promises the customer credit that is
+\*                              already gone.
+\*   dcents > pcents (2,3,4) -- the daemon, the persisted file and the operator's
+\*                              revenue figures carry credit the customer cannot
+\*                              spend, and a restart can resurrect it.
+\*
+\* Note the clamp at daemon.c:107 (`if (inserted_cents < 0) inserted_cents = 0`)
+\* MASKS rather than prevents this: once the ledgers drift, a charge silently
+\* absorbs the difference instead of surfacing it.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Cost       = 50
+    CoinValues = {5, 10, 25}
+    MaxEvents  = 7
+
+INVARIANT
+    LedgerAgreement
+    NeverPromiseMoreThanHeld
+    PersistenceFaithful
+
+CHECK_DEADLOCK FALSE

--- a/host/tests/EventOrdering.cfg
+++ b/host/tests/EventOrdering.cfg
@@ -1,0 +1,29 @@
+\* TLC configuration -- the properties that HOLD.  `make tla-check`
+\*
+\* MaxEvents = 5 explores 3449 distinct states in ~25s. The model is a
+\* bounded-producer FIFO, so every interesting ordering shows up at small
+\* depth; raising the bound costs time without finding anything new.
+\*
+\* CHECK_DEADLOCK is off because "no successor state" here only means the
+\* producers ran out of budget -- normal termination, not a real deadlock.
+\*
+\* All six invariants now hold. Three of them (SettledNotActiveOnHook,
+\* Converged, ActiveImpliesOffHook) failed until daemon_state_data_t grew a
+\* handset_up field; EventOrderingRace.cfg is kept as the regression config
+\* that reproduces the original counterexamples.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    MaxEvents  = 5
+    CoinValues = {5, 10, 25}
+
+INVARIANT
+    TypeOK
+    NoInvalidState
+    NonNegative
+    DownImpliesNoCredit
+    SettledNotActiveOnHook
+    Converged
+
+CHECK_DEADLOCK FALSE

--- a/host/tests/EventOrdering.tla
+++ b/host/tests/EventOrdering.tla
@@ -1,0 +1,252 @@
+--------------------------- MODULE EventOrdering ---------------------------
+(***************************************************************************)
+(* TLA+ model of concurrent event ordering in the Millennium daemon.       *)
+(*                                                                         *)
+(* This discharges the hand-written case analysis in docs/EVENT_ORDERING.md *)
+(* (#100), which walks *two* interleavings of *two* events and concludes    *)
+(* "idempotent -- redundant but safe". Here we check *all* interleavings of *)
+(* every event type, over the two producers that genuinely race.           *)
+(*                                                                         *)
+(* Relationship to the existing proofs:                                    *)
+(*                                                                         *)
+(*   tests/cbmc_state_machine.c (make state-check) verifies ONE transition  *)
+(*     in isolation, sequentially. It cannot express two events in flight,  *)
+(*     so no interleaving property is reachable from it.                    *)
+(*   tests/protocol.pml (make model-check) models the wire framing below    *)
+(*     this layer -- one opcode, one direction.                             *)
+(*                                                                         *)
+(* Step() below is deliberately a faithful transcription of the same        *)
+(* transitions cbmc_state_machine.c models, so the two stay comparable.     *)
+(*                                                                         *)
+(* CONCURRENCY MODEL -- why this shape:                                     *)
+(*                                                                         *)
+(* Handler *bodies* do not run concurrently. daemon.c:1179 holds            *)
+(* engine_mutex across the whole engine step, and web control commands go   *)
+(* through send_control_command (daemon.c:589) which takes the same mutex.  *)
+(* The main loop dequeues exactly ONE event per iteration (daemon.c:1183).  *)
+(* So handlers are atomic with respect to each other.                       *)
+(*                                                                         *)
+(* What is NOT serialized is event *production*. Two independent producers  *)
+(* push into one queue (millennium_sdk.c:46):                               *)
+(*                                                                         *)
+(*   - the serial/Arduino path (hook, coin), read by the main loop          *)
+(*   - the PJSUA worker thread (call state), via sip_event_cb               *)
+(*     (millennium_sdk.c:169)                                               *)
+(*                                                                         *)
+(* Their relative order is decided by whichever thread wins g_queue_mutex.  *)
+(* That -- not concurrent handler execution -- is the whole race surface.   *)
+(*                                                                         *)
+(* KEY MODELING DECISION: `hook` is the *physical* handset position, kept   *)
+(* separate from `state`, which is only the daemon's *belief*. The daemon's *)
+(* 5-state enum conflates handset position with call progress, so the two   *)
+(* can silently disagree. Splitting them is what makes the disagreement     *)
+(* statable as an invariant.                                                *)
+(***************************************************************************)
+EXTENDS Naturals, Sequences
+
+CONSTANTS
+    MaxEvents,   \* bound on total events produced (keeps the state space finite)
+    CoinValues   \* coin denominations in cents; daemon.c:316-322 maps to {5,10,25}
+
+VARIABLES
+    hook,     \* physical handset: "up" | "down"  (ground truth)
+    dhook,    \* daemon_state->handset_up -- the daemon's *belief* about the
+              \* handset, updated only when a hook event is DISPATCHED
+    sipcall,  \* the SIP stack's own view of the call (pjsip_interface.c g_call_id)
+    state,    \* daemon_state->current_state       (the daemon's belief)
+    cents,    \* daemon_state->inserted_cents
+    queue,    \* the SDK event queue (FIFO, millennium_sdk.c:46-63)
+    budget    \* remaining events a producer may emit
+
+vars == <<hook, dhook, sipcall, state, cents, queue, budget>>
+
+States == {"INVALID", "IDLE_DOWN", "IDLE_UP", "CALL_INCOMING", "CALL_ACTIVE"}
+
+SipEventTypes == {"call_incoming", "call_active", "call_invalid"}
+
+Coin(v) == [type |-> "coin",  val |-> v]
+Ev(t)   == [type |-> t,       val |-> 0]
+
+-----------------------------------------------------------------------------
+(***************************************************************************)
+(* The transition function.                                                *)
+(*                                                                         *)
+(* Transcribed from daemon.c:                                              *)
+(*   coin          -> handle_coin_event        daemon.c:324-345            *)
+(*   hook_up/down  -> handle_hook_event        daemon.c:468-514            *)
+(*   call_*        -> handle_call_state_event  daemon.c:370-424            *)
+(*                                                                         *)
+(* Returns <<state', cents'>>.                                             *)
+(***************************************************************************)
+Step(s, c, h, e) ==
+    CASE e.type = "coin" ->
+            \* daemon.c:326 gates credit on is_phone_ready_for_operation(),
+            \* which is exactly `state == IDLE_UP` (daemon.c:213).
+            IF s = "IDLE_UP" THEN <<s, c + e.val, h>> ELSE <<s, c, h>>
+
+      [] e.type = "hook_up" ->
+            \* daemon.c records handset_up here, on dispatch.
+            IF   s = "CALL_INCOMING" THEN <<"CALL_ACTIVE", c, "up">>   \* answer, daemon.c:476
+            ELSE IF s = "IDLE_DOWN"  THEN <<"IDLE_UP", 0, "up">>       \* lift,   daemon.c:485
+            ELSE <<s, c, "up">>
+
+      [] e.type = "hook_down" ->
+            <<"IDLE_DOWN", 0, "down">>                                 \* daemon.c:497-513
+
+      [] e.type = "call_incoming" ->
+            \* #92: accept a ring with the handset either down or up.
+            IF s \in {"IDLE_DOWN", "IDLE_UP"} THEN <<"CALL_INCOMING", c, h>> ELSE <<s, c, h>>
+
+      [] e.type = "call_active" ->
+            \* daemon.c:387. Guarded on handset_up, not current_state:
+            \* CALL_INCOMING is reachable both on-hook and off-hook (#92), so no
+            \* current_state test can separate them. This guard is why the daemon
+            \* grew a handset_up field -- it was added because of this spec.
+            IF h = "up" THEN <<"CALL_ACTIVE", c, h>> ELSE <<s, c, h>>
+
+      [] e.type = "call_invalid" ->
+            \* Return to whichever idle state matches the handset: a call ending
+            \* while the handset is cradled lands in IDLE_DOWN, not IDLE_UP.
+            LET idle == IF h = "up" THEN "IDLE_UP" ELSE "IDLE_DOWN" IN
+            IF   s = "CALL_ACTIVE"      THEN <<idle, 0, h>>   \* daemon.c:402, coins cleared
+            ELSE IF s = "CALL_INCOMING" THEN <<idle, c, h>>   \* #91: coins PRESERVED, daemon.c:411
+            ELSE <<s, c, h>>                                  \* idempotent no-op
+
+      [] OTHER -> <<s, c, h>>
+
+-----------------------------------------------------------------------------
+
+Init ==
+    /\ hook    = "down"
+    /\ dhook   = "down"
+    /\ sipcall = "none"
+    /\ state   = "IDLE_DOWN"     \* daemon_state.c:10
+    /\ cents   = 0
+    /\ queue   = <<>>
+    /\ budget  = MaxEvents
+
+(* The user moves the handset. Physical position changes immediately; the
+   daemon only learns when the event is dequeued. Firmware emits only on a
+   real transition (keypad.ino:164-187), hence d # hook. *)
+ProduceHook ==
+    /\ budget > 0
+    /\ \E d \in {"up", "down"} :
+         /\ d # hook
+         /\ hook'  = d
+         /\ queue' = Append(queue, Ev(IF d = "up" THEN "hook_up" ELSE "hook_down"))
+    /\ budget' = budget - 1
+    /\ UNCHANGED <<dhook, sipcall, state, cents>>
+
+(* A coin drops. The validator is only armed off-hook (daemon.c:526 sends 'a'
+   on the IDLE_UP transition), so physically this needs the handset up. *)
+ProduceCoin ==
+    /\ budget > 0
+    /\ hook = "up"
+    /\ \E v \in CoinValues : queue' = Append(queue, Coin(v))
+    /\ budget' = budget - 1
+    /\ UNCHANGED <<hook, dhook, sipcall, state, cents>>
+
+(* The PJSUA worker thread pushes a call-state event (millennium_sdk.c:169).
+   `sipcall` constrains this to a CAUSALLY HONEST SIP stack: it can only report
+   ESTABLISHED for a call that was actually ringing, and only report CLOSED for
+   a call that exists. Without this, TLC finds a trivial counterexample (a
+   spurious CALL_ESTABLISHED out of nowhere) that is fair to dismiss as "the
+   SIP stack would never do that". With it, any violation TLC reports is a
+   genuine ordering race between two well-behaved producers. *)
+ProduceSip ==
+    /\ budget > 0
+    /\ \E t \in SipEventTypes :
+         /\ CASE t = "call_incoming" -> sipcall  = "none"
+              [] t = "call_active"   -> sipcall  = "ringing"
+              [] OTHER               -> sipcall # "none"
+         /\ sipcall' = CASE t = "call_incoming" -> "ringing"
+                         [] t = "call_active"   -> "up"
+                         [] OTHER               -> "none"
+         /\ queue' = Append(queue, Ev(t))
+    /\ budget' = budget - 1
+    /\ UNCHANGED <<hook, dhook, state, cents>>
+
+(* The main loop: dequeue exactly one event, apply its handler atomically
+   (daemon.c:1179-1187, all under engine_mutex). *)
+Dispatch ==
+    /\ queue # <<>>
+    /\ LET e == Head(queue)
+           r == Step(state, cents, dhook, e)
+       IN  /\ state' = r[1]
+           /\ cents' = r[2]
+           /\ dhook' = r[3]
+    /\ queue' = Tail(queue)
+    /\ UNCHANGED <<hook, sipcall, budget>>
+
+Next == ProduceHook \/ ProduceCoin \/ ProduceSip \/ Dispatch
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Dispatch)
+
+-----------------------------------------------------------------------------
+(***************************************************************************)
+(* Properties.                                                             *)
+(***************************************************************************)
+
+TypeOK ==
+    /\ hook    \in {"up", "down"}
+    /\ dhook   \in {"up", "down"}
+    /\ sipcall \in {"none", "ringing", "up"}
+    /\ state   \in States
+    /\ cents   \in Nat
+    /\ budget  \in 0..MaxEvents
+
+(* Already proven by CBMC for a single step; restated here to confirm they
+   survive arbitrary interleaving. Expected to HOLD. *)
+NoInvalidState == state # "INVALID"
+NonNegative    == cents >= 0
+
+(* Credit must never survive the handset going down (the coins were either
+   collected or returned by the 'c','z' pair at daemon.c:530-531). *)
+DownImpliesNoCredit == (state = "IDLE_DOWN") => (cents = 0)
+
+Quiesced == queue = <<>> /\ budget = 0
+
+(* EVENT_ORDERING.md's claim, formalized: once every queued event has been
+   processed, the daemon's belief agrees with physical reality. The doc argues
+   this by checking two orderings by hand; this checks all of them.
+
+   CALL_INCOMING is an accepted resting state with the handset down -- that is
+   just a phone ringing in its cradle, which #92 explicitly supports. What must
+   NOT survive is IDLE_UP or CALL_ACTIVE. *)
+Converged ==
+    Quiesced => (hook = "down" =>
+                    /\ state \in {"IDLE_DOWN", "CALL_INCOMING"}
+                    /\ cents = 0)
+
+(* The specific unrecoverable case the daemon.c:387 guard was added to fix: a
+   CALL_ESTABLISHED dispatched after the user already hung up used to leave the
+   phone parked in CALL_ACTIVE with the handset in the cradle, with nothing left
+   in the queue to recover it. Distinct from Converged, which also constrains
+   IDLE_UP and credit. *)
+SettledNotActiveOnHook == Quiesced => ~(hook = "down" /\ state = "CALL_ACTIVE")
+
+(* STRONGER, and still violated -- see EventOrderingRace.cfg.
+
+   The daemon should never believe a call is up while the handset is cradled:
+   audio plays to nobody and the far end is connected to a phone no one
+   answered. The guard at daemon.c:387 cannot fully establish this, because the
+   daemon's five-state enum CONFLATES ringing-on-hook with ringing-off-hook --
+   both are CALL_INCOMING (#92). So a SIP-side answer during an on-hook ring
+   still lands in CALL_ACTIVE with the handset down.
+
+   Unlike the case above this one is recoverable (hook_down settles it, and
+   hook_up is correctly a no-op from CALL_ACTIVE), so it is a phantom-answer
+   defect rather than a stuck state. Closing it properly needs the handset
+   position tracked as its own field in daemon_state_data_t rather than
+   inferred from current_state. *)
+ActiveImpliesOffHook == (state = "CALL_ACTIVE") => (hook = "up")
+
+(* NOTE deliberately NOT asserted as an invariant:
+     (state = "IDLE_UP") => (hook = "up")
+   This is violated *transiently* and that is by design -- it is exactly the
+   window EVENT_ORDERING.md calls "Order 2": CALL_INVALID lands first and moves
+   the daemon to IDLE_UP, then the queued hook_down arrives and settles it to
+   IDLE_DOWN. Converged is the right way to state that claim, because it only
+   constrains the settled state. *)
+
+=============================================================================

--- a/host/tests/EventOrderingRace.cfg
+++ b/host/tests/EventOrderingRace.cfg
@@ -1,0 +1,35 @@
+\* TLC configuration -- the one property that is NOT achievable by design.
+\* `make tla-check-race` (expected to report a violation)
+\*
+\* ActiveImpliesOffHook demands that the daemon is never in CALL_ACTIVE while
+\* the handset is *physically* cradled, checked at every instant. That cannot
+\* hold in an event-queue architecture, and it is not a bug: the handset moves,
+\* the firmware queues a hook event, and until the main loop dispatches it the
+\* daemon has not yet learned the handset moved. Any design with an event queue
+\* has this window.
+\*
+\* What matters is that the window always closes, and that IS verified in
+\* EventOrdering.cfg:
+\*
+\*   SettledNotActiveOnHook -- once the queue drains, never CALL_ACTIVE on-hook
+\*   Converged              -- once the queue drains, the daemon's belief agrees
+\*                             with the physical handset, no credit stranded
+\*
+\* Keep this config as documentation of where the boundary lies. Closing the
+\* instantaneous window would need the firmware to report hook position
+\* synchronously rather than as a queued event -- a hardware change, not a
+\* daemon one.
+\*
+\* HISTORICAL: before daemon_state_data_t gained handset_up, all three of these
+\* invariants failed, including the two settled ones.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    MaxEvents  = 5
+    CoinValues = {5, 10, 25}
+
+INVARIANT
+    ActiveImpliesOffHook
+
+CHECK_DEADLOCK FALSE

--- a/host/tests/Updater.cfg
+++ b/host/tests/Updater.cfg
@@ -1,0 +1,12 @@
+\* TLC configuration -- the properties that HOLD.  `make ota-check`
+SPECIFICATION Spec
+CONSTANTS
+    MaxEvents = 8
+    CallCost  = 50
+INVARIANT
+    TypeOK
+    NoInstallWithoutPull
+    RecheckAlwaysPossible
+    StatusHonest
+    NoCreditLostOnRestart
+CHECK_DEADLOCK FALSE

--- a/host/tests/Updater.tla
+++ b/host/tests/Updater.tla
@@ -1,0 +1,263 @@
+------------------------------ MODULE Updater ------------------------------
+(***************************************************************************)
+(* TLA+ model of the OTA updater: the check FSM, the four-step apply        *)
+(* pipeline, and what a restart does to an in-progress call and to escrowed *)
+(* coins.                                                                   *)
+(*                                                                          *)
+(* Source: host/updater.c. Two independent state variables with two         *)
+(* mutexes -- check_state (:12) and apply_state (:152).                      *)
+(*                                                                          *)
+(* Unlike EventOrdering.tla, the interesting properties here are not about   *)
+(* interleaving. They are about a multi-step pipeline that mutates durable   *)
+(* state (the git tree, the build output, the installed binary) with no      *)
+(* rollback, and reports success without checking whether the last step      *)
+(* worked.                                                                   *)
+(***************************************************************************)
+EXTENDS Naturals
+
+CONSTANTS MaxEvents, CallCost
+
+VARIABLES
+    check,     \* check_state: "idle" | "checking" | "checked"   (updater.c:12)
+    verKnown,  \* latest_version[0] != '\0'
+    apply,     \* apply_state: "idle" | "applying"                (updater.c:152)
+    src,       \* the git working tree: "old" | "new"
+    build,     \* build output: "old" | "wiped" | "new"  (make clean wipes it)
+    installed, \* what `make install` has put in place: "old" | "new"
+    running,   \* the binary systemd is actually running: "old" | "new"
+    status,    \* apply_status string, collapsed to its meaning
+    inCall,    \* daemon_state->current_state == CALL_ACTIVE
+    escrow,    \* daemon_state->inserted_cents
+    persisted, \* the persisted state file
+    budget
+
+vars == <<check, verKnown, apply, src, build, installed, running,
+          status, inCall, escrow, persisted, budget>>
+
+Init ==
+    /\ check     = "idle"
+    /\ verKnown  = FALSE
+    /\ apply     = "idle"
+    /\ src       = "old"
+    /\ build     = "old"
+    /\ installed = "old"
+    /\ running   = "old"
+    /\ status    = "none"
+    /\ inCall    = FALSE
+    /\ escrow    = 0
+    /\ persisted = 0
+    /\ budget    = MaxEvents
+
+Tick == budget > 0 /\ budget' = budget - 1
+
+-----------------------------------------------------------------------------
+(***************************************************************************)
+(* The check FSM -- updater_check_async, updater.c:96-110.                 *)
+(*                                                                          *)
+(*   if (check_state == 0) { check_state = 1; ... }                         *)
+(*                                                                          *)
+(* check_thread_func (:84-91) then sets check_state = 2. NOTHING anywhere   *)
+(* in updater.c sets it back to 0 -- grep confirms the only writes are      *)
+(* :89 (=2), :100 (=1), :106 (=0, the pthread_create failure path) and      *)
+(* :127 (=2). So the transition is a one-way ratchet.                        *)
+(***************************************************************************)
+
+CheckStart ==
+    /\ Tick
+    /\ check # "checking"                  \* updater.c:99 -- the guard (was `== "idle"`)
+    /\ check' = "checking"
+    /\ UNCHANGED <<verKnown, apply, src, build, installed, running,
+                   status, inCall, escrow, persisted>>
+
+CheckFinish ==
+    /\ Tick
+    /\ check = "checking"
+    /\ check' = "checked"
+    /\ \E ok \in {TRUE, FALSE} : verKnown' = ok   \* curl may fail (:44, :51, :57)
+    /\ UNCHANGED <<apply, src, build, installed, running,
+                   status, inCall, escrow, persisted>>
+
+-----------------------------------------------------------------------------
+(***************************************************************************)
+(* The apply pipeline -- updater_apply, updater.c:226-278. Four ordered     *)
+(* shell commands, each of which can fail. There is no rollback at any      *)
+(* step, and the return code of the LAST one is never checked (:273).       *)
+(***************************************************************************)
+
+ApplyStart ==
+    /\ Tick
+    /\ apply = "idle"
+    /\ apply'  = "applying"
+    /\ status' = "pulling"
+    /\ UNCHANGED <<check, verKnown, src, build, installed, running,
+                   inCall, escrow, persisted>>
+
+(* Step 1: git pull --ff-only. On failure the pipeline returns -1 with the
+   tree untouched -- this step alone is clean. *)
+PullOk ==
+    /\ Tick
+    /\ apply = "applying" /\ status = "pulling"
+    /\ src' = "new"
+    /\ status' = "building"
+    /\ UNCHANGED <<check, verKnown, apply, build, installed, running,
+                   inCall, escrow, persisted>>
+
+PullFail ==
+    /\ Tick
+    /\ apply = "applying" /\ status = "pulling"
+    /\ apply'  = "idle"
+    /\ status' = "err_pull"
+    /\ UNCHANGED <<check, verKnown, src, build, installed, running,
+                   inCall, escrow, persisted>>
+
+(* Step 2: `make clean && make daemon`. make clean runs FIRST and
+   unconditionally, so a build failure leaves no binary behind -- and the tree
+   is already at the new commit from step 1. *)
+BuildOk ==
+    /\ Tick
+    /\ apply = "applying" /\ status = "building"
+    /\ build'  = "new"
+    /\ status' = "installing"
+    /\ UNCHANGED <<check, verKnown, apply, src, installed, running,
+                   inCall, escrow, persisted>>
+
+BuildFail ==
+    /\ Tick
+    /\ apply = "applying" /\ status = "building"
+    /\ build'  = "wiped"          \* make clean already ran; make daemon did not finish
+    /\ apply'  = "idle"
+    /\ status' = "err_build"
+    /\ UNCHANGED <<check, verKnown, src, installed, running,
+                   inCall, escrow, persisted>>
+
+(* Step 3: sudo make install. *)
+InstallOk ==
+    /\ Tick
+    /\ apply = "applying" /\ status = "installing"
+    /\ installed' = "new"
+    /\ status'    = "restarting"
+    /\ UNCHANGED <<check, verKnown, apply, src, build, running,
+                   inCall, escrow, persisted>>
+
+InstallFail ==
+    /\ Tick
+    /\ apply = "applying" /\ status = "installing"
+    /\ apply'  = "idle"
+    /\ status' = "err_install"
+    /\ UNCHANGED <<check, verKnown, src, build, installed, running,
+                   inCall, escrow, persisted>>
+
+(* Step 4: sudo systemctl restart daemon.service.
+   updater.c:273 calls run_command WITHOUT checking its return value, then
+   unconditionally sets apply_status to "Update applied successfully" (:276).
+   Modelled faithfully: both outcomes lead to the same reported status.
+
+   The restart is also not coordinated with call state -- nothing in
+   web_server_handle_api_update consults web_server_is_in_call() or
+   daemon_state->current_state. *)
+RestartOk ==
+    /\ Tick
+    /\ apply = "applying" /\ status = "restarting"
+    /\ running'   = installed
+    /\ inCall'    = FALSE            \* the process dies; any call goes with it
+    /\ escrow'    = persisted        \* restored from the file at daemon.c:1171
+    /\ apply'     = "idle"
+    /\ status'    = "success"
+    /\ UNCHANGED <<check, verKnown, src, build, installed, persisted>>
+
+RestartFail ==
+    /\ Tick
+    /\ apply = "applying" /\ status = "restarting"
+    /\ apply'  = "idle"
+    /\ status' = "err_restart"       \* now checked -- updater.c:273
+    /\ UNCHANGED <<check, verKnown, src, build, installed, running,
+                   inCall, escrow, persisted>>
+
+-----------------------------------------------------------------------------
+(* Ordinary phone activity, so the restart has something to interrupt. *)
+
+InsertCoin ==
+    /\ Tick
+    /\ ~inCall
+    /\ escrow' = escrow + CallCost
+    /\ persisted' = escrow + CallCost      \* daemon_save_state after each coin
+    /\ UNCHANGED <<check, verKnown, apply, src, build, installed, running,
+                   status, inCall>>
+
+StartCall ==
+    /\ Tick
+    /\ ~inCall /\ escrow >= CallCost
+    /\ inCall' = TRUE
+    /\ UNCHANGED <<check, verKnown, apply, src, build, installed, running,
+                   status, escrow, persisted>>
+
+Next ==
+    \/ CheckStart \/ CheckFinish
+    \/ ApplyStart
+    \/ PullOk \/ PullFail
+    \/ BuildOk \/ BuildFail
+    \/ InstallOk \/ InstallFail
+    \/ RestartOk \/ RestartFail
+    \/ InsertCoin \/ StartCall
+
+Spec == Init /\ [][Next]_vars
+
+-----------------------------------------------------------------------------
+(***************************************************************************)
+(* Properties.                                                             *)
+(***************************************************************************)
+
+TypeOK ==
+    /\ check     \in {"idle", "checking", "checked"}
+    /\ apply     \in {"idle", "applying"}
+    /\ src       \in {"old", "new"}
+    /\ build     \in {"old", "wiped", "new"}
+    /\ installed \in {"old", "new"}
+    /\ running   \in {"old", "new"}
+    /\ verKnown  \in BOOLEAN
+    /\ inCall    \in BOOLEAN
+    /\ escrow    \in Nat
+    /\ persisted \in Nat
+    /\ budget    \in 0..MaxEvents
+
+(* Holds: nothing is ever installed without having been pulled first -- the
+   pipeline's step ordering is genuinely enforced by the status sequencing.
+
+   Note the weaker phrasing. The obvious invariant, "installed = new implies
+   build = new", is FALSE and correctly so: a second apply runs `make clean`
+   and wipes the build tree while the previously installed binary is still in
+   place. That is expected, not a defect. *)
+NoInstallWithoutPull == (installed = "new") => (src = "new")
+
+(* Holds: coins are saved after every insert, so a restart restores them. *)
+NoCreditLostOnRestart == escrow = persisted
+
+-----------------------------------------------------------------------------
+(* VIOLATED -- see UpdaterOpen.cfg.                                        *)
+
+(* A second update check must always be possible unless one is already running.
+   This is the property that caught the ratchet: check_state went 0 -> 1 -> 2
+   and never back, and updater_check_async required 0 to start, so after the
+   first check CheckStart was permanently disabled. Stated with ENABLED because
+   the harm is the absence of a possible action, not a bad state.
+
+   NOW HOLDS -- the guard is `check_state != 1`. *)
+RecheckAlwaysPossible ==
+    (budget > 0 /\ check # "checking") => ENABLED CheckStart
+
+(* "Update applied successfully" must mean the new binary is actually running.
+   updater.c:273 discards the systemctl exit code and :276 reports success
+   unconditionally. *)
+StatusHonest == (status = "success") => (running = installed)
+
+(* A failed apply must not leave the box in a mixed state. `make clean` runs
+   before `make daemon` (:250), and the tree is already at the new commit from
+   step 1, so a build failure strands new source with no binary and no record
+   of the previous commit to go back to. *)
+NoStrandedTree == (apply = "idle") => ~(src = "new" /\ build = "wiped")
+
+(* An OTA restart must not drop a call in progress. Nothing in the update path
+   consults call state. *)
+NoRestartMidCall == ~(status = "restarting" /\ inCall)
+
+=============================================================================

--- a/host/tests/UpdaterOpen.cfg
+++ b/host/tests/UpdaterOpen.cfg
@@ -1,0 +1,9 @@
+\* TLC configuration -- the properties that FAIL. `make ota-check-open`
+SPECIFICATION Spec
+CONSTANTS
+    MaxEvents = 8
+    CallCost  = 50
+INVARIANT
+    NoStrandedTree
+    NoRestartMidCall
+CHECK_DEADLOCK FALSE

--- a/host/tests/cbmc_state_machine.c
+++ b/host/tests/cbmc_state_machine.c
@@ -32,7 +32,11 @@
 #define EV_CALL_ACTIVE   4
 #define EV_CALL_INVALID  5
 
-typedef struct { int state; int balance; } S;
+/* `handset` mirrors daemon_state_data_t.handset_up: the physical handset
+ * position, tracked separately because CALL_INCOMING is reachable both on-hook
+ * and off-hook (#92), so current_state cannot stand in for it. Added after
+ * tests/EventOrdering.tla found the races; see docs/EVENT_ORDERING.md. */
+typedef struct { int state; int balance; int handset; } S;
 
 int nondet_int(void);
 
@@ -42,17 +46,22 @@ static S daemon_step(S s, int ev, int val) {
     if (ev == EV_COIN) {
         if (s.state == IDLE_UP) o.balance = s.balance + val;   /* credit only when up */
     } else if (ev == EV_HOOK_UP) {
+        o.handset = 1;                                         /* recorded on dispatch */
         if (s.state == CALL_INCOMING) o.state = CALL_ACTIVE;   /* answer */
         else if (s.state == IDLE_DOWN) { o.state = IDLE_UP; o.balance = 0; }
     } else if (ev == EV_HOOK_DOWN) {
+        o.handset = 0;
         o.state = IDLE_DOWN; o.balance = 0;
     } else if (ev == EV_CALL_INCOMING) {
         if (s.state == IDLE_DOWN || s.state == IDLE_UP) o.state = CALL_INCOMING;
     } else if (ev == EV_CALL_ACTIVE) {
-        o.state = CALL_ACTIVE;
+        /* Guarded on the handset, not the state: a CALL_ESTABLISHED arriving
+         * while the handset is cradled must not strand us in CALL_ACTIVE. */
+        if (s.handset) o.state = CALL_ACTIVE;
     } else if (ev == EV_CALL_INVALID) {
-        if (s.state == CALL_ACTIVE) { o.state = IDLE_UP; o.balance = 0; }
-        else if (s.state == CALL_INCOMING) { o.state = IDLE_UP; /* #91: keep coins */ }
+        /* Land in the idle state matching the handset, not always IDLE_UP. */
+        if (s.state == CALL_ACTIVE) { o.state = s.handset ? IDLE_UP : IDLE_DOWN; o.balance = 0; }
+        else if (s.state == CALL_INCOMING) { o.state = s.handset ? IDLE_UP : IDLE_DOWN; /* #91: keep coins */ }
     }
     return o;
 }
@@ -63,20 +72,24 @@ static S sim_step(S s, int ev, int val) {
     if (ev == EV_COIN) {
         if (s.state == IDLE_UP) o.balance = s.balance + val;
     } else if (ev == EV_HOOK_UP) {
+        o.handset = 1;
         if (s.state == CALL_INCOMING) o.state = CALL_ACTIVE;
         else if (s.state == IDLE_DOWN) { o.state = IDLE_UP; o.balance = 0; }
     } else if (ev == EV_HOOK_DOWN) {
+        o.handset = 0;
         o.state = IDLE_DOWN; o.balance = 0;
     } else if (ev == EV_CALL_INCOMING) {
         if (s.state == IDLE_DOWN || s.state == IDLE_UP) o.state = CALL_INCOMING;
     } else if (ev == EV_CALL_ACTIVE) {
-        o.state = CALL_ACTIVE;
+        /* Guarded on the handset, not the state: a CALL_ESTABLISHED arriving
+         * while the handset is cradled must not strand us in CALL_ACTIVE. */
+        if (s.handset) o.state = CALL_ACTIVE;
     } else if (ev == EV_CALL_INVALID) {
         /* Matches the daemon after the fix: clear only on an active call; a
          * failed-to-connect incoming keeps coins for the plugin to refund (#91).
          * (The original sim cleared coins for both, which CBMC equiv flagged.) */
-        if (s.state == CALL_ACTIVE) { o.state = IDLE_UP; o.balance = 0; }
-        else if (s.state == CALL_INCOMING) { o.state = IDLE_UP; }
+        if (s.state == CALL_ACTIVE) { o.state = s.handset ? IDLE_UP : IDLE_DOWN; o.balance = 0; }
+        else if (s.state == CALL_INCOMING) { o.state = s.handset ? IDLE_UP : IDLE_DOWN; }
     }
     return o;
 }
@@ -92,6 +105,15 @@ static void mk_input(S *in, int *ev, int *val) {
     __CPROVER_assume(in->balance >= 0 && in->balance <= 1000000);
     __CPROVER_assume(*ev >= EV_COIN && *ev <= EV_CALL_INVALID);
     __CPROVER_assume(*val >= 0 && *val <= 1000);   /* coin denominations are small positives */
+    in->handset = nondet_int();
+    __CPROVER_assume(in->handset == 0 || in->handset == 1);
+    /* CALL_ACTIVE with the handset cradled is not a reachable input -- assuming
+     * it here makes the CALL_ACTIVE check below an INDUCTIVE step: given a
+     * consistent state, one transition keeps it consistent. CBMC proves the
+     * step; tests/EventOrdering.tla proves the reachability side (that no
+     * interleaving of queued events can produce such a state in the first
+     * place). Neither tool covers both halves on its own. */
+    __CPROVER_assume(in->state != CALL_ACTIVE || in->handset);
 }
 
 void verify_invariants(void) {
@@ -104,6 +126,10 @@ void verify_invariants(void) {
                      "coins credit only in IDLE_UP");
     __CPROVER_assert(ev != EV_HOOK_DOWN || d.state == IDLE_DOWN,
                      "hook-down always returns to IDLE_DOWN");
+    /* The property EventOrdering.tla could only state once the handset became
+     * its own field: never CALL_ACTIVE while the handset is on the hook. */
+    __CPROVER_assert(d.state != CALL_ACTIVE || d.handset,
+                     "never CALL_ACTIVE with the handset on hook");
 }
 
 void verify_equiv(void) {
@@ -113,4 +139,5 @@ void verify_equiv(void) {
     s = sim_step(in, ev, val);
     __CPROVER_assert(d.state == s.state, "sim and daemon agree on next state");
     __CPROVER_assert(d.balance == s.balance, "sim and daemon agree on balance");
+    __CPROVER_assert(d.handset == s.handset, "sim and daemon agree on handset");
 }

--- a/host/tests/test_call_duration_metrics.scenario
+++ b/host/tests/test_call_duration_metrics.scenario
@@ -16,7 +16,11 @@ activate_plugin Number Guess
 call_incoming
 assert_state CALL_INCOMING
 call_ended
-assert_state IDLE_UP
+# The handset was never lifted, so the call ending returns to IDLE_DOWN,
+# not IDLE_UP. (Was IDLE_UP until the handset position became a tracked
+# field -- inferring it from current_state left the daemon believing the
+# handset was up while it sat in the cradle. See docs/EVENT_ORDERING.md.)
+assert_state IDLE_DOWN
 
 # 2) An incoming call answered by lifting the handset, then ended by the far
 #    end. Connected for 30 seconds.

--- a/host/tests/test_failed_call_metrics.scenario
+++ b/host/tests/test_failed_call_metrics.scenario
@@ -19,7 +19,11 @@ assert_state CALL_INCOMING
 # It rings out for 12 seconds (from the caller's side) and never connects.
 wait 12
 call_ended
-assert_state IDLE_UP
+# The handset was never lifted, so the call ending returns to IDLE_DOWN,
+# not IDLE_UP. (Was IDLE_UP until the handset position became a tracked
+# field -- inferring it from current_state left the daemon believing the
+# handset was up while it sat in the cradle. See docs/EVENT_ORDERING.md.)
+assert_state IDLE_DOWN
 
 # The attempt is counted as a failure, not a miss. (That no ring time is
 # recorded is proven in step 3: only the one genuine inbound ring lands in the
@@ -31,7 +35,7 @@ assert_counter calls_missed 0
 start_call
 assert_state CALL_INCOMING
 call_ended
-assert_state IDLE_UP
+assert_state IDLE_DOWN
 
 assert_counter calls_failed 2
 assert_counter calls_missed 0
@@ -42,7 +46,7 @@ call_incoming
 assert_state CALL_INCOMING
 wait 5
 call_ended
-assert_state IDLE_UP
+assert_state IDLE_DOWN
 
 assert_counter calls_missed 1
 assert_counter calls_failed 2

--- a/host/tests/test_missed_call_metrics.scenario
+++ b/host/tests/test_missed_call_metrics.scenario
@@ -18,7 +18,11 @@ call_incoming
 assert_state CALL_INCOMING
 wait 20
 call_ended
-assert_state IDLE_UP
+# The handset was never lifted, so the call ending returns to IDLE_DOWN,
+# not IDLE_UP. (Was IDLE_UP until the handset position became a tracked
+# field -- inferring it from current_state left the daemon believing the
+# handset was up while it sat in the cradle. See docs/EVENT_ORDERING.md.)
+assert_state IDLE_DOWN
 
 # One ring recorded (20s); one miss counted.
 assert_histogram call_ring_seconds 1 20
@@ -29,7 +33,7 @@ call_incoming
 assert_state CALL_INCOMING
 wait 10
 call_ended
-assert_state IDLE_UP
+assert_state IDLE_DOWN
 
 # Two rings recorded now (20 + 10 = 30s); two misses.
 assert_histogram call_ring_seconds 2 30

--- a/host/updater.c
+++ b/host/updater.c
@@ -96,7 +96,17 @@ static void *check_thread_func(void *arg) {
 void updater_check_async(void) {
     pthread_t th;
     pthread_mutex_lock(&check_mutex);
-    if (check_state == 0) {
+    /* Start a check unless one is already running. The guard used to be
+     * `check_state == 0`, but nothing ever set check_state back to 0, so the
+     * state machine ratcheted 0 -> 1 -> 2 and this endpoint went inert for the
+     * life of the process. That was worst when the FIRST check failed:
+     * check_thread_func clears latest_version, so the phone reported "no update
+     * known" until the daemon was restarted. Found by tests/Updater.tla
+     * (CheckNotStuck); see docs/OTA_UPDATE.md.
+     *
+     * check_state stays 2 after a completed check so updater_get_latest_version
+     * keeps reporting the last known version while a re-check runs. */
+    if (check_state != 1) {
         check_state = 1;
         pthread_mutex_unlock(&check_mutex);
         if (pthread_create(&th, NULL, check_thread_func, NULL) == 0) {
@@ -270,7 +280,18 @@ int updater_apply(const char *source_dir) {
     snprintf(apply_status, sizeof(apply_status), "Restarting daemon...");
     pthread_mutex_unlock(&apply_mutex);
     logger_info_with_category("Updater", "Restarting daemon via systemd");
-    run_command("sudo systemctl restart daemon.service");
+    /* Check this like every other step. On success systemd kills us before the
+     * next line runs, so reaching it at all means the restart did not take --
+     * reporting "applied successfully" there left the dashboard claiming the
+     * new build was live while the old binary kept running. Found by
+     * tests/Updater.tla (StatusHonest); see docs/OTA_UPDATE.md. */
+    if (run_command("sudo systemctl restart daemon.service") != 0) {
+        pthread_mutex_lock(&apply_mutex);
+        snprintf(apply_status, sizeof(apply_status),
+                 "Error: installed, but daemon restart failed");
+        pthread_mutex_unlock(&apply_mutex);
+        return -1;
+    }
 
     pthread_mutex_lock(&apply_mutex);
     snprintf(apply_status, sizeof(apply_status), "Update applied successfully");


### PR DESCRIPTION
Adds TLA+ model checking alongside the existing CBMC and SPIN work, and fixes what it found.

## Why TLA+ when the repo already has CBMC and SPIN

The existing proofs are strong but share a blind spot. `tests/cbmc_state_machine.c` verifies **one** transition, sequentially — it cannot express two events in flight. `tests/protocol.pml` models one opcode in one direction. Nothing covered **concurrent event interleaving with data**, which is exactly where `docs/EVENT_ORDERING.md` was reasoning by hand.

The division that emerged, and which the docs now state explicitly:

- **CBMC** proves the *inductive step* — given a consistent state, one transition preserves consistency, and `simulator.c` and `daemon.c` agree.
- **TLC** proves the *reachability* half — no interleaving of queued events can reach an inconsistent state in the first place.

Neither covers both halves alone. That is why the `CALL_ACTIVE` bug below survived: CBMC transcribed the unguarded arm faithfully for months and asserted nothing about it.

## Fixed

**Handset position was inferred, not tracked** (commit 1). `daemon_state_data_t` had no field for the handset, so the daemon derived it from `current_state` — unsound, because `CALL_INCOMING` is reachable both on-hook (ringing in the cradle) and off-hook (#92). Two attempts at a `current_state` guard were refuted by TLC before the real cause was clear. A `CALL_ESTABLISHED` arriving with the handset cradled left the daemon parked in `CALL_ACTIVE` with nothing to recover it; a `CALL_INVALID` ending an unanswered on-hook ring dropped to `IDLE_UP`. Now an explicit `handset_up` field, mirrored into `simulator.c` and the CBMC model.

**Two updater defects** (commit 3). `check_state` ratcheted `0 → 1 → 2` and never back, so `/api/check-update` went inert after the first call — worst if the *first* check failed, since a phone booting with the network down then never learns about an update again. And `updater_apply` discarded the `systemctl restart` exit code, reporting success while the old binary kept running.

## Filed rather than guessed

The coin-ledger divergences (#222, needs #223) and the two OTA policy items (#224, #225) are left open on purpose — collapsing the ledgers changes the plugin SDK contract, and rollback/call-awareness are product decisions, not defects.

## Review notes — two things worth your attention

**Six scenario assertions changed**, in `test_call_duration_metrics`, `test_failed_call_metrics` and `test_missed_call_metrics`. Each is a `call_ended` with **no preceding `hook_up`** that asserted `IDLE_UP`. I checked the command sequence in each file: the handset is never lifted, so `IDLE_DOWN` is correct and the assertions were encoding the bug. Changing tests to match new behaviour is normally a smell, so please sanity-check that reasoning.

**Three targets fail by design** and must not be wired into CI as-is: `tla-check-race`, `coin-check-drift`, `ota-check-open`. Each `.cfg` header explains what it documents and why it is not a broken config.

## Verification

| | |
|---|---|
| `make test` | all scenarios pass |
| `./unit_tests` | 117 passed, 0 failed |
| `make compile-check` | clean |
| `make state-check` (CBMC) | 0 of 112 failed, both functions |
| `make tla-check` | 6 invariants, 3389 states |
| `make coin-check` | 3316 states |
| `make ota-check` | 4 properties, 758 states |

Each of the three commits builds and passes tests independently.

The TLA+ targets need `tla2tools.jar` and a JRE, and follow the existing `SPIN ?=` / `CBMC ?=` convention:

```
make tla-check TLA_TOOLS=/path/to/tla2tools.jar
```

They are not part of `make test`, matching how `model-check` and `state-check` already work.

## A note on the process

Roughly half of what these specs caught was **my own spec being wrong**, not the code — an invariant that forbade a legitimate on-hook ring, one that conflated the build tree with the installed binary, and a guard that would have broken every outbound call had I not checked `test_basic_call.scenario` first. Each is documented in place so the wrong version does not get re-added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
