### PR TITLE
fix(#263): exit cleanly when the serial device is missing, instead of SEGV

### DIFF
--- a/host/daemon.c
+++ b/host/daemon.c
@@ -1156,6 +1156,18 @@ int main(int argc, char *argv[]) {
     
     /* Initialize client */
     client = millennium_client_create();
+    if (!client) {
+        /* (#263) Almost always the serial device not being there yet -- the Pi
+         * reaching this point before USB enumeration finishes, or a restart
+         * landing while a Micro is mid-reflash. Exit cleanly and let systemd
+         * retry, which is what already happened; the difference is that this
+         * used to be a SEGV, because millennium_client_update() dereferences
+         * the client with no NULL guard. A crash here is indistinguishable
+         * from a real memory fault and hides one. */
+        logger_error_with_category("Daemon",
+            "Client init failed (serial device unavailable?); exiting for restart");
+        return 1;
+    }
     display_manager_init(client);
     
     /* Initialize health monitoring */

--- a/host/millennium_sdk.c
+++ b/host/millennium_sdk.c
@@ -526,7 +526,9 @@ void millennium_client_update(struct millennium_client *client) {
     struct timespec current_time;
     long elapsed_ms;
 
-    if (client->display_fd == -1) return;
+    /* (#263) NULL-guard to match check_serial. This is where a NULL client
+     * from a failed millennium_client_create() used to land as a SEGV. */
+    if (!client || client->display_fd == -1) return;
 
     /* Read directly from the file descriptor */
     while ((bytes_read = read(client->display_fd, buffer, sizeof(buffer))) > 0) {


### PR DESCRIPTION
Fixes #263.

`millennium_client_create()` returns NULL when it cannot open the serial port, and `daemon.c:1158` used the result unchecked:

```c
client = millennium_client_create();
display_manager_init(client);
```

`display_manager_init` only stores the pointer, so it survived NULL. `millennium_client_update()` dereferences it with no guard, and that is where it died:

```
[ERROR] Failed to open serial device ...Beta-if00: No such file or directory
daemon.service: Main process exited, code=killed, status=11/SEGV
daemon.service: Failed with result 'signal'.
```

## How it surfaced

`NRestarts` had quietly gone from 0 to 1. Everything else looked healthy — which is the point: systemd's restart policy brought it straight back, so this **self-healed by luck rather than design** and left no other trace.

It happens on **every** reflash of the Beta Micro, and would happen at boot any time the Pi reaches the daemon before USB enumeration finishes. A crash loop there is bounded only by systemd's restart limits; hit those and the phone stays down until someone intervenes.

A SEGV is also indistinguishable from the outside from a genuine memory-safety fault, so this would have camouflaged a real one.

## Fix

Check the return and exit 1 with a legible message, letting systemd retry exactly as it already did. Also added the missing NULL guard to `millennium_client_update()`, so the client entry points agree with `millennium_client_check_serial()`, which has had one all along.

## Verification

Reproduced it directly — held Beta in reset over GPIO27 and started the daemon:

```
before:  Main process exited, code=killed, status=11/SEGV
         daemon.service: Failed with result 'signal'

after:   [ERROR] [SDK]    Failed to open serial device ...Beta-if00: No such file or directory
         [ERROR] [Daemon] Client init failed (serial device unavailable?); exiting for restart
         daemon.service: Failed with result 'exit-code'
```

It retried cleanly for as long as Beta was held down, then came up with `serial_connection: HEALTHY` once released.

140 passed / 0 failed; `compile-check` clean under Apple clang and `gcc-15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)