### PR TITLE
fix(#226): call handle_activation outside plugins_mutex

### DIFF
--- a/host/plugins.c
+++ b/host/plugins.c
@@ -117,33 +117,56 @@ static void plugins_record_activation(const char *name) {
 
 int plugins_activate(const char *plugin_name) {
     int i;
+    void (*activation)(void) = NULL;
+    int found = 0;
+
     if (!plugin_name) {
         logger_error_with_category("Plugins", "Plugin name required for activation");
         return -1;
     }
 
+    /* Look the plugin up and snapshot its activation handler under the lock,
+     * but CALL the handler after releasing it (#226).
+     *
+     * This is the same discipline plugins_snapshot_active() documents below:
+     * plugins_mutex is not recursive, so a handler that re-enters the registry
+     * -- plugins_activate, plugins_get_active_name, plugins_get_info,
+     * plugins_to_json -- would deadlock against itself. This function used to
+     * be the one place that broke that rule.
+     *
+     * The plugins[] table is a fixed static array whose entries are never moved
+     * or unregistered, so the snapshotted function pointer stays valid. */
     pthread_mutex_lock(&plugins_mutex);
-
-    /* Find the plugin */
     for (i = 0; i < plugin_count; i++) {
         if (strcmp(plugins[i].name, plugin_name) == 0) {
-            active_plugin_index = i;
-
-            /* Call the plugin's activation handler if it exists */
-            if (plugins[i].handle_activation) {
-                plugins[i].handle_activation();
-            }
-
-            logger_infof_with_category("Plugins", "Plugin %s activated", plugin_name);
-            pthread_mutex_unlock(&plugins_mutex);
-            plugins_record_activation(plugin_name);
-            return 0;
+            activation = plugins[i].handle_activation;
+            found = 1;
+            break;
         }
     }
-    
-    logger_warnf_with_category("Plugins", "Plugin %s not found", plugin_name);
     pthread_mutex_unlock(&plugins_mutex);
-    return -1;
+
+    if (!found) {
+        logger_warnf_with_category("Plugins", "Plugin %s not found", plugin_name);
+        return -1;
+    }
+
+    /* Initialize BEFORE publishing the new active index. The old code assigned
+     * active_plugin_index first and relied on holding plugins_mutex across the
+     * handler to keep dispatch out; dispatching unlocked, that order would let
+     * an event reach a half-initialized plugin. Publishing last means dispatch
+     * sees the previous plugin until the new one is ready. */
+    if (activation) {
+        activation();
+    }
+
+    pthread_mutex_lock(&plugins_mutex);
+    active_plugin_index = i;
+    pthread_mutex_unlock(&plugins_mutex);
+
+    logger_infof_with_category("Plugins", "Plugin %s activated", plugin_name);
+    plugins_record_activation(plugin_name);
+    return 0;
 }
 
 const char* plugins_get_active_name(void) {

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -605,6 +605,53 @@ static void test_plugins_register_custom(void) {
     plugins_cleanup();
 }
 
+/* #226 regression: plugins_activate used to call handle_activation while
+ * holding plugins_mutex, which is not recursive -- so a handler that touched
+ * the registry deadlocked against itself. This handler re-enters via
+ * plugins_get_active_name(), which is exactly what used to hang.
+ *
+ * It also pins the ordering: the new active index is published only AFTER the
+ * handler returns, so a handler still observes the PREVIOUS active plugin and
+ * can never be dispatched to while half-initialized.
+ *
+ * Note the failure mode if this regresses is a hang, not an assertion -- there
+ * is no way to test "does not deadlock" that fails fast. */
+static const char *g_name_seen_during_activation;
+static int g_reentrant_activation_ran;
+
+static void reentrant_activation_handler(void) {
+    const char *n = plugins_get_active_name();   /* would deadlock pre-#226 */
+    g_name_seen_during_activation = n ? n : "(none)";
+    g_reentrant_activation_ran = 1;
+}
+
+static void test_plugins_activation_handler_may_reenter_registry(void) {
+    daemon_state_data_t ds;
+    daemon_state_init(&ds);
+    daemon_state = &ds;
+    client = millennium_client_create();
+
+    plugins_init();   /* leaves "Classic Phone" active */
+    g_reentrant_activation_ran = 0;
+    g_name_seen_during_activation = NULL;
+
+    TEST_ASSERT_EQ_INT(plugins_register("Reentrant Plugin", "Re-enters on activate",
+        NULL, NULL, NULL, NULL, NULL, reentrant_activation_handler, NULL), 0);
+
+    TEST_ASSERT_EQ_INT(plugins_activate("Reentrant Plugin"), 0);
+    TEST_ASSERT_EQ_INT(g_reentrant_activation_ran, 1);
+
+    /* Published after the handler, so the handler saw the outgoing plugin. */
+    TEST_ASSERT_EQ_STR(g_name_seen_during_activation, "Classic Phone");
+    /* ...and the switch did take effect once the handler returned. */
+    TEST_ASSERT_EQ_STR(plugins_get_active_name(), "Reentrant Plugin");
+
+    millennium_client_destroy(client);
+    client = NULL;
+    daemon_state = NULL;
+    plugins_cleanup();
+}
+
 static void test_plugins_list(void) {
     daemon_state_data_t ds;
     char buf[1024];
@@ -2213,6 +2260,7 @@ int main(void) {
     TEST_SUITE_RUN(test_plugins_activation_metrics);
     TEST_SUITE_RUN(test_plugins_activate_nonexistent);
     TEST_SUITE_RUN(test_plugins_register_custom);
+    TEST_SUITE_RUN(test_plugins_activation_handler_may_reenter_registry);
     TEST_SUITE_RUN(test_plugins_list);
     TEST_SUITE_RUN(test_plugins_duplicate_register);
     TEST_SUITE_RUN(test_plugins_dispatch_to_active);


### PR DESCRIPTION
`plugins_activate` invoked the plugin's activation handler **while holding `plugins_mutex`** (`plugins.c:134`). The mutex is not recursive, so any handler touching the registry deadlocked against itself.

This contradicted the discipline documented 160 lines further down, at `plugins_snapshot_active` (`plugins.c:286-296`), which explains that dispatch happens outside the lock precisely because a plugin callback *"may re-enter the registry and would otherwise deadlock"*. `plugins_activate` was the one place that broke its own rule.

No in-tree plugin re-enters today, so this was **latent, not live** — but the rule is written down, and the next plugin author had no way to know it was violated here.

## The change

The lookup snapshots the handler pointer under the lock, releases it, then calls the handler unlocked. `plugins[]` is a fixed static array whose entries are never moved or unregistered, so the snapshotted pointer stays valid — the same argument `plugins_snapshot_active` already relies on.

**One behavioural change worth reviewing:** the new active index is now published *after* the handler returns, not before. The old order was only safe because the mutex kept dispatch out for the handler's duration. Dispatching unlocked, publishing first would let an event reach a half-initialized plugin. Publishing last means dispatch sees the outgoing plugin until the incoming one is ready.

The visible consequence is that a `handle_activation` handler now observes the **previous** active plugin if it asks. That seems clearly right — a plugin isn't active until it's initialized — but it is a semantic change, so flagging it.

## Test

The regression test registers a plugin whose activation handler calls `plugins_get_active_name()` — exactly what used to hang — and asserts both that it returns and that it saw the outgoing plugin.

I verified it against the unfixed code: it deadlocks, and I confirmed that by reverting the fix, rebuilding, and watching it hang.

Note the failure mode if this ever regresses is a **hang, not an assertion**. There's no fast-failing way to test "does not deadlock"; that's called out in a comment above the test so nobody is surprised by a CI timeout.

## Verification

`make compile-check` clean · `./unit_tests` 120 passed, 0 failed (was 119) · `make test` all scenarios pass · changed files also compiled with real **gcc-15** under `-Werror`, since local `gcc` is Apple clang and missed a `-Wstringop-truncation` error in #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
