### PR TITLE
fix(#237): respect CC in the Makefile; add a clang compile-check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,27 @@ jobs:
       - name: Run scenario tests
         working-directory: host
         run: make test
+
+  # Second opinion from clang (#237). The two compilers implement different
+  # warning sets, and the build treats warnings as errors: GCC has
+  # -Wstringop-truncation and -Wmaybe-uninitialized, clang has its own
+  # -Wunused-* and -Wconditional-uninitialized behaviour. Neither alone covers
+  # the other, so a clean GCC build is not evidence the source is warning-free.
+  #
+  # This also mirrors what a developer sees on macOS, where `gcc` is a shim for
+  # Apple clang -- previously the local build and CI could disagree with no
+  # signal until CI failed.
+  #
+  # compile-check only: the scenario/unit suites are behavioural and the `test`
+  # job above already runs them. This job is about diagnostics.
+  compile-check-clang:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev clang
+
+      - name: Compile-check daemon sources with clang
+        working-directory: host
+        run: make compile-check CC=clang

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,14 @@ Pure ALSA (`libasound`), no PipeWire. Left channel → ringer (TDA2822M ch A), r
 ## Coding Conventions
 
 - **C89** across the whole codebase, compiled with `-std=gnu89` (the C89 language plus the GNU extensions the ALSA/PJSIP system headers require, e.g. `inline`; strict `-std=c89` can't parse those headers). `-Wall -Wextra -Wdeclaration-after-statement -Werror` on all targets — warnings are errors, and `-Wdeclaration-after-statement` keeps the source free of C99-style mixed declarations; no separate linter configured
+- **A clean `make compile-check` on a Mac does not mean CI will pass** (#237). On macOS `gcc` is a shim for Apple clang, which does not implement several GCC warnings this build turns into errors — `-Wstringop-truncation` and `-Wmaybe-uninitialized` among them. CI runs real GCC on ubuntu. The Makefile takes `CC`, so check with the CI toolchain before pushing:
+
+  ```bash
+  brew install gcc                    # once
+  make compile-check CC=gcc-15
+  ```
+
+  Run both rather than swapping the default — clang catches things GCC does not.
 - No external dependencies beyond ALSA, pthread, PJSIP (libpjproject), and libc
 - No C++ in the active daemon targets (`.cpp` files in `host/` are legacy/unused)
 

--- a/host/Makefile
+++ b/host/Makefile
@@ -10,6 +10,25 @@ LDFLAGS=-lpthread -latomic -lasound `pkg-config --libs --static libpjproject`
 # declarations, so the source stays C89-conformant.
 CFLAGS=-g -O3 -Wall -Wextra -std=gnu89 -Wdeclaration-after-statement -Werror
 
+# Compiler. Overridable so a developer can build with the same toolchain CI
+# uses (#237). On macOS `gcc` is a shim for Apple clang, which does not
+# implement several of the GCC warnings this build turns into errors -- notably
+# -Wstringop-truncation and -Wmaybe-uninitialized -- so a clean `make
+# compile-check` on a Mac does NOT imply CI will pass. To check before pushing:
+#
+#   brew install gcc
+#   make compile-check CC=gcc-15
+#
+# Running both is strictly better than swapping the default: clang catches
+# things GCC does not.
+#
+# Plain `=`, NOT `?=`: make predefines CC with origin "default", and `?=` only
+# assigns when the origin is "undefined" -- so `CC ?= gcc` would silently leave
+# CC as `cc` and quietly change which compiler this builds with. A command-line
+# `make CC=gcc-15` still overrides this, because command-line variables beat
+# makefile assignments.
+CC = gcc
+
 # Build version info
 GIT_HASH := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_TIME := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "unknown")
@@ -17,112 +36,112 @@ VERSION_CFLAGS = -DGIT_HASH='"$(GIT_HASH)"' -DBUILD_TIME='"$(BUILD_TIME)"'
 
 # Object files
 config.o: config.c config.h
-	gcc config.c -o config.o -c $(CFLAGS)
+	$(CC) config.c -o config.o -c $(CFLAGS)
 
 cli.o: cli.c cli.h
-	gcc cli.c -o cli.o -c $(CFLAGS)
+	$(CC) cli.c -o cli.o -c $(CFLAGS)
 
 # C object files
 clock_source.o: clock_source.c clock_source.h
-	gcc clock_source.c -o clock_source.o -c $(CFLAGS)
+	$(CC) clock_source.c -o clock_source.o -c $(CFLAGS)
 
 daemon_state.o: daemon_state.c daemon_state.h clock_source.h
-	gcc daemon_state.c -o daemon_state.o -c $(CFLAGS)
+	$(CC) daemon_state.c -o daemon_state.o -c $(CFLAGS)
 
 logger.o: logger.c logger.h
-	gcc logger.c -o logger.o -c $(CFLAGS)
+	$(CC) logger.c -o logger.o -c $(CFLAGS)
 
 health_monitor.o: health_monitor.c health_monitor.h logger.h metrics.h
-	gcc health_monitor.c -o health_monitor.o -c $(CFLAGS)
+	$(CC) health_monitor.c -o health_monitor.o -c $(CFLAGS)
 
 metrics.o: metrics.c metrics.h
-	gcc metrics.c -o metrics.o -c $(CFLAGS)
+	$(CC) metrics.c -o metrics.o -c $(CFLAGS)
 
 call_metrics.o: call_metrics.c call_metrics.h metrics.h clock_source.h
-	gcc call_metrics.c -o call_metrics.o -c $(CFLAGS)
+	$(CC) call_metrics.c -o call_metrics.o -c $(CFLAGS)
 
 metrics_server.o: metrics_server.c metrics_server.h metrics.h logger.h
-	gcc metrics_server.c -o metrics_server.o -c $(CFLAGS)
+	$(CC) metrics_server.c -o metrics_server.o -c $(CFLAGS)
 
 websocket.o: websocket.c websocket.h
-	gcc websocket.c -o websocket.o -c $(CFLAGS)
+	$(CC) websocket.c -o websocket.o -c $(CFLAGS)
 
 conn_queue.o: conn_queue.c conn_queue.h
-	gcc conn_queue.c -o conn_queue.o -c $(CFLAGS)
+	$(CC) conn_queue.c -o conn_queue.o -c $(CFLAGS)
 
 web_server.o: web_server.c web_server.h conn_queue.h websocket.h config.h logger.h metrics.h health_monitor.h version.h updater.h
-	gcc web_server.c -o web_server.o -c $(CFLAGS)
+	$(CC) web_server.c -o web_server.o -c $(CFLAGS)
 
 pjsip_interface.o: pjsip_interface.c pjsip_interface.h logger.h
-	gcc pjsip_interface.c -o pjsip_interface.o -c $(CFLAGS) `pkg-config --cflags libpjproject`
+	$(CC) pjsip_interface.c -o pjsip_interface.o -c $(CFLAGS) `pkg-config --cflags libpjproject`
 
 events.o: events.c events.h
-	gcc events.c -o events.o -c $(CFLAGS)
+	$(CC) events.c -o events.o -c $(CFLAGS)
 
 event_processor.o: event_processor.c event_processor.h events.h
-	gcc event_processor.c -o event_processor.o -c $(CFLAGS)
+	$(CC) event_processor.c -o event_processor.o -c $(CFLAGS)
 
 millennium_sdk.o: millennium_sdk.c millennium_sdk.h events.h pjsip_interface.h config.h
-	gcc millennium_sdk.c -o millennium_sdk.o -c $(CFLAGS)
+	$(CC) millennium_sdk.c -o millennium_sdk.o -c $(CFLAGS)
 
 state_persistence.o: state_persistence.c state_persistence.h daemon_state.h logger.h
-	gcc state_persistence.c -o state_persistence.o -c $(CFLAGS)
+	$(CC) state_persistence.c -o state_persistence.o -c $(CFLAGS)
 
 display_manager.o: display_manager.c display_manager.h millennium_sdk.h
-	gcc display_manager.c -o display_manager.o -c $(CFLAGS)
+	$(CC) display_manager.c -o display_manager.o -c $(CFLAGS)
 
 plugin_sdk.o: plugin_sdk.c plugin_sdk.h plugins.h display_manager.h audio_tones.h millennium_sdk.h clock_source.h logger.h daemon_state.h config.h
-	gcc plugin_sdk.c -o plugin_sdk.o -c $(CFLAGS)
+	$(CC) plugin_sdk.c -o plugin_sdk.o -c $(CFLAGS)
 
 version.o: version.c version.h
-	gcc version.c -o version.o -c $(CFLAGS) $(VERSION_CFLAGS)
+	$(CC) version.c -o version.o -c $(CFLAGS) $(VERSION_CFLAGS)
 
 wav.o: wav.c wav.h
-	gcc wav.c -o wav.o -c $(CFLAGS)
+	$(CC) wav.c -o wav.o -c $(CFLAGS)
 
 audio_tones.o: audio_tones.c audio_tones.h wav.h logger.h
-	gcc audio_tones.c -o audio_tones.o -c $(CFLAGS)
+	$(CC) audio_tones.c -o audio_tones.o -c $(CFLAGS)
 
 updater.o: updater.c updater.h version.h logger.h
-	gcc updater.c -o updater.o -c $(CFLAGS)
+	$(CC) updater.c -o updater.o -c $(CFLAGS)
 
 daemon.o: daemon.c millennium_sdk.h events.h event_processor.h config.h logger.h health_monitor.h metrics.h metrics_server.h call_metrics.h web_server.h plugins.h state_persistence.h display_manager.h audio_tones.h
-	gcc daemon.c -o daemon.o -c $(CFLAGS)
+	$(CC) daemon.c -o daemon.o -c $(CFLAGS)
 
 # Executables
 plugins.o: plugins.c plugins.h
-	gcc plugins.c -o plugins.o -c $(CFLAGS)
+	$(CC) plugins.c -o plugins.o -c $(CFLAGS)
 
 plugins/classic_phone.o: plugins/classic_phone.c plugins.h plugin_sdk.h audio_tones.h config.h
-	gcc plugins/classic_phone.c -o plugins/classic_phone.o -c $(CFLAGS)
+	$(CC) plugins/classic_phone.c -o plugins/classic_phone.o -c $(CFLAGS)
 
 plugins/fortune_teller.o: plugins/fortune_teller.c plugins.h plugin_sdk.h
-	gcc plugins/fortune_teller.c -o plugins/fortune_teller.o -c $(CFLAGS)
+	$(CC) plugins/fortune_teller.c -o plugins/fortune_teller.o -c $(CFLAGS)
 
 plugins/jukebox.o: plugins/jukebox.c plugins.h plugin_sdk.h
-	gcc plugins/jukebox.c -o plugins/jukebox.o -c $(CFLAGS)
+	$(CC) plugins/jukebox.c -o plugins/jukebox.o -c $(CFLAGS)
 
 plugins/number_guess.o: plugins/number_guess.c plugins.h plugin_sdk.h config.h
-	gcc plugins/number_guess.c -o plugins/number_guess.o -c $(CFLAGS)
+	$(CC) plugins/number_guess.c -o plugins/number_guess.o -c $(CFLAGS)
 
 plugins/simon.o: plugins/simon.c plugins.h plugin_sdk.h config.h
-	gcc plugins/simon.c -o plugins/simon.o -c $(CFLAGS)
+	$(CC) plugins/simon.c -o plugins/simon.o -c $(CFLAGS)
 
 plugins/dial_a_joke.o: plugins/dial_a_joke.c plugins.h plugin_sdk.h config.h
-	gcc plugins/dial_a_joke.c -o plugins/dial_a_joke.o -c $(CFLAGS)
+	$(CC) plugins/dial_a_joke.c -o plugins/dial_a_joke.o -c $(CFLAGS)
 
 plugins/trivia.o: plugins/trivia.c plugins.h plugin_sdk.h config.h
-	gcc plugins/trivia.c -o plugins/trivia.o -c $(CFLAGS)
+	$(CC) plugins/trivia.c -o plugins/trivia.o -c $(CFLAGS)
 
 plugins/time_operator.o: plugins/time_operator.c plugins.h plugin_sdk.h
-	gcc plugins/time_operator.c -o plugins/time_operator.o -c $(CFLAGS)
+	$(CC) plugins/time_operator.c -o plugins/time_operator.o -c $(CFLAGS)
 
 daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o wav.o updater.o
-	gcc daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o wav.o updater.o -o daemon $(LDFLAGS) -lm
+	$(CC) daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o wav.o updater.o -o daemon $(LDFLAGS) -lm
 
 # Simulator object file
 simulator.o: simulator.c millennium_sdk.h events.h config.h daemon_state.h logger.h metrics.h call_metrics.h plugins.h
-	gcc simulator.c -o simulator.o -c $(CFLAGS)
+	$(CC) simulator.c -o simulator.o -c $(CFLAGS)
 
 # Simulator objects — no baresip, no web server, no daemon.o
 SIM_OBJS = simulator.o daemon_state.o clock_source.o events.o event_processor.o config.o logger.o metrics.o call_metrics.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o
@@ -132,7 +151,7 @@ SIM_OBJS = simulator.o daemon_state.o clock_source.o events.o event_processor.o 
 SIM_LDFLAGS = -lpthread
 
 simulator: $(SIM_OBJS)
-	gcc $(SIM_OBJS) -o simulator $(SIM_LDFLAGS)
+	$(CC) $(SIM_OBJS) -o simulator $(SIM_LDFLAGS)
 
 all: daemon
 
@@ -140,7 +159,7 @@ all: daemon
 UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o cli.o logger.o metrics.o call_metrics.o health_monitor.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o wav.o updater.o conn_queue.o
 
 tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h cli.h daemon_state.h plugins.h logger.h metrics.h call_metrics.h millennium_sdk.h updater.h state_persistence.h conn_queue.h health_monitor.h
-	gcc tests/unit_tests.c -o tests/unit_tests.o -c $(CFLAGS) -I.
+	$(CC) tests/unit_tests.c -o tests/unit_tests.o -c $(CFLAGS) -I.
 
 # Unit tests don't use time wrapping; link ALSA on Linux for jukebox
 UNIT_LDFLAGS = -lpthread
@@ -149,14 +168,14 @@ UNIT_LDFLAGS += -lasound -lm
 endif
 
 unit_tests: $(UNIT_TEST_OBJS)
-	gcc $(UNIT_TEST_OBJS) -o unit_tests $(UNIT_LDFLAGS)
+	$(CC) $(UNIT_TEST_OBJS) -o unit_tests $(UNIT_LDFLAGS)
 
 # Optional PJSIP runtime smoke test. Needs libpjproject on the dev box
 # (macOS: `brew install pjproject`; Pi: built from source). Brings PJSUA up and
 # down without a SIP peer or phone hardware — validates the PJSIP integration
 # compiles and runs. Not part of `make test` (which must run anywhere).
 pjsip-smoke: tests/pjsip_smoke.c pjsip_interface.c pjsip_interface.h logger.o
-	gcc tests/pjsip_smoke.c pjsip_interface.c logger.o -o pjsip_smoke \
+	$(CC) tests/pjsip_smoke.c pjsip_interface.c logger.o -o pjsip_smoke \
 		$(CFLAGS) `pkg-config --cflags libpjproject` \
 		`pkg-config --libs --static libpjproject` -lpthread -lm
 


### PR DESCRIPTION
Closes #237.

`make compile-check` is the guard against `-Werror` breakage, but on macOS it didn't test what CI tests. The Makefile hardcoded `gcc` in all 39 compile rules, and on macOS `gcc` is a shim for Apple clang. That cost a CI round-trip in #234, where `-Wstringop-truncation` (GCC-only) failed a build that was clean locally.

## Three parts

- **All 39 rules use `$(CC)`**, so `make compile-check CC=gcc-15` reproduces the CI toolchain locally. Also unblocks cross-compiling and `scan-build`.
- **`CLAUDE.md`** records that a clean compile-check on a Mac doesn't imply CI will pass, with the command to check properly.
- **A clang CI job.** Neither compiler's warning set covers the other, so a clean GCC build was never evidence the source is warning-free. Both now run on every PR.

## The part worth reviewing

The assignment is `CC = gcc`, **not** `CC ?= gcc`.

I wrote `?=` first, which is the reflexive idiom, and it's wrong here. make predefines `CC` with origin `default`, and `?=` only assigns when the origin is `undefined` — so `?=` silently leaves `CC` as `cc`, quietly changing which compiler the project builds with:

```
$ make showcc          # with CC ?= gcc
CC=[cc] origin=default
```

It passes the entire test suite either way, because `cc` resolves to clang on macOS and gcc on Linux. That's precisely what makes it a bad silent change — nothing would have caught it. A command-line `make CC=...` still overrides a plain assignment, so the override path is unaffected:

```
$ make showcc          # with CC = gcc
CC=[gcc] origin=file
$ make showcc CC=gcc-15
CC=[gcc-15] origin=command line
```

## Verification

`compile-check` clean under **gcc** (default), **clang**, and **gcc-15** · `./unit_tests` 121 passed under both gcc-15- and clang-built objects · `make test` all scenarios pass.

The new CI job is the real check on the clang path — it runs against ubuntu clang, not the Apple fork I have locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
