### PR TITLE
fix: updater status getter races (#227) and durable state save (#228)

### DIFF
--- a/host/state_persistence.c
+++ b/host/state_persistence.c
@@ -7,6 +7,8 @@
 #include <unistd.h>
 #include <ctype.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
 
 int state_persistence_save(const persisted_state_t *state, const char *filepath) {
     FILE *f;
@@ -39,6 +41,43 @@ int state_persistence_save(const persisted_state_t *state, const char *filepath)
         logger_warn_with_category("Persistence", "Failed to rename state file");
         remove(tmp_path);
         return -1;
+    }
+
+    /* Sync the parent directory so the rename itself is durable (#228).
+     * fsync on the file only makes its *contents* durable; the directory entry
+     * created by rename() is not, so a power cut here could roll the balance
+     * back to the previous file or leave the .tmp behind. The phone runs on
+     * mains with no UPS, so this is a routine event, not a corner case.
+     *
+     * Best-effort: a failure to sync the directory does not invalidate the
+     * write that already succeeded, so it is logged rather than returned. */
+    {
+        char dir_path[512];
+        char *slash;
+        int dfd;
+
+        strncpy(dir_path, filepath, sizeof(dir_path) - 1);
+        dir_path[sizeof(dir_path) - 1] = '\0';
+        slash = strrchr(dir_path, '/');
+        if (slash == dir_path) {
+            dir_path[1] = '\0';          /* file sits in "/" */
+        } else if (slash) {
+            *slash = '\0';
+        } else {
+            strcpy(dir_path, ".");       /* relative path, no directory part */
+        }
+
+        dfd = open(dir_path, O_RDONLY);
+        if (dfd >= 0) {
+            if (fsync(dfd) != 0) {
+                logger_warn_with_category("Persistence",
+                        "Failed to fsync state directory; save may not survive power loss");
+            }
+            close(dfd);
+        } else {
+            logger_warn_with_category("Persistence",
+                    "Failed to open state directory for fsync");
+        }
     }
 
     return 0;

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -1206,18 +1206,24 @@ static void test_version_compare_with_v_prefix(void) {
 }
 
 static void test_version_no_update_initially(void) {
+    char latest[64];
     TEST_ASSERT_EQ_INT(0, updater_is_update_available());
-    TEST_ASSERT_NULL((void *)updater_get_latest_version());
+    TEST_ASSERT_EQ_INT(0, updater_get_latest_version(latest, sizeof(latest)));
+    TEST_ASSERT_EQ_INT(0, (int)strlen(latest));   /* cleared, not left stale */
 }
 
 static void test_updater_apply_null_dir(void) {
+    char st[256];
     TEST_ASSERT_EQ_INT(-1, updater_apply(NULL));
-    TEST_ASSERT(strstr(updater_get_apply_status(), "no source") != NULL);
+    updater_get_apply_status(st, sizeof(st));
+    TEST_ASSERT(strstr(st, "no source") != NULL);
 }
 
 static void test_updater_apply_bad_dir(void) {
+    char st[256];
     TEST_ASSERT_EQ_INT(-1, updater_apply("/nonexistent/path/to/repo"));
-    TEST_ASSERT(strstr(updater_get_apply_status(), "git pull failed") != NULL);
+    updater_get_apply_status(st, sizeof(st));
+    TEST_ASSERT(strstr(st, "git pull failed") != NULL);
 }
 
 /* ── Card config tests ─────────────────────────────────────────── */

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -1636,6 +1636,42 @@ static void test_state_load_round_trip(void) {
     remove(path);
 }
 
+/* #228: the save path now derives the parent directory to fsync it. That
+ * derivation has three cases -- a normal path, a bare filename with no
+ * directory part, and a file directly in "/" -- and getting it wrong would
+ * break saving entirely. Exercise the two we can write to. */
+static void test_state_save_relative_path(void) {
+    const char *path = "millennium_state_rel.test";   /* no '/' at all */
+    persisted_state_t saved;
+    persisted_state_t loaded;
+
+    saved.inserted_cents = 25;
+    saved.last_state = (int)DAEMON_STATE_IDLE_DOWN;
+    strcpy(saved.active_plugin, "Number Guess");
+
+    TEST_ASSERT_EQ_INT(state_persistence_save(&saved, path), 0);
+    TEST_ASSERT_EQ_INT(state_persistence_load(&loaded, path), 0);
+    TEST_ASSERT_EQ_INT(loaded.inserted_cents, 25);
+    TEST_ASSERT_EQ_STR(loaded.active_plugin, "Number Guess");
+    remove(path);
+}
+
+static void test_state_save_nested_path(void) {
+    const char *path = "/tmp/millennium_state_nested.test";
+    persisted_state_t saved;
+    persisted_state_t loaded;
+
+    saved.inserted_cents = 50;
+    saved.last_state = (int)DAEMON_STATE_IDLE_UP;
+    strcpy(saved.active_plugin, "");
+
+    TEST_ASSERT_EQ_INT(state_persistence_save(&saved, path), 0);
+    TEST_ASSERT_EQ_INT(state_persistence_load(&loaded, path), 0);
+    TEST_ASSERT_EQ_INT(loaded.inserted_cents, 50);
+    TEST_ASSERT_EQ_STR(loaded.active_plugin, "");
+    remove(path);
+}
+
 static void test_state_load_absent_file_is_silent(void) {
     const char *path = "/tmp/millennium_state_absent.test";
     persisted_state_t ps;
@@ -2248,6 +2284,8 @@ int main(void) {
 
     TEST_SUITE_BEGIN("State Persistence");
     TEST_SUITE_RUN(test_state_load_round_trip);
+    TEST_SUITE_RUN(test_state_save_relative_path);
+    TEST_SUITE_RUN(test_state_save_nested_path);
     TEST_SUITE_RUN(test_state_load_absent_file_is_silent);
     TEST_SUITE_RUN(test_state_load_rejects_negative_cents);
     TEST_SUITE_RUN(test_state_load_rejects_huge_cents);

--- a/host/updater.c
+++ b/host/updater.c
@@ -149,8 +149,10 @@ int updater_get_latest_version(char *out, size_t out_size) {
     out[0] = '\0';
     pthread_mutex_lock(&check_mutex);
     if (check_state == 2 && latest_version[0]) {
-        strncpy(out, latest_version, out_size - 1);
-        out[out_size - 1] = '\0';
+        size_t n = strlen(latest_version);
+        if (n > out_size - 1) n = out_size - 1;
+        memcpy(out, latest_version, n);
+        out[n] = '\0';
         known = 1;
     }
     pthread_mutex_unlock(&check_mutex);
@@ -175,9 +177,17 @@ void updater_get_apply_status(char *out, size_t out_size) {
     pthread_mutex_lock(&apply_mutex);
     /* Copy while holding the lock. Returning apply_status itself only protected
      * the pointer read, not the buffer -- the caller then read it unlocked while
-     * updater_apply was snprintf-ing into it (#227). */
-    strncpy(out, apply_status, out_size - 1);
-    out[out_size - 1] = '\0';
+     * updater_apply was snprintf-ing into it (#227).
+     *
+     * memcpy with an explicit clamp rather than strncpy: when gcc inlines this
+     * into a caller whose buffer is the same size as the source, strncpy trips
+     * -Wstringop-truncation, and the build is -Werror. */
+    {
+        size_t n = strlen(apply_status);
+        if (n > out_size - 1) n = out_size - 1;
+        memcpy(out, apply_status, n);
+        out[n] = '\0';
+    }
     pthread_mutex_unlock(&apply_mutex);
 }
 

--- a/host/updater.c
+++ b/host/updater.c
@@ -67,8 +67,11 @@ static int do_check(void) {
     {
         const char *end = strchr(tag, '"');
         if (!end || (size_t)(end - tag) >= sizeof(latest_version)) return -1;
+        /* Under the lock: readers take check_mutex, so the write must too (#227). */
+        pthread_mutex_lock(&check_mutex);
         memcpy(latest_version, tag, (size_t)(end - tag));
         latest_version[end - tag] = '\0';
+        pthread_mutex_unlock(&check_mutex);
     }
 
     {
@@ -140,22 +143,26 @@ int updater_check(void) {
     return rc;
 }
 
-const char *updater_get_latest_version(void) {
-    const char *v = NULL;
+int updater_get_latest_version(char *out, size_t out_size) {
+    int known = 0;
+    if (!out || out_size == 0) return 0;
+    out[0] = '\0';
     pthread_mutex_lock(&check_mutex);
-    if (check_state == 2 && latest_version[0]) v = latest_version;
+    if (check_state == 2 && latest_version[0]) {
+        strncpy(out, latest_version, out_size - 1);
+        out[out_size - 1] = '\0';
+        known = 1;
+    }
     pthread_mutex_unlock(&check_mutex);
-    return v;
+    return known;
 }
 
 int updater_is_update_available(void) {
-    const char *lv;
-    int avail = 0;
-    pthread_mutex_lock(&check_mutex);
-    lv = (check_state == 2 && latest_version[0]) ? latest_version : NULL;
-    pthread_mutex_unlock(&check_mutex);
-    if (lv) avail = updater_compare_versions(lv, version_get_string()) > 0;
-    return avail;
+    char lv[64];
+    /* Compare against a copy, not the shared buffer: holding the pointer past
+     * the unlock had the same race as the getters (#227). */
+    if (!updater_get_latest_version(lv, sizeof(lv))) return 0;
+    return updater_compare_versions(lv, version_get_string()) > 0;
 }
 
 static char apply_status[256] = "No update attempted";
@@ -163,12 +170,15 @@ static int apply_state = 0;  /* 0=idle, 1=applying */
 static char apply_source_dir[512] = {0};
 static pthread_mutex_t apply_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-const char *updater_get_apply_status(void) {
-    const char *s;
+void updater_get_apply_status(char *out, size_t out_size) {
+    if (!out || out_size == 0) return;
     pthread_mutex_lock(&apply_mutex);
-    s = apply_status;
+    /* Copy while holding the lock. Returning apply_status itself only protected
+     * the pointer read, not the buffer -- the caller then read it unlocked while
+     * updater_apply was snprintf-ing into it (#227). */
+    strncpy(out, apply_status, out_size - 1);
+    out[out_size - 1] = '\0';
     pthread_mutex_unlock(&apply_mutex);
-    return s;
 }
 
 /* #118: Run apply in background; returns immediately. */

--- a/host/updater.h
+++ b/host/updater.h
@@ -1,6 +1,8 @@
 #ifndef UPDATER_H
 #define UPDATER_H
 
+#include <stddef.h>   /* size_t */
+
 /*
  * OTA update checker.
  * Compares the running version against the latest GitHub release tag.
@@ -24,7 +26,11 @@ void updater_check_async(void);
 int updater_is_checking(void);
 
 /* Returns the cached latest version string, or NULL if never checked. */
-const char *updater_get_latest_version(void);
+/* Copy the last known release tag into `out` (always NUL-terminated).
+ * Returns 1 if a version is known, 0 otherwise (out becomes ""). Copying under
+ * the lock is the point: returning the internal pointer let callers read the
+ * buffer while the check thread was writing it (#227). */
+int updater_get_latest_version(char *out, size_t out_size);
 
 /* Returns 1 if the latest version is newer than the running version. */
 int updater_is_update_available(void);
@@ -45,6 +51,8 @@ int updater_apply_async(const char *source_dir);
 int updater_is_applying(void);
 
 /* Get a human-readable status message from the last updater_apply call. */
-const char *updater_get_apply_status(void);
+/* Copy the current apply status into `out` (always NUL-terminated). Copying
+ * under the lock is the point -- see updater_get_latest_version (#227). */
+void updater_get_apply_status(char *out, size_t out_size);
 
 #endif /* UPDATER_H */

--- a/host/web_server.c
+++ b/host/web_server.c
@@ -1614,7 +1614,8 @@ struct http_response web_server_handle_api_version(const struct http_request* re
 struct http_response web_server_handle_api_check_update(const struct http_request* request) {
     struct http_response response;
     char json[512];
-    const char *latest;
+    char latest[64];
+    int have_latest;
     (void)request;
     memset(&response, 0, sizeof(response));
     web_server_strcpy_safe(response.content_type, "application/json", sizeof(response.content_type));
@@ -1622,13 +1623,13 @@ struct http_response web_server_handle_api_check_update(const struct http_reques
 
     /* #119: Non-blocking - don't block HTTP handler for curl timeout */
     updater_check_async();
-    latest = updater_get_latest_version();
+    have_latest = updater_get_latest_version(latest, sizeof(latest));
 
     snprintf(json, sizeof(json),
         "{\"current_version\":\"%s\",\"latest_version\":\"%s\","
         "\"update_available\":%s,\"checking\":%s,\"git_hash\":\"%s\"}",
         version_get_string(),
-        latest ? latest : (updater_is_checking() ? "" : "unknown"),
+        have_latest ? latest : (updater_is_checking() ? "" : "unknown"),
         updater_is_update_available() ? "true" : "false",
         updater_is_checking() ? "true" : "false",
         version_get_git_hash());
@@ -1639,6 +1640,7 @@ struct http_response web_server_handle_api_check_update(const struct http_reques
 struct http_response web_server_handle_api_update(const struct http_request* request) {
     struct http_response response;
     char json[512];
+    char apply_status[256];
     const char *source_dir;
     int rc;
     (void)request;
@@ -1654,10 +1656,11 @@ struct http_response web_server_handle_api_update(const struct http_request* req
             "{\"success\":true,\"status\":\"Applying update in background. Daemon will restart when complete.\",\"accepted\":true}");
         response.status_code = 202;  /* Accepted */
     } else {
+        updater_get_apply_status(apply_status, sizeof(apply_status));
         snprintf(json, sizeof(json),
             "{\"success\":%s,\"status\":\"%s\"}",
             rc == 0 ? "true" : "false",
-            updater_get_apply_status());
+            apply_status);
         response.status_code = rc == 0 ? 200 : 500;
     }
     web_server_strcpy_safe(response.body, json, sizeof(response.body));


### PR DESCRIPTION
Two independent fixes, both found while writing `tests/Updater.tla` in #233 but neither requiring the model to state.

## #227 — the lock protected the wrong thing

```c
const char *updater_get_apply_status(void) {
    pthread_mutex_lock(&apply_mutex);
    s = apply_status;          /* just the pointer */
    pthread_mutex_unlock(&apply_mutex);
    return s;                  /* caller reads the buffer with no lock */
}
```

The mutex guarded the pointer read, not the buffer. Callers dereferenced it while the apply thread was `snprintf`-ing into that same buffer at six sites, so a reader could see a torn string.

Both getters now copy into a caller-supplied buffer under the lock:

```c
void updater_get_apply_status(char *out, size_t out_size);
int  updater_get_latest_version(char *out, size_t out_size);
```

Two more instances of the same shape fixed alongside: `updater_is_update_available` held the pointer past the unlock, and `do_check` wrote `latest_version` with **no lock at all** while readers took `check_mutex`.

## #228 — `rename()` was not made durable

`state_persistence_save` did tmp → `fsync` → `rename`, which is the right pattern except that `fsync` makes the file's *contents* durable, not the directory entry `rename` creates. A power cut shortly after a save could revert the file to its previous contents or leave `.tmp` behind. The phone runs on mains with no UPS, so the practical effect is a coin balance silently reverting.

The parent directory is now fsynced after the rename, best-effort — failing to sync doesn't invalidate a write that already succeeded, so it logs rather than returning an error.

Deriving the directory has three cases (normal path, bare filename, file in `/`) and getting it wrong would break saving outright, so the two writable cases have tests.

## Verification

`make compile-check` clean · `./unit_tests` 119 passed, 0 failed (was 117) · `make test` all scenarios pass. Both commits build and pass independently.

## Note

`updater_get_latest_version` changed from returning `const char *`/NULL to returning `1`/`0` with an out-param. That's a breaking signature change, but the only callers are `web_server.c` and the unit tests, both updated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
