### PR TITLE
verify: mutation-test every model-checked property

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -384,4 +384,12 @@ lock-check:
 lock-check-mutant:
 	cd tests && $(TLC) -config LockOrderMutant.cfg LockOrder.tla
 
-.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke regen-clips tsan-queue cbmc-parser cbmc-parsers model-check game-check state-check tla-check tla-check-race coin-check ota-check lock-check lock-check-mutant pjsip-smoke
+# Mutation-test every model-checked property: break the system in a way each one
+# is supposed to notice, and check that it actually does. A property that cannot
+# fail is not verifying anything, and a green TLC run looks identical either way
+# -- this has already caught two such properties. See the header of
+# tests/mutation_audit.sh. Slow (runs TLC once per mutation); not in `make test`.
+mutation-audit:
+	cd tests && TLA_TOOLS=$(abspath $(TLA_TOOLS)) ./mutation_audit.sh
+
+.PHONY: all clean install uninstall test unit_tests api-test device-test break-test operator-smoke regen-clips tsan-queue cbmc-parser cbmc-parsers model-check game-check state-check tla-check tla-check-race coin-check ota-check lock-check lock-check-mutant mutation-audit pjsip-smoke

--- a/host/docs/EVENT_ORDERING.md
+++ b/host/docs/EVENT_ORDERING.md
@@ -121,3 +121,27 @@ relied on TLC's built-in deadlock detection, which only flags a *global* stall
 — and reported "no error" even on the deliberately-cycled model, because two
 threads deadlocking while three keep running is not a global stall. The spec
 now states circular wait directly as a waits-for cycle.
+
+## Auditing the specs themselves (`make mutation-audit`)
+
+A green TLC run is not evidence that a property is doing anything. Twice while
+writing these specs a property passed for a reason unrelated to the system:
+
+- `LockOrder.tla` relied on TLC's built-in deadlock detection, which flags only
+  a state with *no successor*. A lock-order bug does not produce one — two
+  threads deadlock while others keep running — so it reported "no error" on a
+  deliberately-cycled version of itself.
+- `Updater.tla`'s `RestartOk` both assigned `callDropped'` and listed it in
+  `UNCHANGED`. That contradiction silently disabled the action whenever a call
+  was up, so the guard under test was never exercised.
+
+Both were caught by accident. `tests/mutation_audit.sh` makes it systematic:
+for each property, break the system in the way that property is meant to notice
+and confirm it fires. Anything reported `NOT CAUGHT` is vacuous or subsumed, and
+its green result means nothing.
+
+The audit also identified three properties that are **subsumed** and can never
+be the invariant TLC reports — `NonNegative` in both specs (implied by
+`TypeOK`'s `\in Nat`) and `NeverPromiseMoreThanHeld` (implied by
+`LedgerAgreement`). They are kept for readability and now say so in place, so
+nobody counts them as coverage.

--- a/host/tests/CoinLedger.tla
+++ b/host/tests/CoinLedger.tla
@@ -212,6 +212,8 @@ TypeOK ==
     /\ fcents \in Nat
     /\ budget \in 0..MaxEvents
 
+(* SUBSUMED by TypeOK (all three are `\in Nat`), so this can never be the
+   invariant TLC reports. Kept for readability; adds no coverage. *)
 NonNegative == dcents >= 0 /\ pcents >= 0 /\ fcents >= 0
 
 (* THE property. The daemon ledger is what the web API, the metrics gauge and
@@ -222,8 +224,10 @@ NonNegative == dcents >= 0 /\ pcents >= 0 /\ fcents >= 0
    revenue figures do not match what the customer was charged. *)
 LedgerAgreement == dcents = pcents
 
-(* Weaker fallback: even if the exact figures drift, the customer should never
-   be shown MORE credit than the daemon will actually honour. *)
+(* SUBSUMED by LedgerAgreement (dcents = pcents implies pcents <= dcents), so
+   this can never be the invariant TLC reports while that one is checked. It
+   was the meaningful weaker fallback back when the two ledgers could legitimately
+   differ; with a single ledger it is documentation, not coverage. *)
 NeverPromiseMoreThanHeld == pcents <= dcents
 
 (* A restart must not resurrect credit that was already spent or returned, nor

--- a/host/tests/EventOrdering.tla
+++ b/host/tests/EventOrdering.tla
@@ -198,6 +198,13 @@ TypeOK ==
 (* Already proven by CBMC for a single step; restated here to confirm they
    survive arbitrary interleaving. Expected to HOLD. *)
 NoInvalidState == state # "INVALID"
+
+(* SUBSUMED by TypeOK (`cents \in Nat`), so it can never be the invariant TLC
+   reports -- any state violating this violates TypeOK too. Kept because it
+   states the intent in the reader's terms, but it adds no coverage: do not
+   count it when judging how much this spec actually checks.
+   Confirmed by ./mutation_audit.sh, where the underflow mutation is caught by
+   TypeOK rather than by this. *)
 NonNegative    == cents >= 0
 
 (* Credit must never survive the handset going down (the coins were either

--- a/host/tests/mutation_audit.sh
+++ b/host/tests/mutation_audit.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+#
+# Mutation-test every model-checked property (#231 follow-up).
+#
+# WHY THIS EXISTS
+#
+# Twice while writing these specs, a property passed for a reason that had
+# nothing to do with the system being correct:
+#
+#   - LockOrder.tla originally relied on TLC's built-in deadlock detection,
+#     which only flags a state with NO successor. A lock-order bug does not
+#     produce one -- two threads deadlock while three keep running -- so the
+#     model reported "no error" on a deliberately-cycled version of itself.
+#
+#   - Updater.tla's RestartOk both assigned callDropped' AND listed it in
+#     UNCHANGED. That contradiction silently disabled the action whenever a
+#     call was up, so the guard being tested was never exercised and the
+#     invariant held vacuously.
+#
+# Both were caught by accident. A property that cannot fail is not verifying
+# anything, and nothing about a green TLC run distinguishes the two cases.
+#
+# So: break the system in a way each property is supposed to notice, and check
+# that it actually does. Any "NOT CAUGHT" line means that property is either
+# vacuous or subsumed by another, and its green result means nothing.
+#
+#   ./mutation_audit.sh            (from host/tests, needs tla2tools.jar)
+#   TLA_TOOLS=/path/to/jar ./mutation_audit.sh
+#
+set -u
+JAR="${TLA_TOOLS:-tla2tools.jar}"
+[ -f "$JAR" ] || { echo "tla2tools.jar not found; set TLA_TOOLS=/path/to/tla2tools.jar"; exit 2; }
+fails=0
+
+run() {  # run <spec> <cfg> <label> <python-mutation>
+    local spec=$1 cfg=$2 label=$3 mut=$4 out
+    cp "$spec" "/tmp/_orig_$$.tla"
+    if ! python3 -c "$mut"; then
+        echo "  !! $label -- mutation did not apply (spec text changed?)"
+        cp "/tmp/_orig_$$.tla" "$spec"; fails=$((fails+1)); return
+    fi
+    out=$(java -XX:+UseParallelGC -cp "$JAR" tlc2.TLC -config "$cfg" "$spec" 2>&1 \
+          | grep -E "Invariant .* is violated|No error" | head -1)
+    cp "/tmp/_orig_$$.tla" "$spec"
+    if echo "$out" | grep -q "No error"; then
+        echo "  NOT CAUGHT  $label"; fails=$((fails+1))
+    else
+        echo "  caught      $label -> ${out#Error: }"
+    fi
+}
+
+echo "== EventOrdering =="
+run EventOrdering.tla EventOrdering.cfg "hook_down keeps coins" '
+s=open("EventOrdering.tla").read()
+a="""      [] e.type = "hook_down" ->
+            <<"IDLE_DOWN", 0, "down">>"""
+b="""      [] e.type = "hook_down" ->
+            <<"IDLE_DOWN", c, "down">>"""
+assert a in s; open("EventOrdering.tla","w").write(s.replace(a,b))'
+run EventOrdering.tla EventOrdering.cfg "hook_down reaches INVALID" '
+s=open("EventOrdering.tla").read()
+a="""      [] e.type = "hook_down" ->
+            <<"IDLE_DOWN", 0, "down">>"""
+b="""      [] e.type = "hook_down" ->
+            <<"INVALID", 0, "down">>"""
+assert a in s; open("EventOrdering.tla","w").write(s.replace(a,b))'
+run EventOrdering.tla EventOrdering.cfg "call_active unguarded (pre-#100)" '
+s=open("EventOrdering.tla").read()
+a="""IF h = "up" THEN <<"CALL_ACTIVE", c, h>> ELSE <<s, c, h>>"""
+assert a in s; open("EventOrdering.tla","w").write(s.replace(a,"""<<"CALL_ACTIVE", c, h>>"""))'
+run EventOrdering.tla EventOrdering.cfg "call_invalid ignores handset" '
+s=open("EventOrdering.tla").read()
+a="""LET idle == IF h = "up" THEN "IDLE_UP" ELSE "IDLE_DOWN" IN"""
+assert a in s; open("EventOrdering.tla","w").write(s.replace(a,"""LET idle == "IDLE_UP" IN"""))'
+
+echo "== CoinLedger =="
+run CoinLedger.tla CoinLedger.cfg "coin_return skips the plugin ledger (pre-#222)" '
+import re
+s=open("CoinLedger.tla").read()
+m=re.search(r"CoinReturn ==.*?budget. = budget - 1", s, re.S); assert m
+blk=m.group(0)
+new=blk.replace("/\\ pcents\x27 = 0          \\* one ledger: the plugin reads sdk_balance() live\n    ","").replace("UNCHANGED state","UNCHANGED <<state, pcents>>")
+assert new!=blk; open("CoinLedger.tla","w").write(s.replace(blk,new))'
+run CoinLedger.tla CoinLedger.cfg "coin insert not persisted (pre-#222 keypad gap)" '
+s=open("CoinLedger.tla").read()
+a="""         /\\ fcents\x27 = dcents + v            \\* handle_coin_event saves"""
+assert a in s
+s=s.replace(a,"").replace("    /\\ UNCHANGED state\n    /\\ budget\x27 = budget - 1\n\n(* Web dashboard","    /\\ UNCHANGED <<state, fcents>>\n    /\\ budget\x27 = budget - 1\n\n(* Web dashboard")
+open("CoinLedger.tla","w").write(s)'
+run CoinLedger.tla CoinLedger.cfg "charge underflows past zero" '
+s=open("CoinLedger.tla").read()
+a="Max(0, dcents - Cost)"; assert a in s
+open("CoinLedger.tla","w").write(s.replace(a,"dcents - Cost - 100"))'
+
+echo "== Updater =="
+run Updater.tla Updater.cfg "restart fires during a call (pre-#225)" '
+s=open("Updater.tla").read()
+a="""    /\\ ~inCall
+    \\* Records whether"""
+assert a in s; open("Updater.tla","w").write(s.replace(a,"""    \\* Records whether""",1))'
+run Updater.tla Updater.cfg "build failure strands the tree (pre-#224)" '
+s=open("Updater.tla").read()
+a="""    /\\ src\x27    = "old"            \\* #224: rollback_to(prev_commit)"""
+assert a in s; open("Updater.tla","w").write(s.replace(a,"""    /\\ UNCHANGED src"""))'
+run Updater.tla Updater.cfg "restart exit code ignored (pre-fix)" '
+s=open("Updater.tla").read()
+a="""    /\\ status\x27 = "err_restart"       \\* now checked -- updater.c:273"""
+assert a in s; open("Updater.tla","w").write(s.replace(a,"""    /\\ status\x27 = "success\"""" ))'
+
+echo "== LockOrder =="
+run LockOrder.tla LockOrder.cfg "plugin callback takes daemon_state under plugins_mutex" '
+s=open("LockOrder.tla").read()
+a="Chains == IF Mutated THEN MutatedChains ELSE RealChains"
+assert a in s; open("LockOrder.tla","w").write(s.replace(a,"Chains == MutatedChains"))'
+
+echo
+if [ "$fails" -eq 0 ]; then echo "All properties caught their mutation."; else echo "$fails property/properties did not catch their mutation."; fi
+exit $fails


### PR DESCRIPTION
Not a new feature — an audit of the specs I already shipped, because I twice found a property passing for a reason unrelated to the system.

## Why

A green TLC run is not evidence a property is doing anything, and the output looks identical either way:

- **`LockOrder.tla`** relied on TLC's built-in deadlock detection, which flags only a state with *no successor*. A lock-order bug doesn't produce one — two threads deadlock while three keep running — so it reported "no error" on a deliberately-cycled version of itself.
- **`Updater.tla`**'s `RestartOk` both assigned `callDropped'` *and* listed it in `UNCHANGED`. That contradiction silently disabled the action whenever a call was up, so the guard under test was never exercised.

Both were caught by accident. That's not a method, and `EventOrdering` and `CoinLedger` had **twelve properties I'd never checked this way**.

## What this adds

`tests/mutation_audit.sh` — for each property, break the system in the way that property is meant to notice, and confirm it fires. Eleven mutations across the four specs, each reproducing a real historical bug (`call_active` unguarded pre-#100, `coin_return` skipping the plugin ledger pre-#222, the restart firing mid-call pre-#225, and so on).

All eleven are currently caught.

## What it found

Three properties are **subsumed** and can never be the invariant TLC reports:

| Property | Implied by |
|---|---|
| `NonNegative` (EventOrdering) | `TypeOK`'s `cents \in Nat` |
| `NonNegative` (CoinLedger) | `TypeOK`'s `\in Nat` |
| `NeverPromiseMoreThanHeld` | `LedgerAgreement` |

The underflow mutation is caught by `TypeOK`, not by `NonNegative`. These aren't wrong — they read well — but reporting "six invariants verified" when two of them cannot fire **overstates the coverage**, and I've been doing exactly that. They're kept and now say so in place.

No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)