### PR TITLE
test: give the serial recovery policy a testable seam (#247 follow-up)

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -100,11 +100,14 @@ events.o: events.c events.h
 event_processor.o: event_processor.c event_processor.h events.h
 	$(CC) event_processor.c -o event_processor.o -c $(CFLAGS)
 
-millennium_sdk.o: millennium_sdk.c millennium_sdk.h events.h pjsip_interface.h config.h coin_gate.h
+millennium_sdk.o: millennium_sdk.c millennium_sdk.h events.h pjsip_interface.h config.h coin_gate.h serial_recovery.h
 	$(CC) millennium_sdk.c -o millennium_sdk.o -c $(CFLAGS)
 
 coin_gate.o: coin_gate.c coin_gate.h
 	$(CC) coin_gate.c -o coin_gate.o -c $(CFLAGS)
+
+serial_recovery.o: serial_recovery.c serial_recovery.h millennium_sdk.h
+	$(CC) serial_recovery.c -o serial_recovery.o -c $(CFLAGS)
 
 state_persistence.o: state_persistence.c state_persistence.h daemon_state.h logger.h
 	$(CC) state_persistence.c -o state_persistence.o -c $(CFLAGS)
@@ -158,8 +161,8 @@ plugins/trivia.o: plugins/trivia.c plugins.h plugin_sdk.h config.h
 plugins/time_operator.o: plugins/time_operator.c plugins.h plugin_sdk.h
 	$(CC) plugins/time_operator.c -o plugins/time_operator.o -c $(CFLAGS)
 
-daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o coin_gate.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o wav.o updater.o
-	$(CC) daemon.o daemon_state.o clock_source.o millennium_sdk.o coin_gate.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o wav.o updater.o -o daemon $(LDFLAGS) -lm
+daemon: daemon.o daemon_state.o clock_source.o millennium_sdk.o coin_gate.o serial_recovery.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o wav.o updater.o
+	$(CC) daemon.o daemon_state.o clock_source.o millennium_sdk.o coin_gate.o serial_recovery.o pjsip_interface.o events.o event_processor.o config.o cli.o logger.o health_monitor.o metrics.o metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o audio_tones.o wav.o updater.o -o daemon $(LDFLAGS) -lm
 
 # Simulator object file
 simulator.o: simulator.c millennium_sdk.h events.h config.h daemon_state.h logger.h metrics.h call_metrics.h plugins.h
@@ -178,9 +181,9 @@ simulator: $(SIM_OBJS)
 all: daemon
 
 # Unit test binary
-UNIT_TEST_OBJS = tests/unit_tests.o coin_gate.o daemon_state.o clock_source.o events.o event_processor.o config.o cli.o logger.o metrics.o call_metrics.o health_monitor.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o wav.o updater.o conn_queue.o
+UNIT_TEST_OBJS = tests/unit_tests.o coin_gate.o serial_recovery.o daemon_state.o clock_source.o events.o event_processor.o config.o cli.o logger.o metrics.o call_metrics.o health_monitor.o plugins.o plugin_sdk.o plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o plugins/number_guess.o plugins/simon.o plugins/dial_a_joke.o plugins/trivia.o plugins/time_operator.o state_persistence.o display_manager.o version.o wav.o updater.o conn_queue.o
 
-tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h coin_gate.h config.h cli.h daemon_state.h plugins.h logger.h metrics.h call_metrics.h millennium_sdk.h updater.h state_persistence.h conn_queue.h health_monitor.h
+tests/unit_tests.o: tests/unit_tests.c tests/test_framework.h coin_gate.h serial_recovery.h config.h cli.h daemon_state.h plugins.h logger.h metrics.h call_metrics.h millennium_sdk.h updater.h state_persistence.h conn_queue.h health_monitor.h
 	$(CC) tests/unit_tests.c -o tests/unit_tests.o -c $(CFLAGS) -I.
 
 # Unit tests don't use time wrapping; link ALSA on Linux for jukebox
@@ -216,7 +219,7 @@ test: simulator unit_tests
 # ALSA paths in audio_tones.c, plus web_server/websocket/health_monitor — is
 # never compiled by `make test`. This target catches type/syntax errors in that
 # code on any Linux box with libasound2-dev (e.g. CI), short of a full link.
-COMPILE_CHECK_OBJS = daemon.o daemon_state.o clock_source.o millennium_sdk.o coin_gate.o events.o \
+COMPILE_CHECK_OBJS = daemon.o daemon_state.o clock_source.o millennium_sdk.o coin_gate.o serial_recovery.o events.o \
 	event_processor.o config.o logger.o health_monitor.o metrics.o \
 	metrics_server.o call_metrics.o web_server.o websocket.o conn_queue.o plugins.o plugin_sdk.o \
 	plugins/classic_phone.o plugins/fortune_teller.o plugins/jukebox.o \

--- a/host/docs/SERIAL_DISCONNECT_RECOVERY.md
+++ b/host/docs/SERIAL_DISCONNECT_RECOVERY.md
@@ -38,6 +38,42 @@ While the serial link is down:
 - The actual `write()` to the fd may fail (broken link), but the in-memory `display_message` is updated.
 - When reconnect succeeds, we have the latest content and re-send it.
 
+## Recovery Policy (#247)
+
+The decision `millennium_client_check_serial` makes each pass — idle, keepalive,
+declare dead, or retry the reopen — lives in `serial_recovery.c` as pure logic:
+
+```c
+serial_action_t serial_recovery_next_action(const serial_link_state_t *state);
+int             serial_recovery_backoff_seconds(int reconnect_attempts);
+```
+
+`check_serial` samples the link into a `serial_link_state_t`, asks for the verdict,
+and carries it out. Marking the link dead makes a retry due immediately, so it
+re-asks and reconnects in the same pass.
+
+The split exists because `check_serial` itself is stubbed out by **both**
+`simulator.c` and `tests/unit_tests.c` — it touches real fds — so its policy had
+no coverage at all, which is how #247 shipped. The pure half is unit-tested on any
+platform, including the specific #247 state: fd closed while the health flag is
+still set must resolve to `MARK_DEAD`, never `NONE`.
+
 ## Testing
 
-A scenario test that unplugs the serial mid-call is difficult without hardware. Manual testing: start a call, unplug USB, wait for "Serial link recovered" in logs, verify the display shows current call state.
+Policy: covered by the `Serial Recovery` unit suite (`make test`), including the
+keepalive/watchdog boundaries, that retries never give up while the link is down,
+and that the backoff stays in range for an unbounded outage.
+
+Execution: still needs hardware. Unbinding the display Arduino from its driver on
+the Pi drives a real disconnect without touching the cable:
+
+```bash
+echo 1-1.3:1.0 | sudo tee /sys/bus/usb/drivers/cdc_acm/unbind   # ttyACM1 = Beta
+sleep 75                                                        # past the 60s watchdog
+echo 1-1.3:1.0 | sudo tee /sys/bus/usb/drivers/cdc_acm/bind
+```
+
+Expect retries backing off 2/4/8/16 s, `Serial port reopened successfully`, the
+coin gate replayed (see `COIN_VALIDATOR.md`), and `/api/health` returning to
+`HEALTHY` on its own. The `by-id` symlink is what makes the rebind transparent —
+the port may come back as a different `ttyACM*`.

--- a/host/millennium_sdk.c
+++ b/host/millennium_sdk.c
@@ -7,6 +7,7 @@
 #include "config.h"
 #include "logger.h"
 #include "coin_gate.h"
+#include "serial_recovery.h"
 #include <errno.h>
 #include <fcntl.h>
 /* #include <linux/serial.h> */ /* Linux-specific, not available on macOS */
@@ -435,50 +436,51 @@ int millennium_client_serial_is_healthy(struct millennium_client *client) {
 void millennium_client_check_serial(struct millennium_client *client) {
 #if SERIAL_WATCHDOG_ENABLED
     struct timespec now;
-    long elapsed;
+    serial_link_state_t st;
+    serial_action_t action;
     int backoff;
 #endif
     if (!client) return;
 
 #if SERIAL_WATCHDOG_ENABLED
     clock_gettime(CLOCK_MONOTONIC, &now);
-    elapsed = now.tv_sec - client->last_serial_activity.tv_sec;
 
-    /* (#247) A failed reconnect leaves display_fd == -1, because
-     * open_serial_port() drops the stale fd before it tries the open.  This
-     * used to be an early return at the top of this function, which stranded
-     * the daemon for good: the retry that would reopen the port lives further
-     * down, so the first failed attempt was also the last one and the link
-     * never came back without a restart.  Treat a missing fd as a dead link
-     * instead -- getting it back is exactly this function's job. */
-    if (client->display_fd == -1 && client->serial_healthy) {
-        logger_warn_with_category("SDK", "Serial fd is closed, marking link dead");
+    /* The policy lives in serial_recovery.c so it can be unit-tested; this
+     * function just samples the link and carries the verdict out (#247). */
+    st.fd_open = (client->display_fd != -1);
+    st.link_healthy = client->serial_healthy;
+    st.idle_seconds = now.tv_sec - client->last_serial_activity.tv_sec;
+    st.seconds_until_retry = client->next_reconnect_time.tv_sec - now.tv_sec;
+
+    action = serial_recovery_next_action(&st);
+
+    if (action == SERIAL_ACTION_MARK_DEAD) {
+        if (st.fd_open) {
+            logger_warnf_with_category("SDK",
+                "Serial watchdog: no activity for %ld seconds, marking link dead",
+                st.idle_seconds);
+        } else {
+            logger_warn_with_category("SDK", "Serial fd is closed, marking link dead");
+        }
         client->serial_healthy = 0;
         client->reconnect_attempts = 0;
         client->next_reconnect_time = now;
+
+        /* Marking the link dead makes a retry due immediately, so ask again and
+         * reconnect in this same pass -- which is what the daemon has always
+         * done on the pass where the watchdog fires. */
+        st.link_healthy = 0;
+        st.seconds_until_retry = 0;
+        action = serial_recovery_next_action(&st);
     }
 
-    /* The keepalive and the activity watchdog both need a live fd; skip them
-     * while the link is down and fall through to the reconnect below. */
-    if (client->display_fd != -1) {
-        /* (#59) Send periodic keepalive when idle to avoid false watchdog triggers.
-         * Arduino consumes CMD_KEEPALIVE (0x06) as no-op; write_command updates last_serial_activity. */
-        if (client->serial_healthy && elapsed >= SERIAL_KEEPALIVE_INTERVAL && elapsed < SERIAL_WATCHDOG_SECONDS) {
-            millennium_client_write_command(client, CMD_KEEPALIVE, NULL, 0);
-        }
-
-        if (client->serial_healthy && elapsed > SERIAL_WATCHDOG_SECONDS) {
-            logger_warnf_with_category("SDK",
-                "Serial watchdog: no activity for %ld seconds, marking link dead", elapsed);
-            client->serial_healthy = 0;
-            client->reconnect_attempts = 0;
-            client->next_reconnect_time = now;
-        }
+    /* (#59) Send periodic keepalive when idle to avoid false watchdog triggers.
+     * Arduino consumes CMD_KEEPALIVE (0x06) as no-op; write_command updates last_serial_activity. */
+    if (action == SERIAL_ACTION_KEEPALIVE) {
+        millennium_client_write_command(client, CMD_KEEPALIVE, NULL, 0);
     }
 
-    if (!client->serial_healthy) {
-        if (now.tv_sec < client->next_reconnect_time.tv_sec) return;
-
+    if (action == SERIAL_ACTION_RECONNECT) {
         logger_infof_with_category("SDK",
             "Serial reconnect attempt %d", client->reconnect_attempts + 1);
 
@@ -508,8 +510,7 @@ void millennium_client_check_serial(struct millennium_client *client) {
             }
         } else {
             client->reconnect_attempts++;
-            backoff = 1 << client->reconnect_attempts;
-            if (backoff > SERIAL_MAX_BACKOFF_SECONDS) backoff = SERIAL_MAX_BACKOFF_SECONDS;
+            backoff = serial_recovery_backoff_seconds(client->reconnect_attempts);
             client->next_reconnect_time.tv_sec = now.tv_sec + backoff;
             logger_warnf_with_category("SDK",
                 "Serial reconnect failed, next attempt in %d seconds", backoff);

--- a/host/serial_recovery.c
+++ b/host/serial_recovery.c
@@ -1,0 +1,56 @@
+#include "serial_recovery.h"
+
+serial_action_t serial_recovery_next_action(const serial_link_state_t *state) {
+    if (!state) return SERIAL_ACTION_NONE;
+
+    /* (#247) A closed fd means the link is down, whatever the health flag says.
+     * Testing this FIRST is the whole of that fix.  It used to be an early
+     * return at the top of check_serial, and open_serial_port() drops the stale
+     * fd before it tries the open -- so one failed reconnect left the fd closed
+     * and every later pass bailed out before reaching the retry below. */
+    if (!state->fd_open && state->link_healthy) {
+        return SERIAL_ACTION_MARK_DEAD;
+    }
+
+    if (state->fd_open && state->link_healthy) {
+        if (state->idle_seconds > SERIAL_WATCHDOG_SECONDS) {
+            return SERIAL_ACTION_MARK_DEAD;
+        }
+        /* (#59) Poke an idle-but-alive link so the watchdog doesn't fire on a
+         * phone nobody is using.  The upper bound leaves idle_seconds exactly
+         * equal to SERIAL_WATCHDOG_SECONDS doing nothing for one pass, which is
+         * the long-standing behaviour: by then the keepalive writes are already
+         * failing, so the next pass declares the link dead anyway. */
+        if (state->idle_seconds >= SERIAL_KEEPALIVE_INTERVAL &&
+            state->idle_seconds < SERIAL_WATCHDOG_SECONDS) {
+            return SERIAL_ACTION_KEEPALIVE;
+        }
+        return SERIAL_ACTION_NONE;
+    }
+
+    /* Link is already down: retry once the backoff has elapsed. */
+    if (!state->link_healthy && state->seconds_until_retry <= 0) {
+        return SERIAL_ACTION_RECONNECT;
+    }
+
+    return SERIAL_ACTION_NONE;
+}
+
+int serial_recovery_backoff_seconds(int reconnect_attempts) {
+    int backoff;
+
+    if (reconnect_attempts < 0) reconnect_attempts = 0;
+
+    /* Clamp before shifting.  reconnect_attempts climbs by one per failed
+     * retry and is never reset while the link stays down, so an outage lasting
+     * past roughly half an hour would otherwise evaluate 1 << 31 and shift a
+     * signed int past its width -- undefined behaviour.  The result is capped
+     * a moment later anyway, so clamping the exponent costs nothing. */
+    if (reconnect_attempts > 30) reconnect_attempts = 30;
+
+    backoff = 1 << reconnect_attempts;
+    if (backoff > SERIAL_MAX_BACKOFF_SECONDS) {
+        backoff = SERIAL_MAX_BACKOFF_SECONDS;
+    }
+    return backoff;
+}

--- a/host/serial_recovery.h
+++ b/host/serial_recovery.h
@@ -1,0 +1,40 @@
+/* Serial link watchdog / reconnect policy (#247).
+ *
+ * millennium_client_check_serial() decides, once per main-loop pass, whether to
+ * nudge an idle link, declare it dead, or retry the reopen.  That decision used
+ * to be tangled up with the syscalls that carry it out, and both simulator.c
+ * and tests/unit_tests.c stub the whole SDK serial layer -- so the policy had
+ * no coverage at all, which is how #247 (the reconnect that gave up after one
+ * failed attempt) survived.
+ *
+ * The policy lives here as pure logic so it can be unit-tested on any platform,
+ * leaving check_serial as the thin shell that executes it.
+ */
+#ifndef SERIAL_RECOVERY_H
+#define SERIAL_RECOVERY_H
+
+#include "millennium_sdk.h"   /* SERIAL_WATCHDOG_SECONDS and friends */
+
+typedef enum {
+    SERIAL_ACTION_NONE = 0,
+    SERIAL_ACTION_KEEPALIVE,   /* link is idle but alive; poke it (#59) */
+    SERIAL_ACTION_MARK_DEAD,   /* declare the link down and start retrying */
+    SERIAL_ACTION_RECONNECT    /* backoff elapsed; try to reopen the port */
+} serial_action_t;
+
+typedef struct {
+    int  fd_open;              /* client->display_fd != -1 */
+    int  link_healthy;         /* client->serial_healthy */
+    long idle_seconds;         /* now - last_serial_activity */
+    long seconds_until_retry;  /* next_reconnect_time - now; <= 0 means due */
+} serial_link_state_t;
+
+/* What check_serial should do this pass.  NULL state yields NONE. */
+serial_action_t serial_recovery_next_action(const serial_link_state_t *state);
+
+/* Seconds to wait before retry number `reconnect_attempts` (1-based, i.e. the
+ * count after the failure has been tallied).  Doubles per attempt, capped at
+ * SERIAL_MAX_BACKOFF_SECONDS. */
+int serial_recovery_backoff_seconds(int reconnect_attempts);
+
+#endif /* SERIAL_RECOVERY_H */

--- a/host/tests/unit_tests.c
+++ b/host/tests/unit_tests.c
@@ -9,6 +9,7 @@
 #include "../call_metrics.h"
 #include "../millennium_sdk.h"
 #include "../coin_gate.h"
+#include "../serial_recovery.h"
 #include "../updater.h"
 #include "../plugin_sdk.h"
 #include "../clock_source.h"
@@ -2327,6 +2328,85 @@ static void test_coin_gate_resync_rejects_short_buffer(void) {
     TEST_ASSERT_EQ_INT((int)millennium_coin_gate_resync('c', seq, 0), 0);
 }
 
+/* ── Serial recovery policy (#247) ──────────────────────────────── */
+
+static serial_action_t action_for(int fd_open, int healthy, long idle, long until_retry) {
+    serial_link_state_t st;
+    st.fd_open = fd_open;
+    st.link_healthy = healthy;
+    st.idle_seconds = idle;
+    st.seconds_until_retry = until_retry;
+    return serial_recovery_next_action(&st);
+}
+
+static void test_serial_healthy_link_idles_quietly(void) {
+    TEST_ASSERT_EQ_INT(action_for(1, 1, 0, 0), SERIAL_ACTION_NONE);
+    TEST_ASSERT_EQ_INT(action_for(1, 1, SERIAL_KEEPALIVE_INTERVAL - 1, 0), SERIAL_ACTION_NONE);
+}
+
+static void test_serial_keepalive_window(void) {
+    TEST_ASSERT_EQ_INT(action_for(1, 1, SERIAL_KEEPALIVE_INTERVAL, 0), SERIAL_ACTION_KEEPALIVE);
+    TEST_ASSERT_EQ_INT(action_for(1, 1, SERIAL_WATCHDOG_SECONDS - 1, 0), SERIAL_ACTION_KEEPALIVE);
+    /* Long-standing boundary: exactly at the watchdog threshold, neither the
+     * keepalive nor the watchdog fires; the next pass declares it dead. */
+    TEST_ASSERT_EQ_INT(action_for(1, 1, SERIAL_WATCHDOG_SECONDS, 0), SERIAL_ACTION_NONE);
+}
+
+static void test_serial_watchdog_marks_dead(void) {
+    TEST_ASSERT_EQ_INT(action_for(1, 1, SERIAL_WATCHDOG_SECONDS + 1, 0), SERIAL_ACTION_MARK_DEAD);
+}
+
+/* #247's regression: open_serial_port() drops the fd before it retries, so a
+ * failed reconnect leaves fd_open == 0 while the health flag is still set.
+ * That state must not resolve to NONE -- doing so stranded the daemon until a
+ * manual restart. */
+static void test_serial_closed_fd_is_a_dead_link(void) {
+    TEST_ASSERT_EQ_INT(action_for(0, 1, 0, 0), SERIAL_ACTION_MARK_DEAD);
+    TEST_ASSERT_EQ_INT(action_for(0, 1, 1000, 9999), SERIAL_ACTION_MARK_DEAD);
+}
+
+static void test_serial_down_link_retries_when_due(void) {
+    /* Backoff still running: wait. */
+    TEST_ASSERT_EQ_INT(action_for(0, 0, 0, 5), SERIAL_ACTION_NONE);
+    /* Due now, and overdue. */
+    TEST_ASSERT_EQ_INT(action_for(0, 0, 0, 0), SERIAL_ACTION_RECONNECT);
+    TEST_ASSERT_EQ_INT(action_for(0, 0, 0, -30), SERIAL_ACTION_RECONNECT);
+}
+
+/* The daemon keeps retrying for as long as the link stays down -- the failure
+ * mode in #247 was the retries stopping after the first one. */
+static void test_serial_retries_do_not_give_up(void) {
+    int i;
+    for (i = 0; i < 500; i++) {
+        TEST_ASSERT_EQ_INT(action_for(0, 0, i, 0), SERIAL_ACTION_RECONNECT);
+    }
+}
+
+static void test_serial_null_state(void) {
+    TEST_ASSERT_EQ_INT(serial_recovery_next_action(NULL), SERIAL_ACTION_NONE);
+}
+
+static void test_serial_backoff_doubles_then_caps(void) {
+    TEST_ASSERT_EQ_INT(serial_recovery_backoff_seconds(1), 2);
+    TEST_ASSERT_EQ_INT(serial_recovery_backoff_seconds(2), 4);
+    TEST_ASSERT_EQ_INT(serial_recovery_backoff_seconds(3), 8);
+    TEST_ASSERT_EQ_INT(serial_recovery_backoff_seconds(4), 16);
+    TEST_ASSERT_EQ_INT(serial_recovery_backoff_seconds(5), 32);
+    TEST_ASSERT_EQ_INT(serial_recovery_backoff_seconds(6), SERIAL_MAX_BACKOFF_SECONDS);
+}
+
+/* reconnect_attempts is never reset while the link stays down, so a long outage
+ * drives it arbitrarily high.  Shifting by that directly would run past the
+ * width of an int within about half an hour. */
+static void test_serial_backoff_survives_a_long_outage(void) {
+    int i;
+    for (i = 0; i < 100000; i++) {
+        int b = serial_recovery_backoff_seconds(i);
+        TEST_ASSERT(b > 0 && b <= SERIAL_MAX_BACKOFF_SECONDS);
+    }
+    TEST_ASSERT_EQ_INT(serial_recovery_backoff_seconds(-1), 1);
+}
+
 /* ── Main ───────────────────────────────────────────────────────── */
 
 int main(void) {
@@ -2404,6 +2484,17 @@ int main(void) {
     TEST_SUITE_RUN(test_coin_gate_resync_untracked_rejects);
     TEST_SUITE_RUN(test_coin_gate_resync_follows_hook_state);
     TEST_SUITE_RUN(test_coin_gate_resync_rejects_short_buffer);
+
+    TEST_SUITE_BEGIN("Serial Recovery");
+    TEST_SUITE_RUN(test_serial_healthy_link_idles_quietly);
+    TEST_SUITE_RUN(test_serial_keepalive_window);
+    TEST_SUITE_RUN(test_serial_watchdog_marks_dead);
+    TEST_SUITE_RUN(test_serial_closed_fd_is_a_dead_link);
+    TEST_SUITE_RUN(test_serial_down_link_retries_when_due);
+    TEST_SUITE_RUN(test_serial_retries_do_not_give_up);
+    TEST_SUITE_RUN(test_serial_null_state);
+    TEST_SUITE_RUN(test_serial_backoff_doubles_then_caps);
+    TEST_SUITE_RUN(test_serial_backoff_survives_a_long_outage);
 
     TEST_SUITE_BEGIN("Clock Seam");
     TEST_SUITE_RUN(test_clock_default_is_real_time);


### PR DESCRIPTION
Follow-up to #247, as flagged in #248.

`check_serial` touches real fds, so **both** `simulator.c` and `tests/unit_tests.c` stub it out entirely. Its policy had no coverage at all — which is exactly how #247 (the reconnect that gave up after one failed attempt) shipped and survived until someone unplugged a cable.

## Change

The decision moves into `serial_recovery.c` as pure logic:

```c
serial_action_t serial_recovery_next_action(const serial_link_state_t *state);
int             serial_recovery_backoff_seconds(int reconnect_attempts);
```

`check_serial` becomes the thin shell: sample the link into a `serial_link_state_t`, ask for a verdict, carry it out. Marking the link dead makes a retry due immediately, so it re-asks and reconnects in the same pass — as it always has.

**No behaviour change intended**, including the long-standing boundary where `idle_seconds` exactly equal to `SERIAL_WATCHDOG_SECONDS` does nothing for one pass.

Same pattern as `coin_gate.c` and the `clock_source` seam.

## Tests

Nine new, in a `Serial Recovery` suite — **136 passed / 0 failed** (was 127):

- keepalive and watchdog boundaries, including the exact-threshold dead zone
- retries never stop while the link is down (the #247 failure mode)
- #247's own state: fd closed while the health flag is still set must resolve to `MARK_DEAD`, never `NONE`
- backoff doubles then caps

## Latent overflow found

Writing the backoff down as a function exposed a real bug. `reconnect_attempts` is never reset while the link stays down, so it climbs one per retry — and once the 60 s cap is in force that is one per minute. After roughly half an hour disconnected, `1 << client->reconnect_attempts` shifts a signed int past its width:

```c
client->reconnect_attempts++;
backoff = 1 << client->reconnect_attempts;   /* UB once attempts >= 31 */
```

The exponent is now clamped. The result was already capped at `SERIAL_MAX_BACKOFF_SECONDS`, so nothing observable changes short of the undefined behaviour itself.

## Hardware verification

Refactoring code whose only prior evidence was a hardware run, so I re-ran it. Unbind/rebind of the Beta Micro from `cdc_acm`:

```
[15:47:55] Serial watchdog: no activity for 61 seconds, marking link dead
[15:47:55] Serial reconnect attempt 1     (2s)
[15:48:09] Serial reconnect attempt 4     (16s)
[15:48:25] Serial reconnect attempt 5 -> Serial port reopened successfully
[15:48:25] Writing to coin validator: 99   <- 'c'
[15:48:25] Writing to coin validator: 122  <- 'z'
```

Identical to the pre-refactor run, and `/api/health` recovered unaided. An idle link then held `HEALTHY` for 130 s with zero watchdog trips.

One honest caveat: the **keepalive branch never executes live**. The Beta heartbeats every 10 s (`HEARTBEAT_INTERVAL_MS`), so `idle_seconds` never reaches the 30 s threshold — it is a backstop for a silent Arduino, and these unit tests are its only coverage.

`compile-check` clean under Apple clang and `gcc-15`; builds clean on the Pi GCC 10.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)