### PR TITLE
fix(#229): display frame length truncation; docs(#231): complete lock order

### DIFF
--- a/host/daemon.c
+++ b/host/daemon.c
@@ -59,8 +59,42 @@ pthread_mutex_t daemon_state_mutex = PTHREAD_MUTEX_INITIALIZER;
 /* Serializes one whole engine step (serial read + event dispatch + plugin ticks
  * + display writes) in the main loop against web-thread control commands, which
  * run the same paths via send_control_command. Held only around the work, never
- * across the idle sleep. Lock order: engine_mutex -> daemon_state_mutex /
- * plugins_mutex / the SDK queue mutex (never the reverse). */
+ * across the idle sleep.
+ *
+ * LOCK ORDER (#231). Acquire only left to right, never the reverse:
+ *
+ *   engine_mutex
+ *     -> g_monitor_mutex
+ *          -> daemon_state_mutex
+ *               -> metrics_mutex
+ *     -> daemon_state_mutex
+ *          -> metrics_mutex
+ *     -> plugins_mutex
+ *     -> g_queue_mutex        (the SDK event queue)
+ *
+ * Two paths here are easy to miss, so spelling them out:
+ *
+ *   - engine_mutex -> g_monitor_mutex: the main loop holds engine_mutex across
+ *     the engine step and calls update_metrics(), which reaches
+ *     health_monitor_publish_metrics -> health_monitor_get_all_checks and takes
+ *     g_monitor_mutex. Meanwhile the health thread's monitoring_loop holds
+ *     g_monitor_mutex across execute_check(), and check_daemon_activity() takes
+ *     daemon_state_mutex -- hence the three-deep chain.
+ *
+ *   - daemon_state_mutex -> metrics_mutex: the event handlers below bump
+ *     counters and call_metrics_* from INSIDE the daemon_state_mutex region
+ *     (handle_coin_event, handle_call_state_event, handle_hook_event). So
+ *     metrics_mutex is genuinely nested, not leaf-only. Nothing in metrics.c or
+ *     call_metrics.c reaches back into daemon_state, which is what keeps this
+ *     acyclic -- do not add such a call.
+ *
+ * Note plugins_mutex and metrics_mutex are deliberately kept UN-nested in the
+ * other direction: plugins_record_activation is called after releasing
+ * plugins_mutex (see plugins.c). That is a choice, not an accident.
+ *
+ * These are outside the order because they are always taken alone: running_mutex,
+ * the logger mutexes, tone_mutex, the updater's check_mutex / apply_mutex, the
+ * web server's state_mutex and conn_queue.mutex. */
 static pthread_mutex_t engine_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /* Simple validation macro */

--- a/host/millennium_sdk.c
+++ b/host/millennium_sdk.c
@@ -687,12 +687,26 @@ void millennium_client_write_to_display(struct millennium_client *client, const 
 
     logger_debugf_with_category("SDK", "Writing message to display: %s", message);
 
+    /* The declared length and the number of bytes actually written must agree
+     * (#229). The old code narrowed strlen() to uint8_t for the header but then
+     * wrote the full strlen() in the body, so any message of 256 bytes or more
+     * declared the wrong size -- and since the framing has no resync, every
+     * byte past the declared length was consumed as a command opcode.
+     *
+     * Computing the length ONCE and clamping it makes the two agree by
+     * construction rather than by the caller happening to stay short. */
+    message_length = millennium_display_payload_len(message);
+    if (strlen(message) > message_length) {
+        logger_warnf_with_category("SDK",
+                "Display message truncated from %lu to %d bytes",
+                (unsigned long)strlen(message), DISPLAY_MAX_PAYLOAD);
+    }
+
     /* Step 1: Write the command */
-    cmd_data = (uint8_t)strlen(message);
+    cmd_data = (uint8_t)message_length;
     millennium_client_write_command(client, 0x02, &cmd_data, 1);
 
     /* Step 2: Write the message in a loop to ensure all bytes are written */
-    message_length = strlen(message);
 
     while (total_bytes_written < message_length) {
         ssize_t bytes_written = write(client->display_fd, message + total_bytes_written,

--- a/host/millennium_sdk.h
+++ b/host/millennium_sdk.h
@@ -2,6 +2,7 @@
 #define MILLENNIUM_SDK_H
 
 #include <stddef.h>
+#include <string.h>   /* strlen, for millennium_display_payload_len */
 #include <stdint.h>
 #include <time.h>
 
@@ -112,5 +113,33 @@ void millennium_sdk_get_sip_status(int *registered, char *last_error, size_t las
 #define SERIAL_MAX_BACKOFF_SECONDS 60
 #define SERIAL_WATCHDOG_ENABLED 1
 #define CMD_KEEPALIVE 0x06  /* Pi->Arduino: no-op, resets watchdog activity timer */
+
+/* Largest display payload the 0x02 frame can carry (#229).
+ *
+ * MUST match `byte buf[100]` in Arduino/sketches/display/display.ino, which
+ * rejects any frame declaring more than that (`num_bytes > sizeof(buf)`).
+ * The length is also carried in a single byte, so it could never exceed 255
+ * regardless.
+ *
+ * The framing has no resynchronisation: the receiver consumes exactly the
+ * number of bytes the header declares, so if the header and the body ever
+ * disagree the remainder of the message is read as command opcodes. */
+#define DISPLAY_MAX_PAYLOAD 100
+
+/* Number of bytes millennium_client_write_to_display will actually send for
+ * `message`: strlen clamped to DISPLAY_MAX_PAYLOAD, and 0 for NULL.
+ *
+ * Defined here rather than in millennium_sdk.c so the unit tests can exercise
+ * it -- unit_tests does not link millennium_sdk.o, which would pull in the
+ * PJSIP symbols that are only available on the Pi.
+ *
+ * `static inline` (a GNU extension the build already relies on via -std=gnu89)
+ * so translation units that never call it do not trip -Wunused-function. */
+static inline size_t millennium_display_payload_len(const char *message) {
+    size_t len;
+    if (!message) return 0;
+    len = strlen(message);
+    return (len > DISPLAY_MAX_PAYLOAD) ? (size_t)DISPLAY_MAX_PAYLOAD : len;
+}
 
 #endif /* MILLENNIUM_SDK_H */

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -652,6 +652,38 @@ static void test_plugins_activation_handler_may_reenter_registry(void) {
     plugins_cleanup();
 }
 
+/* #229: the 0x02 display frame carries its length in one byte, and the
+ * receiver consumes exactly that many bytes with no resynchronisation. The old
+ * code narrowed strlen() to uint8_t for the header but wrote the full strlen()
+ * in the body, so a message of 256+ bytes declared the wrong length and the
+ * remainder was consumed as command opcodes.
+ *
+ * The write path now derives both the header and the body from this one
+ * function, so these cases pin the agreement. */
+static void test_display_payload_len_clamps(void) {
+    char big[DISPLAY_MAX_PAYLOAD + 200];
+    char exact[DISPLAY_MAX_PAYLOAD + 1];
+
+    /* NULL and empty */
+    TEST_ASSERT_EQ_INT((int)millennium_display_payload_len(NULL), 0);
+    TEST_ASSERT_EQ_INT((int)millennium_display_payload_len(""), 0);
+
+    /* Ordinary two-line display text passes through untouched */
+    TEST_ASSERT_EQ_INT((int)millennium_display_payload_len("Insert 50c"), 10);
+
+    /* Exactly at the limit is allowed: the firmware's check is `>`, not `>=` */
+    memset(exact, 'x', DISPLAY_MAX_PAYLOAD);
+    exact[DISPLAY_MAX_PAYLOAD] = '\0';
+    TEST_ASSERT_EQ_INT((int)millennium_display_payload_len(exact), DISPLAY_MAX_PAYLOAD);
+
+    /* Over the limit clamps -- and critically stays inside one byte, which is
+     * what the old code failed to do */
+    memset(big, 'y', sizeof(big) - 1);
+    big[sizeof(big) - 1] = '\0';
+    TEST_ASSERT_EQ_INT((int)millennium_display_payload_len(big), DISPLAY_MAX_PAYLOAD);
+    TEST_ASSERT(millennium_display_payload_len(big) <= 255);
+}
+
 static void test_plugins_list(void) {
     daemon_state_data_t ds;
     char buf[1024];
@@ -2261,6 +2293,7 @@ int main(void) {
     TEST_SUITE_RUN(test_plugins_activate_nonexistent);
     TEST_SUITE_RUN(test_plugins_register_custom);
     TEST_SUITE_RUN(test_plugins_activation_handler_may_reenter_registry);
+    TEST_SUITE_RUN(test_display_payload_len_clamps);
     TEST_SUITE_RUN(test_plugins_list);
     TEST_SUITE_RUN(test_plugins_duplicate_register);
     TEST_SUITE_RUN(test_plugins_dispatch_to_active);


### PR DESCRIPTION
Two changes found while writing the TLA+ specs in #233 — one real framing bug, one documentation correction.

## #229 — the frame header and body could disagree

`millennium_client_write_to_display` narrowed `strlen()` to `uint8_t` for the `0x02` header, then wrote the **full** `strlen()` in the body. For any message ≥256 bytes the two disagreed, and the framing has no resynchronisation: the receiver consumes exactly what the header declares, so everything past it is read as command opcodes.

The firmware's own bounds check doesn't save this. `display.ino:194` rejects the frame and returns — but the Pi has already committed to sending those bytes, which then land as opcodes anyway.

**Not reachable today** (`display_manager` sends two 20-char lines), but it becomes reachable the moment anything longer is sent. `tests/protocol.pml` can't catch it either — it caps the modelled length at 6.

Both header and body now derive from **one** clamped length, so they agree by construction rather than by callers happening to stay short. `DISPLAY_MAX_PAYLOAD` is pinned to the firmware's `buf[100]` with a comment on both sides.

The clamp is a `static inline` in `millennium_sdk.h` so `unit_tests` can exercise it — `unit_tests` doesn't link `millennium_sdk.o`, which would drag in PJSIP symbols that only exist on the Pi. Tests cover NULL, empty, ordinary text, exactly-at-limit (the firmware check is `>`, not `>=`), and over-limit.

## #231 — the documented lock order was incomplete

`daemon.c:59-63` gave the order as `engine_mutex → daemon_state_mutex / plugins_mutex / queue` and read as if that were complete. Two paths were missing:

- `engine_mutex → g_monitor_mutex → daemon_state_mutex` — the main loop's `update_metrics()` takes `g_monitor_mutex`, and the health thread holds it across `execute_check()`, whose `check_daemon_activity()` takes `daemon_state_mutex`.
- `daemon_state_mutex → metrics_mutex` — the event handlers bump counters from **inside** the state-mutex region.

**Worth flagging:** my first draft of this comment asserted that `metrics_mutex` was always taken alone. I checked before committing and found **31** nested calls across `handle_coin_event`, `handle_call_state_event` and `handle_hook_event`. The code contradicted the doc I was about to write.

What keeps the graph acyclic is that nothing in `metrics.c`/`call_metrics.c` reaches back into `daemon_state`, and nothing under `g_monitor_mutex` touches metrics. Both are now written down as constraints, so a future change doesn't quietly close the cycle.

No functional change in that commit.

## Verification

`make compile-check` clean · `./unit_tests` 121 passed, 0 failed (was 120) · `make test` all scenarios pass · both commits compile independently · changed files also built with real **gcc-15** under `-Werror` (local `gcc` is Apple clang, which missed a `-Wstringop-truncation` error in #234).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
