### PR TITLE
fix(#239): replay the tracked coin gate on serial reconnect

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -81,8 +81,11 @@ events.o: events.c events.h
 event_processor.o: event_processor.c event_processor.h events.h
 	$(CC) event_processor.c -o event_processor.o -c $(CFLAGS)
 
-millennium_sdk.o: millennium_sdk.c millennium_sdk.h events.h pjsip_interface.h config.h
+millennium_sdk.o: millennium_sdk.c millennium_sdk.h events.h pjsip_interface.h config.h coin_gate.h
 	$(CC) millennium_sdk.c -o millennium_sdk.o -c $(CFLAGS)
+
+coin_gate.o: coin_gate.c coin_gate.h
+	$(CC) coin_gate.c -o coin_gate.o -c $(CFLAGS)
 
 state_persistence.o: state_persistence.c state_persistence.h daemon_state.h logger.h
 	$(CC) state_persistence.c -o state_persistence.o -c $(CFLAGS)
@@ -136,8 +139,8 @@ plugins/trivia.o: plugins/trivia.c plugins.h plugin_sdk.h config.h
 plugins/time_operator.o: plugins/time_operator.c plugins.h plugin_sdk.h
 	$(CC) plugins/time_operator.c -o plugins/time_operator.o -c $(CFLAGS)
 
-daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o wav.o updater.o
-	$(CC) daemon.o daemon_state.o clock_source.o millennium_sdk.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o wav.o updater.o -o daemon $(LDFLAGS) -lm
+daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o coin_gate.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o wav.o updater.o
+	$(CC) daemon.o daemon_state.o clock_source.o millennium_sdk.o coin_gate.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o wav.o updater.o -o daemon $(LDFLAGS) -lm
 
 # Simulator object file
 simulator.o: simulator.c millennium_sdk.h events.h config.h daemon_state.h logger.h metrics.h call_metrics.h plugins.h
@@ -156,9 +159,9 @@ simulator: $(SIM_OBJS)
 all: daemon
 
 # Unit test binary
-UNIT_TEST_OBJS = tests/unit_tests.o daemon_state.o clock_source.o events.o event_processor.o config.o cli.o logger.o metrics.o call_metrics.o health_monitor.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o wav.o updater.o conn_queue.o
+UNIT_TEST_OBJS = tests/unit_tests.o coin_gate.o daemon_state.o clock_source.o events.o event_processor.o config.o cli.o logger.o metrics.o call_metrics.o health_monitor.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o wav.o updater.o conn_queue.o
 
-tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h config.h cli.h daemon_state.h plugins.h logger.h metrics.h call_metrics.h millennium_sdk.h updater.h state_persistence.h conn_queue.h health_monitor.h
+tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h coin_gate.h config.h cli.h daemon_state.h plugins.h logger.h metrics.h call_metrics.h millennium_sdk.h updater.h state_persistence.h conn_queue.h health_monitor.h
 	$(CC) tests/unit_tests.c -o tests/unit_tests.o -c $(CFLAGS) -I.
 
 # Unit tests don't use time wrapping; link ALSA on Linux for jukebox
@@ -194,7 +197,7 @@ test: simulator unit_tests
 # ALSA paths in audio_tones.c, plus web_server/websocket/health_monitor — is
 # never compiled by `make test`. This target catches type/syntax errors in that
 # code on any Linux box with libasound2-dev (e.g. CI), short of a full link.
-COMPILE_CHECK_OBJS = daemon.o daemon_state.o clock_source.o millennium_sdk.o events.o \
+COMPILE_CHECK_OBJS = daemon.o daemon_state.o clock_source.o millennium_sdk.o coin_gate.o events.o \
 	event_processor.o config.o logger.o health_monitor.o metrics.o \
 	metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o \
 	plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o \

--- a/host/coin_gate.c
+++ b/host/coin_gate.c
@@ -1,0 +1,45 @@
+#include "coin_gate.h"
+
+/* (#239) The daemon gates the validator with three commands, each paired with
+ * its terminator exactly as the call sites in daemon.c send them:
+ *
+ *   'a'       accept coins    -- hook up, on the IDLE_DOWN -> IDLE_UP edge
+ *   'c' 'z'   reject coins    -- hook down, remote hangup, call ended
+ *   'f' 'z'   re-init/enable  -- a call is coming in
+ *
+ * Note 'a' travels alone; only 'c' and 'f' take the 'z' terminator.  See
+ * docs/COIN_VALIDATOR.md.
+ */
+uint8_t millennium_coin_gate_track(uint8_t gate, uint8_t cmd) {
+    if (cmd == 'a' || cmd == 'c' || cmd == 'f') {
+        return cmd;
+    }
+    /* 'z' (terminator) and '@' (validator hard reset) are not gate changes. */
+    return gate;
+}
+
+size_t millennium_coin_gate_resync(uint8_t gate, uint8_t *out, size_t cap) {
+    if (!out || cap < COIN_GATE_RESYNC_MAX) {
+        return 0;
+    }
+
+    if (gate == 'a') {
+        out[0] = 'a';
+        return 1;
+    }
+
+    if (gate == 'f') {
+        out[0] = 'f';
+        out[1] = 'z';
+        return 2;
+    }
+
+    /* 'c', or nothing tracked yet because the link died before the daemon ever
+     * gated the validator.  Reject is the fail-safe answer either way: an
+     * armed validator with the handset down physically swallows a coin that
+     * handle_coin_event() then refuses to credit, because it only credits in
+     * IDLE_UP.  Refusing the coin loses nobody's money. */
+    out[0] = 'c';
+    out[1] = 'z';
+    return 2;
+}

--- a/host/coin_gate.h
+++ b/host/coin_gate.h
@@ -1,0 +1,26 @@
+/* Coin validator gate tracking (#239).
+ *
+ * The daemon opens and closes the Mars/MEI TRC-6500's coin gate with a handful
+ * of one-byte commands.  When the serial link drops and comes back, the SDK
+ * has to put the validator back into whatever gate state the daemon last asked
+ * for -- the same way it re-sends the last display contents.  These helpers
+ * keep that decision in one testable place, away from the serial layer.
+ */
+#ifndef COIN_GATE_H
+#define COIN_GATE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Longest sequence millennium_coin_gate_resync() emits. */
+#define COIN_GATE_RESYNC_MAX 2
+
+/* Fold a byte the daemon is about to send to the validator into the tracked
+ * gate state.  Returns the new state; non-gate bytes leave it unchanged. */
+uint8_t millennium_coin_gate_track(uint8_t gate, uint8_t cmd);
+
+/* Write the byte sequence that restores `gate` into `out` and return its
+ * length.  `cap` must be at least COIN_GATE_RESYNC_MAX; returns 0 otherwise. */
+size_t millennium_coin_gate_resync(uint8_t gate, uint8_t *out, size_t cap);
+
+#endif /* COIN_GATE_H */

--- a/host/docs/COIN_VALIDATOR.md
+++ b/host/docs/COIN_VALIDATOR.md
@@ -11,13 +11,43 @@ The daemon sends 1-byte commands to the Mars/MEI TRC-6500 coin validator via the
 | `'f'` (0x66) | Serial reconnect, call incoming | Re-init / enable validator |
 | `'z'` (0x7a) | After `'c'` or `'f'` | Commit/execute (sequence terminator?) |
 
-## Serial Reconnect (#110)
+Note `'a'` travels alone — `daemon.c` sends no `'z'` after it. Only `'c'` and `'f'` are terminated.
 
-When the serial link recovers (`open_serial_port` succeeds), the SDK immediately sends `'f'` to re-init the validator. This may cause problems if:
+## Serial Reconnect (#110, #239)
 
-- A coin was mid-accept or mid-reject when the link dropped
-- The validator is in an uncertain state after a brief disconnect
+When the serial link recovers (`open_serial_port` succeeds), the SDK restores the
+gate to whatever state the daemon last asked for, replaying that call site's exact
+byte sequence. This mirrors how the same reconnect path re-sends the last display
+contents (see `SERIAL_DISCONNECT_RECOVERY.md`).
 
-**Risk**: Double-credit, lost coin, or validator stuck in weird state.
+The gate state is tracked in `client->coin_gate_cmd`, updated on every
+`millennium_client_write_to_coin_validator` call; the replay decision lives in
+`coin_gate.c` and is unit-tested:
 
-**Mitigation (future)**: A non-blocking delay (e.g. 2 s) before sending `'f'` would let in-progress coins settle. Would require storing reconnect timestamp and sending `'f'` on a later `check_serial` call.
+| Tracked gate | Replayed on reconnect |
+|---|---|
+| `'a'` (handset up) | `'a'` |
+| `'c'` (handset down) | `'c'` `'z'` |
+| `'f'` (call incoming) | `'f'` `'z'` |
+| nothing yet | `'c'` `'z'` |
+
+Untracked defaults to reject, which is the fail-safe direction: an armed validator
+with the handset on the hook physically swallows a coin that `handle_coin_event`
+then refuses to credit, because it only credits in `IDLE_UP`.
+
+**Previously (#239)**: this path sent a bare `'f'` unconditionally. That both
+dropped the `'z'` every other `'f'` call site pairs with — so the re-init may never
+have committed — and armed the validator regardless of hook state. Replaying the
+tracked gate fixes both without introducing any byte sequence the daemon does not
+already send elsewhere, so it needs no new assumption about what the TRC-6500 does
+with an unterminated `'f'`.
+
+**Still open**: whether `'z'` really is a commit/terminator is unconfirmed against
+the hardware; the table above just preserves each call site's existing pairing.
+
+**Risk (unchanged)**: a coin mid-accept or mid-reject when the link dropped is
+still unaccounted for.
+
+**Mitigation (future)**: a non-blocking delay (e.g. 2 s) before the replay would
+let in-progress coins settle. Would require storing the reconnect timestamp and
+replaying on a later `check_serial` call.

--- a/host/docs/SERIAL_DISCONNECT_RECOVERY.md
+++ b/host/docs/SERIAL_DISCONNECT_RECOVERY.md
@@ -22,6 +22,14 @@ When `open_serial_port` succeeds:
 
 **Result**: After reconnect, the display shows the correct state (e.g. "Call active | 2:15 remaining") because the SDK re-sends the last display content.
 
+## Coin Gate Re-sync on Reconnect (#239)
+
+The same reconnect path restores the coin validator's gate the same way it restores
+the display: by replaying the last command the daemon sent (`'a'`, `'c'` `'z'`, or
+`'f'` `'z'`), tracked in `client->coin_gate_cmd`. If the link died before the daemon
+ever gated the validator, the reconnect rejects coins rather than accepting them.
+See `COIN_VALIDATOR.md`.
+
 ## Buffered Updates While Disconnected
 
 While the serial link is down:

--- a/host/millennium_sdk.c
+++ b/host/millennium_sdk.c
@@ -6,6 +6,7 @@
 #include "pjsip_interface.h"
 #include "config.h"
 #include "logger.h"
+#include "coin_gate.h"
 #include <errno.h>
 #include <fcntl.h>
 /* #include <linux/serial.h> */ /* Linux-specific, not available on macOS */
@@ -466,10 +467,21 @@ void millennium_client_check_serial(struct millennium_client *client) {
         if (open_serial_port(client, client->serial_device_path) == 0) {
             logger_info_with_category("SDK", "Serial port reopened successfully");
 
-            /* Re-init coin validator (send 'f' command). See docs/COIN_VALIDATOR.md (#110) */
+            /* (#239) Put the coin gate back where the daemon last asked for
+             * it, replaying that call site's exact byte sequence -- the same
+             * idea as the display refresh below.  This used to send a bare
+             * 'f': it dropped the 'z' every other 'f' call site pairs with,
+             * and it armed the validator even with the handset on the hook,
+             * where handle_coin_event() drops the coin uncredited.
+             * See docs/COIN_VALIDATOR.md (#110). */
             {
-                uint8_t coin_init = 'f';
-                millennium_client_write_to_coin_validator(client, coin_init);
+                uint8_t coin_seq[COIN_GATE_RESYNC_MAX];
+                size_t coin_len = millennium_coin_gate_resync(
+                        client->coin_gate_cmd, coin_seq, sizeof(coin_seq));
+                size_t i;
+                for (i = 0; i < coin_len; i++) {
+                    millennium_client_write_to_coin_validator(client, coin_seq[i]);
+                }
             }
 
             /* Refresh display */
@@ -736,6 +748,11 @@ void millennium_client_write_to_display(struct millennium_client *client, const 
 
 void millennium_client_write_to_coin_validator(struct millennium_client *client, uint8_t data) {
     logger_debugf_with_category("SDK", "Writing to coin validator: %d", data);
+
+    /* (#239) Remember the gate state so a reconnect can restore it. */
+    if (client) {
+        client->coin_gate_cmd = millennium_coin_gate_track(client->coin_gate_cmd, data);
+    }
 
     /* Step 1: Write the command */
     millennium_client_write_command(client, 0x03, &data, 1);

--- a/host/millennium_sdk.h
+++ b/host/millennium_sdk.h
@@ -56,6 +56,10 @@ typedef struct millennium_client {
     int reconnect_attempts;
     struct timespec next_reconnect_time;
     char serial_device_path[256];
+
+    /* (#239) Last coin-gate command sent to the validator, replayed after a
+     * serial reconnect.  0 until the daemon gates the validator once. */
+    uint8_t coin_gate_cmd;
 } millennium_client_t;
 
 /* Function declarations */

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -8,6 +8,7 @@
 #include "../metrics.h"
 #include "../call_metrics.h"
 #include "../millennium_sdk.h"
+#include "../coin_gate.h"
 #include "../updater.h"
 #include "../plugin_sdk.h"
 #include "../clock_source.h"
@@ -2247,6 +2248,85 @@ static void test_health_metrics_published(void) {
     health_monitor_unregister_check("ut_sip");
 }
 
+/* ── Coin validator gate (#239) ─────────────────────────────────── */
+
+/* Run the tracked gate through the byte sequence a call site sends, the way
+ * millennium_client_write_to_coin_validator() folds each byte in one at a
+ * time, and return the resulting state. */
+static uint8_t gate_after(uint8_t gate, const char *bytes) {
+    size_t i;
+    for (i = 0; bytes[i]; i++) {
+        gate = millennium_coin_gate_track(gate, (uint8_t)bytes[i]);
+    }
+    return gate;
+}
+
+static void test_coin_gate_tracks_gate_commands(void) {
+    TEST_ASSERT_EQ_INT(gate_after(0, "a"), 'a');    /* hook up */
+    TEST_ASSERT_EQ_INT(gate_after(0, "cz"), 'c');   /* hook down */
+    TEST_ASSERT_EQ_INT(gate_after(0, "fz"), 'f');   /* call incoming */
+    /* Last one wins, and the 'z' terminator never clobbers the gate. */
+    TEST_ASSERT_EQ_INT(gate_after(0, "acz"), 'c');
+    TEST_ASSERT_EQ_INT(gate_after(0, "czfza"), 'a');
+}
+
+static void test_coin_gate_ignores_non_gate_bytes(void) {
+    TEST_ASSERT_EQ_INT(millennium_coin_gate_track('a', 'z'), 'a');
+    TEST_ASSERT_EQ_INT(millennium_coin_gate_track('a', '@'), 'a');
+    TEST_ASSERT_EQ_INT(millennium_coin_gate_track('c', 'q'), 'c');
+    TEST_ASSERT_EQ_INT(millennium_coin_gate_track(0, 'z'), 0);
+}
+
+static void test_coin_gate_resync_replays_call_site_sequence(void) {
+    uint8_t seq[COIN_GATE_RESYNC_MAX];
+
+    /* 'a' travels alone -- daemon.c sends no 'z' on the IDLE_UP edge. */
+    TEST_ASSERT_EQ_INT((int)millennium_coin_gate_resync('a', seq, sizeof(seq)), 1);
+    TEST_ASSERT_EQ_INT(seq[0], 'a');
+
+    TEST_ASSERT_EQ_INT((int)millennium_coin_gate_resync('c', seq, sizeof(seq)), 2);
+    TEST_ASSERT_EQ_INT(seq[0], 'c');
+    TEST_ASSERT_EQ_INT(seq[1], 'z');
+
+    /* #239: the reconnect path used to send this one without its 'z'. */
+    TEST_ASSERT_EQ_INT((int)millennium_coin_gate_resync('f', seq, sizeof(seq)), 2);
+    TEST_ASSERT_EQ_INT(seq[0], 'f');
+    TEST_ASSERT_EQ_INT(seq[1], 'z');
+}
+
+static void test_coin_gate_resync_untracked_rejects(void) {
+    uint8_t seq[COIN_GATE_RESYNC_MAX];
+
+    /* #239: reconnecting before the daemon ever gated the validator must not
+     * arm it -- a coin accepted with the handset down is never credited. */
+    TEST_ASSERT_EQ_INT((int)millennium_coin_gate_resync(0, seq, sizeof(seq)), 2);
+    TEST_ASSERT_EQ_INT(seq[0], 'c');
+    TEST_ASSERT_EQ_INT(seq[1], 'z');
+}
+
+/* #239's core claim: a reconnect while the handset is on the hook must leave
+ * the validator closed, and one with the handset lifted must leave it open. */
+static void test_coin_gate_resync_follows_hook_state(void) {
+    uint8_t seq[COIN_GATE_RESYNC_MAX];
+    uint8_t gate;
+
+    gate = gate_after(0, "cz");  /* handset down */
+    TEST_ASSERT_EQ_INT((int)millennium_coin_gate_resync(gate, seq, sizeof(seq)), 2);
+    TEST_ASSERT_EQ_INT(seq[0], 'c');
+
+    gate = gate_after(gate, "a");  /* handset lifted */
+    TEST_ASSERT_EQ_INT((int)millennium_coin_gate_resync(gate, seq, sizeof(seq)), 1);
+    TEST_ASSERT_EQ_INT(seq[0], 'a');
+}
+
+static void test_coin_gate_resync_rejects_short_buffer(void) {
+    uint8_t seq[COIN_GATE_RESYNC_MAX];
+
+    TEST_ASSERT_EQ_INT((int)millennium_coin_gate_resync('c', NULL, sizeof(seq)), 0);
+    TEST_ASSERT_EQ_INT((int)millennium_coin_gate_resync('c', seq, 1), 0);
+    TEST_ASSERT_EQ_INT((int)millennium_coin_gate_resync('c', seq, 0), 0);
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -2316,6 +2396,14 @@ int main(void) {
     TEST_SUITE_RUN(test_sdk_rand_choice);
     TEST_SUITE_RUN(test_sdk_balance);
     TEST_SUITE_RUN(test_sdk_state);
+
+    TEST_SUITE_BEGIN("Coin Validator Gate");
+    TEST_SUITE_RUN(test_coin_gate_tracks_gate_commands);
+    TEST_SUITE_RUN(test_coin_gate_ignores_non_gate_bytes);
+    TEST_SUITE_RUN(test_coin_gate_resync_replays_call_site_sequence);
+    TEST_SUITE_RUN(test_coin_gate_resync_untracked_rejects);
+    TEST_SUITE_RUN(test_coin_gate_resync_follows_hook_state);
+    TEST_SUITE_RUN(test_coin_gate_resync_rejects_short_buffer);
 
     TEST_SUITE_BEGIN("Clock Seam");
     TEST_SUITE_RUN(test_clock_default_is_real_time);


### PR DESCRIPTION
Fixes #239.

The reconnect path sent a bare `'f'` to the coin validator, which was wrong twice over:

1. **Missing terminator** — it dropped the `'z'` that every other `'f'`/`'c'` call site pairs with, so the re-init may never have committed.
2. **Ignored hook state** — it armed the validator unconditionally. A reconnect with the handset on the hook left the mech accepting coins that `handle_coin_event()` then refuses to credit, since it only credits in `IDLE_UP`. The coin is physically swallowed and the customer gets nothing.

## Approach

The issue flagged that fixing this blind was unsafe, because the right answer depends on what the Mars/MEI TRC-6500 actually does with an unterminated `'f'` — and `COIN_VALIDATOR.md` records that opcode with a question mark.

This sidesteps that question rather than answering it. The SDK now tracks the last gate command the daemon sent and **replays it with that call site's exact sequence**:

| Tracked gate | Replayed on reconnect |
|---|---|
| `'a'` (handset up) | `'a'` |
| `'c'` (handset down) | `'c'` `'z'` |
| `'f'` (call incoming) | `'f'` `'z'` |
| nothing tracked yet | `'c'` `'z'` |

Every one of those is a sequence `daemon.c` already sends in production, so the fix introduces **no new assumption about the hardware**. The unterminated-`'f'` question stops being load-bearing and goes back to being a documentation `?`, still flagged as open in the doc.

The untracked default is reject, which is the fail-safe direction: an armed validator with the handset down loses the customer's coin; a closed one loses nobody anything.

This mirrors what the same reconnect path already does for `display_message`.

## Testing

The decision lives in a new `coin_gate.c` as pure logic, because both `simulator.c` and `tests/unit_tests.c` stub the SDK's serial layer out entirely — so the reconnect path itself is unreachable from either harness. That keeps the gate logic unit-testable on the Mac. Six new tests; **127 passed / 0 failed**, scenarios pass, `compile-check` clean under Apple clang and `gcc-15`, builds clean on the Pi GCC 10.2.1.

## Hardware verification

On the phone, unbinding the Beta Micro from `cdc_acm` and rebinding past the watchdog:

```
handset DOWN (tracked gate 'c'):
[14:05:19] Serial port reopened successfully
[14:05:19] Writing to coin validator: 99     <- 'c'
[14:05:19] Writing to coin validator: 122    <- 'z'

handset UP (tracked gate 'a'):
[14:07:45] Serial port reopened successfully
[14:07:45] Writing to coin validator: 97     <- 'a', alone
```

Both cases previously wrote `102 'f'`.

## Note

Reproducing the reconnect at all first required fixing #247 (the retry gave up after one attempt), so that hardware run was done with #248 applied. This PR is independent of it and merges cleanly either way, but #248 is what makes this code path actually reachable in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)