### PR TITLE
fix(#247): keep retrying the serial reconnect after the first failure

### DIFF
--- a/host/millennium_sdk.c
+++ b/host/millennium_sdk.c
@@ -437,24 +437,42 @@ void millennium_client_check_serial(struct millennium_client *client) {
     long elapsed;
     int backoff;
 #endif
-    if (!client || client->display_fd == -1) return;
+    if (!client) return;
 
 #if SERIAL_WATCHDOG_ENABLED
     clock_gettime(CLOCK_MONOTONIC, &now);
     elapsed = now.tv_sec - client->last_serial_activity.tv_sec;
 
-    /* (#59) Send periodic keepalive when idle to avoid false watchdog triggers.
-     * Arduino consumes CMD_KEEPALIVE (0x06) as no-op; write_command updates last_serial_activity. */
-    if (client->serial_healthy && elapsed >= SERIAL_KEEPALIVE_INTERVAL && elapsed < SERIAL_WATCHDOG_SECONDS) {
-        millennium_client_write_command(client, CMD_KEEPALIVE, NULL, 0);
-    }
-
-    if (client->serial_healthy && elapsed > SERIAL_WATCHDOG_SECONDS) {
-        logger_warnf_with_category("SDK",
-            "Serial watchdog: no activity for %ld seconds, marking link dead", elapsed);
+    /* (#247) A failed reconnect leaves display_fd == -1, because
+     * open_serial_port() drops the stale fd before it tries the open.  This
+     * used to be an early return at the top of this function, which stranded
+     * the daemon for good: the retry that would reopen the port lives further
+     * down, so the first failed attempt was also the last one and the link
+     * never came back without a restart.  Treat a missing fd as a dead link
+     * instead -- getting it back is exactly this function's job. */
+    if (client->display_fd == -1 && client->serial_healthy) {
+        logger_warn_with_category("SDK", "Serial fd is closed, marking link dead");
         client->serial_healthy = 0;
         client->reconnect_attempts = 0;
         client->next_reconnect_time = now;
+    }
+
+    /* The keepalive and the activity watchdog both need a live fd; skip them
+     * while the link is down and fall through to the reconnect below. */
+    if (client->display_fd != -1) {
+        /* (#59) Send periodic keepalive when idle to avoid false watchdog triggers.
+         * Arduino consumes CMD_KEEPALIVE (0x06) as no-op; write_command updates last_serial_activity. */
+        if (client->serial_healthy && elapsed >= SERIAL_KEEPALIVE_INTERVAL && elapsed < SERIAL_WATCHDOG_SECONDS) {
+            millennium_client_write_command(client, CMD_KEEPALIVE, NULL, 0);
+        }
+
+        if (client->serial_healthy && elapsed > SERIAL_WATCHDOG_SECONDS) {
+            logger_warnf_with_category("SDK",
+                "Serial watchdog: no activity for %ld seconds, marking link dead", elapsed);
+            client->serial_healthy = 0;
+            client->reconnect_attempts = 0;
+            client->next_reconnect_time = now;
+        }
     }
 
     if (!client->serial_healthy) {


### PR DESCRIPTION
Fixes #247.

`millennium_client_check_serial()` opened with an early return on `display_fd == -1`:

```c
if (!client || client->display_fd == -1) return;
```

but `open_serial_port()` drops the stale fd **before** it attempts the open, so a failed reconnect leaves it at `-1`. The retry/backoff logic lives further down the same function, past that guard — so the first failed attempt was also the last one. Any serial disconnect outlasting ~2 s stranded the daemon: coin validator, VFD, keypad, hook switch and magstripe all dead until someone restarted the service. Since a re-enumerating Arduino takes far longer than 2 s, reconnect essentially never worked.

This treats a closed fd as a dead link — reopening it is exactly what the function is for — and gates the keepalive and activity watchdog on having a live fd so they fall through to the reconnect.

## Verification

On the phone, unbinding the Beta Micro from `cdc_acm` via sysfs, waiting past the 60 s watchdog, then rebinding.

Before:
```
[13:58:09] [WARN] Serial watchdog: no activity for 61 seconds, marking link dead
[13:58:09] [INFO] Serial reconnect attempt 1
[13:58:09] [WARN] Serial reconnect failed, next attempt in 2 seconds
                  <nothing further -- device was back 80s later>
```
Health stayed `CRITICAL` until `systemctl restart daemon.service`.

After:
```
[14:04:49] [WARN] Serial watchdog: no activity for 61 seconds, marking link dead
[14:04:49] [INFO] Serial reconnect attempt 1     (backoff 2s)
[14:05:03] [INFO] Serial reconnect attempt 4     (backoff 16s)
[14:05:19] [INFO] Serial reconnect attempt 5 -> Serial port reopened successfully
```
`/api/health` returned to `HEALTHY` with no restart.

`make test` 121 passed / 0 failed; `compile-check` clean under Apple clang and `gcc-15`; builds clean on the Pi GCC 10.2.1.

## Caveat

`check_serial` is stubbed out by both `simulator.c` and `tests/unit_tests.c`, so this path has **no automated coverage** — which is how the bug survived. Its evidence is the hardware run above. Giving it a testable seam around `open_serial_port` is worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)