### PR TITLE
fix(#250): stamp the deployed binary with the commit it was built from

### DIFF
--- a/.claude/skills/deploy-daemon/SKILL.md
+++ b/.claude/skills/deploy-daemon/SKILL.md
@@ -59,11 +59,21 @@ Pi layout: scratch build dir `~/millennium-pjsip/host` · installed binary
 
 3. **Rebuild — `make clean` FIRST.** rsync preserves source mtimes, so a plain
    `make daemon` often prints "up to date" and silently keeps the OLD binary.
-   The build takes ~40 s on the Pi Zero 2 W:
+   The build takes ~40 s on the Pi Zero 2 W.
+
+   **Pass `GIT_HASH` (#250).** The rsync above excludes `.git`, so `git rev-parse`
+   on the Pi fails and the binary would be stamped `git unknown` — leaving no way
+   to ask a running phone which commit it is on. Compute it on the Mac and hand it
+   to the remote `make`; the `-dirty` suffix is what tells you the deploy did not
+   match any commit:
    ```bash
+   HASH=$(git rev-parse --short HEAD)
+   git diff --quiet HEAD || HASH="$HASH-dirty"
    ssh -i "$KEY" -o IdentitiesOnly=yes -o BatchMode=yes "$PI" \
-     'cd ~/millennium-pjsip/host && make clean && make daemon 2>&1 | tail -15'
+     "cd ~/millennium-pjsip/host && make clean && make daemon GIT_HASH=$HASH 2>&1 | tail -15"
    ```
+   Confirm it took, in step 5: `millennium-daemon --version` should report that
+   hash, not `unknown`.
    GOTCHA: never `pkill -f "make daemon"` over SSH — the remote shell's own argv
    contains that string, so it self-matches and kills your command. Use a `[m]ake`
    bracket pattern or check the binary mtime instead.
@@ -90,9 +100,11 @@ Pi layout: scratch build dir `~/millennium-pjsip/host` · installed binary
    ssh -i "$KEY" -o IdentitiesOnly=yes -o BatchMode=yes "$PI" \
      'systemctl is-active daemon.service; \
      echo NRestarts=$(systemctl show daemon.service -p NRestarts --value); \
+     /usr/local/bin/millennium-daemon --version; \
      curl -s --max-time 4 http://127.0.0.1:80/api/state'
    ```
-   Expect `active`, `NRestarts=0`, `"sip_registered":1`, empty `sip_last_error`.
+   Expect `active`, `NRestarts=0`, `"sip_registered":1`, empty `sip_last_error`,
+   and a `--version` reporting the hash from step 3 rather than `git unknown`.
    On failure: check `sip.*` keys in `/etc/millennium/daemon.conf` and
    `sudo journalctl -u daemon.service -n 50 --no-pager`.
 

--- a/host/Makefile
+++ b/host/Makefile
@@ -29,8 +29,27 @@ CFLAGS=-g -O3 -Wall -Wextra -std=gnu89 -Wdeclaration-after-statement -Werror
 # makefile assignments.
 CC = gcc
 
-# Build version info
-GIT_HASH := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+# Build version info.
+#
+# GIT_HASH is deliberately overridable from the command line (#250): the Pi
+# deploy rsyncs host/ WITHOUT .git, so `git rev-parse` there always fails and
+# every deployed binary used to be stamped "unknown" -- leaving no way to ask a
+# running phone which commit it is on. The deploy passes the hash from the Mac:
+#
+#   make daemon GIT_HASH="$(git rev-parse --short HEAD)"
+#
+# A `:=` assignment (not `override`) is what makes that work, since command-line
+# variables beat makefile assignments.
+#
+# The `-dirty` suffix matters as much as the hash: deploying an uncommitted
+# working tree is routine during development, and a bare hash would claim the
+# binary matches a commit it does not.
+GIT_HASH := $(shell if git rev-parse --short HEAD >/dev/null 2>&1; then \
+	    printf '%s' "`git rev-parse --short HEAD`"; \
+	    git diff --quiet HEAD 2>/dev/null || printf '%s' '-dirty'; \
+	else \
+	    printf 'unknown'; \
+	fi)
 BUILD_TIME := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "unknown")
 VERSION_CFLAGS = -DGIT_HASH='"$(GIT_HASH)"' -DBUILD_TIME='"$(BUILD_TIME)"'
 


### PR DESCRIPTION
Fixes #250.

The deploy rsyncs `host/` **without** `.git`, so `git rev-parse` on the Pi always failed and every deployed binary reported `git unknown`:

```
millennium-daemon 0.3.0 (git unknown, built 2026-08-01T21:28:24Z)
```

There was no way to ask a running phone which commit it was on — only a build timestamp, which tells you *when* someone deployed, not *what*. The Pi's own checkout at `~/millennium` is unrelated to the installed binary, so it actively misleads. This came up concretely at the start of the #239 work: the phone was running a binary built 2026-06-15 and the only way to tell it predated #222/#223/#224/#225 was to diff behavior.

## Change

`GIT_HASH` was already overridable — it is a plain `:=` assignment, and command-line variables beat makefile assignments — the deploy just never passed one. This documents that contract in the Makefile and updates the `deploy-daemon` skill to compute the hash on the Mac and hand it to the remote `make`:

```bash
HASH=$(git rev-parse --short HEAD)
git diff --quiet HEAD || HASH="$HASH-dirty"
ssh … "cd ~/millennium-pjsip/host && make clean && make daemon GIT_HASH=$HASH …"
```

The `-dirty` suffix is the part that earns its keep: deploying an uncommitted working tree is routine while developing (it happened twice during the #239/#247 work), and a bare hash would claim the binary matches a commit it does not.

The skill's verify step now also runs `--version`, so a deploy that silently loses the hash is caught rather than discovered weeks later.

## Verification

```
$ make -n version.o | grep -o "GIT_HASH='[^']*'"
GIT_HASH='"e6137d8-dirty"'          # working tree modified

$ make -n version.o GIT_HASH=deadbee
GIT_HASH='"deadbee"'                # override takes
```

Falls back to `unknown` when not in a git repo at all, as before — and does not spuriously append `-dirty` in that case.

`make test` 127 passed / 0 failed; `compile-check` clean under Apple clang and `gcc-15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)