### PR TITLE
fix(#223): release the session on plugin switch instead of adding a deactivation hook

### DIFF
--- a/host/PLUGIN_AUTHORING.md
+++ b/host/PLUGIN_AUTHORING.md
@@ -155,3 +155,32 @@ See [`plugin_sdk.h`](plugin_sdk.h) for the full API: time (`sdk_now`,
 `sdk_keypad`), balance (`sdk_balance`, `sdk_spend_balance`, …), logging
 (`sdk_log`, `sdk_logf`), and randomness (`sdk_rand_below`, `sdk_rand_range`,
 `sdk_rand_choice`).
+
+## Session teardown on plugin switch
+
+There is deliberately **no `handle_deactivation` callback**. When the active
+plugin is switched away from, it is simply frozen — it stops receiving events
+and ticks, and its static session struct keeps whatever was in it.
+
+The daemon releases the resources *it* owns before activating the incoming
+plugin (`sdk_release_session`, called from `plugins_activate`): a call in
+progress is hung up, continuous audio is stopped, the keypad is cleared, and
+the state drops to the idle state matching the physical handset.
+
+Two consequences for plugin authors:
+
+- **You do not need to clean up on the way out.** Do not rely on being told;
+  you will not be.
+- **Do your session reset in `handle_activation`, not on exit.** That is the
+  only hook that runs, and it runs on every activation — boot, a restore from
+  persistence, and every deliberate switch. `plugins/classic_phone.c`'s
+  `classic_phone_on_activation` is the reference: it re-reads the coin balance
+  from `sdk_balance()` and zeroes its own per-session flags.
+
+The coin balance is deliberately **not** cleared on a switch — an operator
+changing plugins should not swallow the customer's money — so read it fresh in
+`handle_activation` rather than assuming it is zero.
+
+If your plugin ever holds a resource the daemon cannot see, say a file handle
+or an external connection, that is the case this design does not cover; raise
+it rather than leaking it.

--- a/host/plugin_sdk.c
+++ b/host/plugin_sdk.c
@@ -13,6 +13,8 @@
 #include "clock_source.h"
 #include "logger.h"
 #include "config.h"
+#include "metrics.h"
+#include "call_metrics.h"
 
 /* Globals owned by the daemon / simulator / test harness. */
 extern daemon_state_data_t *daemon_state;
@@ -131,6 +133,39 @@ void sdk_spend_balance(int cents) {
 void sdk_clear_balance(void) {
     if (daemon_state && daemon_state->inserted_cents != 0) {
         plugins_adjust_inserted_cents(-daemon_state->inserted_cents);
+    }
+}
+
+/* ── Session teardown (see plugin_sdk.h) ─────────────────────────────── */
+
+void sdk_release_session(void) {
+    daemon_state_t s = sdk_state();
+    int in_call = (s == DAEMON_STATE_CALL_ACTIVE || s == DAEMON_STATE_CALL_INCOMING);
+
+    sdk_stop_audio();
+
+    if (in_call) {
+        sdk_hangup();
+        /* Resolve the call phase so the duration/miss metrics stay honest --
+         * mirrors what handle_call_state_event does on EVENT_CALL_STATE_INVALID. */
+        if (s == DAEMON_STATE_CALL_ACTIVE) {
+            call_metrics_ended();
+        } else {
+            call_metrics_incoming_ended();
+        }
+        metrics_increment_counter("plugin_switch_calls_released", 1);
+        logger_warn_with_category("Plugins",
+                "Plugin switched during a call; releasing it");
+    }
+
+    sdk_clear_keypad();
+
+    if (daemon_state && in_call) {
+        /* Land in the idle state matching the physical handset, exactly as the
+         * call-ended path does (see docs/EVENT_ORDERING.md). */
+        daemon_state->current_state = daemon_state->handset_up
+                ? DAEMON_STATE_IDLE_UP : DAEMON_STATE_IDLE_DOWN;
+        daemon_state_update_activity(daemon_state);
     }
 }
 

--- a/host/plugin_sdk.h
+++ b/host/plugin_sdk.h
@@ -136,4 +136,24 @@ int sdk_rand_range(int lo, int hi);   /* inclusive [lo, hi] */
 /* Pick a random element from an array of strings (NULL if n<=0). */
 const char *sdk_rand_choice(const char *const *choices, int n);
 
+/* ── Session teardown (daemon-internal) ──────────────────────────────────
+ * Release anything the phone is holding on behalf of the ACTIVE plugin: hang
+ * up a call in progress, stop any continuous tone, clear the keypad, and drop
+ * back to the idle state matching the physical handset.
+ *
+ * Called by plugins_activate when switching between two different plugins
+ * (#223). The plugin API has no handle_deactivation hook, so an outgoing
+ * plugin gets no chance to clean up after itself -- switching mid-call used to
+ * leave the SIP call up, the audio running, and the daemon in CALL_ACTIVE,
+ * while the outgoing plugin forgot it ever had a call. Rather than obliging
+ * every plugin author to implement teardown correctly, the daemon releases the
+ * resources it owns.
+ *
+ * The coin balance is deliberately NOT cleared: an operator switching plugins
+ * should not swallow the customer's money, and the incoming plugin reads the
+ * balance from daemon_state on activation.
+ *
+ * Not part of the plugin-facing API -- plugins should not call this. */
+void sdk_release_session(void);
+
 #endif /* PLUGIN_SDK_H */

--- a/host/plugins.c
+++ b/host/plugins.c
@@ -9,6 +9,7 @@
 #include "logger.h"
 #include "millennium_sdk.h"
 #include "metrics.h"
+#include "plugin_sdk.h"
 
 /* Maximum number of plugins. Generous headroom so experimenters can add
  * their own alongside the built-ins (8 ship by default). */
@@ -119,6 +120,7 @@ int plugins_activate(const char *plugin_name) {
     int i;
     void (*activation)(void) = NULL;
     int found = 0;
+    int previous = -1;
 
     if (!plugin_name) {
         logger_error_with_category("Plugins", "Plugin name required for activation");
@@ -137,6 +139,7 @@ int plugins_activate(const char *plugin_name) {
      * The plugins[] table is a fixed static array whose entries are never moved
      * or unregistered, so the snapshotted function pointer stays valid. */
     pthread_mutex_lock(&plugins_mutex);
+    previous = active_plugin_index;
     for (i = 0; i < plugin_count; i++) {
         if (strcmp(plugins[i].name, plugin_name) == 0) {
             activation = plugins[i].handle_activation;
@@ -146,9 +149,24 @@ int plugins_activate(const char *plugin_name) {
     }
     pthread_mutex_unlock(&plugins_mutex);
 
+    /* Resolve the lookup BEFORE tearing anything down: a request naming a
+     * plugin that does not exist must leave the current session untouched. */
     if (!found) {
         logger_warnf_with_category("Plugins", "Plugin %s not found", plugin_name);
         return -1;
+    }
+
+    /* #223: the plugin API has no handle_deactivation hook, so the outgoing
+     * plugin never gets a chance to release what it was holding. Switching
+     * mid-call used to leave the SIP call up, the audio running and the daemon
+     * in CALL_ACTIVE, while the outgoing plugin's own activation handler later
+     * reset is_in_call and forgot the call existed. The daemon releases the
+     * resources it owns instead of obliging every plugin author to.
+     *
+     * Only on a real switch: re-activating the plugin that is already active
+     * (which the web dashboard can do) must not drop a call in progress. */
+    if (previous >= 0 && previous != i) {
+        sdk_release_session();
     }
 
     /* Initialize BEFORE publishing the new active index. The old code assigned

--- a/host/tests/test_plugin_switch_releases_call.scenario
+++ b/host/tests/test_plugin_switch_releases_call.scenario
@@ -1,0 +1,49 @@
+# Test: switching plugins releases the call but keeps the coins (#223)
+#
+# The plugin API has no handle_deactivation hook, so an outgoing plugin never
+# gets a chance to clean up after itself. Switching mid-call used to leave the
+# SIP call up, the audio running, and the daemon parked in CALL_ACTIVE -- while
+# the outgoing plugin's own activation handler later reset is_in_call and
+# forgot the call had ever existed. The daemon now releases what it owns.
+
+assert_state IDLE_DOWN
+
+# ── 1) A switch mid-call releases the call ──────────────────────────────
+hook_up
+assert_state IDLE_UP
+
+coin 25
+coin 25
+keys 5551234567
+assert_state CALL_ACTIVE
+
+activate_plugin Number Guess
+
+# The handset is still up, so we land in IDLE_UP -- not stranded in
+# CALL_ACTIVE, and not dropped to IDLE_DOWN as though the user hung up.
+assert_state IDLE_UP
+
+# ── 2) A switch does NOT swallow the customer's coins ───────────────────
+# Back to Classic Phone and a clean slate first: Number Guess is active after
+# part 1, and it charges to start a game, so coins inserted now would go to it.
+activate_plugin Classic Phone
+hook_down
+assert_state IDLE_DOWN
+hook_up
+
+coin 25
+coin 25
+assert_display Have: 50c
+
+# Switch away and back. Classic Phone re-reads the balance from daemon_state
+# on activation, so if the switch had cleared it this would show "Insert 50c".
+activate_plugin Number Guess
+activate_plugin Classic Phone
+assert_display Have: 50c
+
+# ── 3) Re-activating the plugin that is already active is not a switch ──
+# The dashboard can do this; it must not tear down a call in progress.
+keys 5551234567
+assert_state CALL_ACTIVE
+activate_plugin Classic Phone
+assert_state CALL_ACTIVE


### PR DESCRIPTION
Closes #223.

Implements option 2 from the discussion: **the daemon cleans up on switch, rather than adding a `handle_deactivation` hook.**

## Why not the hook

The harm in #223 turned out not to be stale data. `classic_phone_on_activation` (`:244-252`) already resets its own per-session flags and re-reads the balance, so Classic Phone self-heals on re-entry — I overstated the link to #222 when filing.

The harm is **leaked resources**. `activate_plugin` did nothing but call `plugins_activate`, so switching mid-call left the SIP call up, the audio running, and the daemon parked in `CALL_ACTIVE` — while the outgoing plugin later reset `is_in_call` and forgot the call existed. The incoming plugin then started receiving call-state events for a call it knew nothing about.

Every resource that leaks today — the SIP call, the tone generator — **already belongs to the daemon**. So it can clean up without the plugin's cooperation, and correctness doesn't depend on every future plugin author implementing teardown properly.

The hook would also have broken `plugins_register`'s positional signature across all 8 built-ins, the tests, the authoring guide and the `new-plugin` skill — and fought The Operator's deliberate state preservation across hook events.

## Where it lives, and why that matters

`sdk_release_session()` is in **`plugin_sdk.c`**, not `daemon.c`.

`simulator.c` calls `plugins_activate` directly, so putting the cleanup in `daemon.c` would have re-introduced exactly the sim/daemon drift that `make state-check`'s equivalence proof exists to catch. `plugin_sdk.o` is linked into the daemon, the simulator **and** the unit tests, so there is one implementation and no way for them to diverge.

## Behaviour

Hangs up a call in progress, stops continuous audio, clears the keypad, lands in the idle state matching the physical handset (reusing the `handset_up` field from #100), and resolves the call-metrics phase so durations and misses stay honest.

**Coins are deliberately not cleared** — an operator switching plugins shouldn't swallow the customer's money.

Two guards:
- The lookup resolves **before** any teardown, so naming a nonexistent plugin leaves the session untouched.
- Re-activating the already-active plugin is **not** a switch, so the dashboard can't drop a call by re-selecting the current plugin.

## Test

`tests/test_plugin_switch_releases_call.scenario` covers all three cases. Verified against the unfixed code — the mid-call switch strands the daemon in `CALL_ACTIVE`:

```
FAIL: expected state containing "IDLE_UP", got "CALL_ACTIVE"
```

Worth noting I got the test wrong twice before it was right: first I asserted coins were preserved in a case where they'd legitimately been spent on the call, then I checked the balance while Number Guess was still the active plugin and had charged 25¢ for a game. Both were my test being wrong, not the code.

## Verification

`compile-check` clean under **gcc**, **clang** and **gcc-15** · `unit_tests` 121/0 · all scenarios pass · CBMC both functions · `tla-check` / `coin-check` / `ota-check` all green.

`PLUGIN_AUTHORING.md` documents the contract: plugins are not told when they're switched away from, and should do session reset in `handle_activation`. It also flags the case this design doesn't cover — a plugin holding a resource the daemon can't see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
